### PR TITLE
Fix identity decoder config and setup

### DIFF
--- a/src/autocast/configs/decoder/identity.yaml
+++ b/src/autocast/configs/decoder/identity.yaml
@@ -1,1 +1,2 @@
 _target_: autocast.decoders.identity.IdentityDecoder
+in_channels: auto

--- a/src/autocast/scripts/setup.py
+++ b/src/autocast/scripts/setup.py
@@ -231,6 +231,23 @@ def setup_autoencoder_components(
         decoder_config,
     )
     encoder = instantiate(encoder_config)
+
+    if (
+        decoder_config
+        and "in_channels" in decoder_config
+        and decoder_config.get("in_channels") in (None, "auto")
+    ):
+        if hasattr(encoder, "latent_channels") and isinstance(
+            encoder.latent_channels, int
+        ):
+            decoder_config["in_channels"] = encoder.latent_channels
+        else:
+            msg = (
+                "decoder.in_channels is auto, but encoder latent_channels is not "
+                "available."
+            )
+            raise ValueError(msg)
+
     decoder = instantiate(decoder_config)
     checkpoint = config.get("autoencoder_checkpoint")
 

--- a/tests/scripts/test_setup.py
+++ b/tests/scripts/test_setup.py
@@ -12,6 +12,7 @@ from autocast.scripts.setup import (
     _get_latent_channels,
     _set_if_auto,
     resolve_auto_params,
+    setup_autoencoder_components,
 )
 from autocast.types import Batch
 
@@ -191,3 +192,27 @@ def test_get_latent_channels_requires_attribute():
     encoder = BrokenEncoder()
     with pytest.raises(ValueError, match="must set latent_channels"):
         _get_latent_channels(encoder)
+
+
+def test_setup_autoencoder_components_resolves_decoder_in_channels_auto():
+    cfg = OmegaConf.create(
+        {
+            "model": {
+                "encoder": {
+                    "_target_": "autocast.encoders.identity.IdentityEncoder",
+                    "in_channels": "auto",
+                },
+                "decoder": {
+                    "_target_": "autocast.decoders.identity.IdentityDecoder",
+                    "in_channels": "auto",
+                },
+            },
+            "autoencoder_checkpoint": None,
+        }
+    )
+    stats = {"channel_count": 3, "n_steps_input": 2, "n_steps_output": 2}
+
+    encoder, decoder = setup_autoencoder_components(cfg, stats)
+
+    assert encoder.latent_channels == 3
+    assert decoder.latent_channels == 3


### PR DESCRIPTION
This PR:
- Updates identity config and setup to support `auto` `in_channels`
- Adds corresponding test