### PR TITLE
Revise default trainer config

### DIFF
--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -18,4 +18,5 @@ callbacks:
     every_n_epochs: 5
     save_on_train_epoch_end: true
     filename: "latest-5ep-{epoch:04d}"
+    auto_insert_metric_name: false
 


### PR DESCRIPTION
Closes #252.

This PR updates default trainer config to:
- have max time instead of epochs
- checkpoint every 5 epochs keeping only latest