### PR TITLE
add Winkler metric

### DIFF
--- a/src/autocast/metrics/__init__.py
+++ b/src/autocast/metrics/__init__.py
@@ -27,6 +27,7 @@ from .ensemble import (
     FairCRPS,
     SpreadSkillRatio,
     VariogramScore,
+    WinklerScore,
 )
 
 __all__ = [
@@ -57,6 +58,7 @@ __all__ = [
     "PowerSpectrumRMSETail",
     "SpreadSkillRatio",
     "VariogramScore",
+    "WinklerScore",
 ]
 
 ALL_DETERMINISTIC_METRICS = (
@@ -87,6 +89,7 @@ ALL_ENSEMBLE_METRICS = (
     EnergyScore,
     VariogramScore,
     SpreadSkillRatio,
+    WinklerScore,
     Coverage,
     MultiCoverage,
 )

--- a/src/autocast/metrics/ensemble.py
+++ b/src/autocast/metrics/ensemble.py
@@ -652,18 +652,12 @@ class WinklerScore(BTSCMMetric):
 
         Shape conventions
         -----------------
-        - Input prediction tensor: ``y_pred`` has shape ``(B, T, S..., C, M)``
-            where:
-            - ``B``: batch size
-            - ``T``: number of forecast timesteps
-            - ``S...``: one or more spatial dimensions
-            - ``C``: number of channels/variables
-            - ``M``: number of ensemble members
-        - Input truth tensor: ``y_true`` has shape ``(B, T, S..., C)``.
-        - Quantiles are computed along ensemble dim ``M``:
-            - ``l`` (``lower``): ``q_{alpha/2}``, shape ``(B, T, S..., C)``
-            - ``u`` (``upper``): ``q_{1-alpha/2}``, shape ``(B, T, S..., C)``
-            - ``y`` corresponds to ``y_true``, same shape ``(B, T, S..., C)``.
+        - Input prediction tensor: y_pred has shape (B, T, S..., C, M)
+        - Input truth tensor: y_true has shape (B, T, S..., C)
+        - Quantiles are computed along ensemble dim M:
+            - l (lower): ``q_{alpha/2}``, shape (B, T, S..., C)
+            - u (upper): ``q_{1-alpha/2}``, shape (B, T, S..., C)
+            - y corresponds to y_true, same shape (B, T, S..., C).
 
         The internal ``_score`` returns pointwise Winkler scores with shape
         ``(B, T, S..., C)``. The base class then applies ``score_dims`` and

--- a/src/autocast/metrics/ensemble.py
+++ b/src/autocast/metrics/ensemble.py
@@ -633,3 +633,72 @@ class SpreadSkillRatio(BTSCMMetric):
         ssr = (spread / torch.clamp(skill, min=self.eps)) * correction
 
         return ssr
+
+
+class WinklerScore(BTSCMMetric):
+    r"""
+    Winkler interval score for central prediction intervals.
+
+    For significance level :math:`\alpha \in (0, 1)`, this metric computes
+    central :math:`(1-\alpha)` prediction intervals from ensemble quantiles and
+    returns the per-point interval score
+
+    .. math::
+        W_\alpha = (u - l)
+        + \frac{2}{\alpha}(l - y)\mathbf{1}(y < l)
+        + \frac{2}{\alpha}(y - u)\mathbf{1}(y > u),
+
+        where :math:`l` and :math:`u` are the lower/upper interval bounds.
+
+        Shape conventions
+        -----------------
+        - Input prediction tensor: ``y_pred`` has shape ``(B, T, S..., C, M)``
+            where:
+            - ``B``: batch size
+            - ``T``: number of forecast timesteps
+            - ``S...``: one or more spatial dimensions
+            - ``C``: number of channels/variables
+            - ``M``: number of ensemble members
+        - Input truth tensor: ``y_true`` has shape ``(B, T, S..., C)``.
+        - Quantiles are computed along ensemble dim ``M``:
+            - ``l`` (``lower``): ``q_{alpha/2}``, shape ``(B, T, S..., C)``
+            - ``u`` (``upper``): ``q_{1-alpha/2}``, shape ``(B, T, S..., C)``
+            - ``y`` corresponds to ``y_true``, same shape ``(B, T, S..., C)``.
+
+        The internal ``_score`` returns pointwise Winkler scores with shape
+        ``(B, T, S..., C)``. The base class then applies ``score_dims`` and
+        ``reduce_all`` reductions:
+        - ``score_dims='spatial'`` (default) -> ``(B, T, C)``
+        - ``score_dims='temporal'`` -> ``(B, S..., C)``
+        - ``score_dims=None`` -> ``(B, T, S..., C)``
+        - if ``reduce_all=True`` (default), ``compute()`` returns a scalar.
+
+    Lower values are better: narrow intervals are rewarded, and misses are
+    penalized in proportion to their distance outside the interval.
+    """
+
+    name: str = "winkler"
+
+    def __init__(self, alpha: float = 0.1, **kwargs):
+        super().__init__(**kwargs)
+        if not (0 < alpha < 1):
+            raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+        self.alpha = alpha
+
+    def _score(self, y_pred: TensorBTSCM, y_true: TensorBTSC) -> TensorBTSC:
+        """Compute pointwise Winkler score before spatial/temporal reductions."""
+        q_low = self.alpha / 2.0
+        q_high = 1.0 - self.alpha / 2.0
+
+        q_tensor = torch.tensor(
+            [q_low, q_high], device=y_pred.device, dtype=y_pred.dtype
+        )
+        quantiles = torch.quantile(y_pred, q_tensor, dim=-1)
+        lower = quantiles[0]
+        upper = quantiles[1]
+
+        width = upper - lower
+        below_penalty = (2.0 / self.alpha) * torch.clamp(lower - y_true, min=0.0)
+        above_penalty = (2.0 / self.alpha) * torch.clamp(y_true - upper, min=0.0)
+
+        return width + below_penalty + above_penalty

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -46,6 +46,7 @@ from autocast.metrics.ensemble import (
     FairCRPS,
     SpreadSkillRatio,
     VariogramScore,
+    WinklerScore,
 )
 from autocast.models.encoder_processor_decoder import EncoderProcessorDecoder
 from autocast.models.encoder_processor_decoder_ensemble import (
@@ -110,6 +111,7 @@ AVAILABLE_METRICS_ENSEMBLE = {
     "energy": EnergyScore,
     "variogram": VariogramScore,
     "ssr": SpreadSkillRatio,
+    "winkler": WinklerScore,
 }
 
 DEFAULT_EVAL_METRICS = [
@@ -132,6 +134,7 @@ DEFAULT_EVAL_METRICS = [
     "afcrps",
     "energy",
     "ssr",
+    "winkler",
 ]
 
 MEMORY_INTENSIVE_METRICS = {"variogram"}

--- a/tests/metrics/test_ensemble.py
+++ b/tests/metrics/test_ensemble.py
@@ -4,7 +4,12 @@ import torch
 from autocast.metrics import ALL_ENSEMBLE_METRICS
 from autocast.metrics.base import BaseMetric
 from autocast.metrics.coverage import Coverage
-from autocast.metrics.ensemble import EnergyScore, SpreadSkillRatio, VariogramScore
+from autocast.metrics.ensemble import (
+    EnergyScore,
+    SpreadSkillRatio,
+    VariogramScore,
+    WinklerScore,
+)
 from autocast.types import TensorBTSC
 from autocast.types.types import TensorBTC
 
@@ -202,6 +207,29 @@ def test_spread_skill_ratio_requires_multiple_ensemble_members():
 
     with pytest.raises(ValueError, match="at least 2 ensemble members"):
         SpreadSkillRatio()(y_pred, y_true)
+
+
+def test_winkler_score_manual_value():
+    # Shape: (B=1, T=1, S=2, C=1, M=5)
+    # Ensemble members: [0, 1, 2, 3, 4], alpha=0.2
+    # Interval bounds: q0.1=0.4, q0.9=3.6
+    # S=0: y=2.0 in interval -> score = width = 3.2
+    # S=1: y=4.6 above upper by 1.0 -> + (2/0.2)*1.0 = +10.0
+    # Mean over spatial points = (3.2 + 13.2) / 2 = 8.2
+    members = torch.arange(5.0)
+    y_pred = members.view(1, 1, 1, 1, 5).expand(1, 1, 2, 1, 5)
+    y_true = torch.tensor([[[[2.0], [4.6]]]])
+
+    value = WinklerScore(alpha=0.2)(y_pred, y_true)
+    assert torch.allclose(value, torch.tensor(8.2), atol=1e-6)
+
+
+def test_winkler_score_invalid_alpha():
+    with pytest.raises(ValueError):  # noqa: PT011
+        WinklerScore(alpha=0.0)
+
+    with pytest.raises(ValueError):  # noqa: PT011
+        WinklerScore(alpha=1.0)
 
 
 @pytest.mark.parametrize("MetricCls", ALL_ENSEMBLE_METRICS)


### PR DESCRIPTION
Closes #286 by implementing Winkler metric

## Summary of Changes

- Added Winkler Interval Score (`WinklerScore`) as a new ensemble metric in `ensemble.py`.
- Registered the metric in the metric registry and evaluation scripts.
- Added unit tests for correctness and parameter validation.
- Documented the metric with explicit shape conventions and mathematical definition.

## Winkler Interval Score Definition

The [Winkler interval score](https://mapie.readthedocs.io/en/latest/theoretical_description_metrics.html#mean-winkler-interval-score) evaluates the sharpness and coverage of central prediction intervals. For significance level $\alpha \in (0, 1)$, the score for a single point is:

$$W_\alpha = (u - l) + \frac{2}{\alpha}(l - y)\mathbf{1}(y < l) + \frac{2}{\alpha}(y - u)\mathbf{1}(y > u)$$

where:

- $l$ is the lower bound of the central $(1-\alpha)$ prediction interval (ensemble quantile at $\alpha/2$)
- $u$ is the upper bound (ensemble quantile at $1-\alpha/2$)
- $y$ is the observed value

Lower values are better: narrow intervals are rewarded, and misses are penalized in proportion to their distance outside the interval.

The implementation supports flexible reduction over spatial/temporal dimensions and returns the mean Winkler score by default.