### PR TITLE
Add support for EMA of model weights

### DIFF
--- a/local_hydra/local_experiment/epd_diffusion_fm_256_dc_large_ema.yaml
+++ b/local_hydra/local_experiment/epd_diffusion_fm_256_dc_large_ema.yaml
@@ -1,0 +1,49 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: advection_diffusion_multichannel_64_64
+  - override /encoder@model.encoder: dc_large
+  - override /decoder@model.decoder: dc_large
+  - override /processor@model.processor: flow_matching_vit
+  - override /backbone@model.processor.backbone: vit
+  - _self_
+
+experiment_name: epd_diffusion_fm_256
+
+datamodule:
+  use_normalization: true
+  batch_size: 256
+
+logging:
+  wandb:
+    enabled: true
+
+model:
+  encoder:
+    periodic: false
+  decoder:
+    periodic: false
+  train_in_latent_space: true
+  processor:
+    backbone:
+      # hid_channels: 256 ~ 19 M
+      # hid_channels: 512 ~ 58.5 M
+      #  ~ 90 M
+      hid_channels: 640
+      # hid_channels: 1024 ~  217 M
+    flow_ode_steps: 50
+
+optimizer:
+  learning_rate: 0.0002
+
+trainer:
+  callbacks:
+    - _target_: lightning.pytorch.callbacks.ModelCheckpoint
+      save_top_k: 1
+      every_n_epochs: 5
+      save_on_train_epoch_end: true
+      filename: "latest-5ep-{epoch:04d}"
+      auto_insert_metric_name: false
+    - _target_: autocast.callbacks.ema.EMACallback
+      decay: 0.999
+

--- a/src/autocast/callbacks/ema.py
+++ b/src/autocast/callbacks/ema.py
@@ -1,0 +1,58 @@
+# ruff: noqa: ARG002
+from lightning.pytorch.callbacks import Callback
+from torch.optim.swa_utils import AveragedModel, get_ema_multi_avg_fn
+
+EMA_CHECKPOINT_KEY = "ema_state_dict"
+
+
+class EMACallback(Callback):
+    """Exponential Moving Average (EMA) callback for PyTorch Lightning.
+
+    Silently maintains an EMA of the model parameters during training and
+    writes them into the checkpoint under a dedicated key
+    (``ema_state_dict``) so that ``state_dict`` still reflects the raw
+    training weights. Validation/train metrics therefore stay comparable
+    across runs; eval scripts opt in to the EMA weights explicitly.
+    """
+
+    def __init__(self, decay: float = 0.9999):
+        super().__init__()
+        self.decay = decay
+        self.ema_model = None
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        """Update EMA parameters after every training batch."""
+        if self.ema_model is not None:
+            self.ema_model.update_parameters(pl_module)
+
+    def on_save_checkpoint(self, trainer, pl_module, checkpoint: dict) -> None:
+        """Persist EMA weights alongside the raw training state_dict.
+
+        Stored under a separate top-level key so eval scripts can opt in
+        without affecting training-time checkpoints or resume behaviour.
+        """
+        if self.ema_model is not None:
+            checkpoint[EMA_CHECKPOINT_KEY] = {
+                k: v.clone() for k, v in self.ema_model.module.state_dict().items()
+            }
+
+    def state_dict(self) -> dict:
+        """Save the EMA model state to the Lightning checkpoint."""
+        return {
+            "ema_model_state": self.ema_model.state_dict() if self.ema_model else None
+        }
+
+    def load_state_dict(self, state_dict: dict) -> None:
+        """Restore the EMA model state from the Lightning checkpoint."""
+        # Note: on_fit_start must be handled correctly if resuming
+        self._loaded_state_dict = state_dict.get("ema_model_state")
+
+    def on_fit_start(self, trainer, pl_module):
+        """Initialize the EMA model using the starting weights."""
+        if self.ema_model is None:
+            avg_fn = get_ema_multi_avg_fn(self.decay)
+            self.ema_model = AveragedModel(pl_module, multi_avg_fn=avg_fn)
+            # If resuming from checkpoint, load the preserved EMA state
+            if getattr(self, "_loaded_state_dict", None) is not None:
+                self.ema_model.load_state_dict(self._loaded_state_dict)  # type: ignore[arg-type]
+                self._loaded_state_dict = None

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -1034,9 +1034,20 @@ def main(cfg: DictConfig) -> None:
 
 def _extract_processor_state_dict(
     checkpoint_payload: Mapping[str, Any],
+    *,
+    use_ema: bool = False,
 ) -> dict[str, Any]:
     """Return only the processor sub-module weights with the prefix stripped."""
-    state_dict = checkpoint_payload.get("state_dict", checkpoint_payload)
+    if use_ema:
+        state_dict = checkpoint_payload.get("ema_state_dict")
+        if state_dict is None:
+            msg = (
+                "use_ema=True but checkpoint has no 'ema_state_dict'. "
+                "Was EMACallback enabled during training?"
+            )
+            raise KeyError(msg)
+    else:
+        state_dict = checkpoint_payload.get("state_dict", checkpoint_payload)
     return {
         k[len("processor.") :]: v
         for k, v in state_dict.items()
@@ -1192,6 +1203,16 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     checkpoint_payload = load_checkpoint_payload(checkpoint_path)
     processor_only = _is_processor_only_checkpoint(checkpoint_payload)
 
+    use_ema = bool(eval_cfg.get("use_ema", False))
+    if use_ema:
+        if "ema_state_dict" not in checkpoint_payload:
+            msg = (
+                "eval.use_ema=True but checkpoint has no 'ema_state_dict'. "
+                "Was EMACallback enabled during training?"
+            )
+            raise KeyError(msg)
+        log.info("Loading EMA weights from checkpoint (eval.use_ema=True)")
+
     # Setup datamodule and resolve config
     datamodule, cfg, stats = setup_datamodule(cfg)
 
@@ -1258,12 +1279,14 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
                 "+ processor checkpoint."
             )
             model = setup_epd_model(cfg, stats, datamodule=datamodule)
-            processor_sd = _extract_processor_state_dict(checkpoint_payload)
+            processor_sd = _extract_processor_state_dict(
+                checkpoint_payload, use_ema=use_ema
+            )
             load_result = model.processor.load_state_dict(processor_sd, strict=True)
         else:
             model = setup_processor_model(cfg, stats, datamodule=datamodule)
             load_result = model.load_state_dict(
-                extract_state_dict(checkpoint_payload), strict=True
+                extract_state_dict(checkpoint_payload, use_ema=use_ema), strict=True
             )
             if isinstance(example_batch, EncodedBatch):
                 # Mode 2: try to load decoder for data-space evaluation
@@ -1280,7 +1303,7 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     else:
         model = setup_epd_model(cfg, stats, datamodule=datamodule)
         load_result = model.load_state_dict(
-            extract_state_dict(checkpoint_payload), strict=True
+            extract_state_dict(checkpoint_payload, use_ema=use_ema), strict=True
         )
 
     if load_result.missing_keys or load_result.unexpected_keys:

--- a/src/autocast/scripts/execution.py
+++ b/src/autocast/scripts/execution.py
@@ -64,10 +64,28 @@ def load_checkpoint_payload(checkpoint_path: Path) -> Mapping[str, Any]:
 
 def extract_state_dict(
     checkpoint: Mapping[str, Any],
+    *,
+    use_ema: bool = False,
 ) -> OrderedDict[str, torch.Tensor]:
-    """Extract and clean the state dict from a checkpoint payload."""
+    """Extract and clean the state dict from a checkpoint payload.
+
+    When ``use_ema=True`` the EMA weights written by ``EMACallback`` under
+    the ``ema_state_dict`` top-level key are returned instead of the raw
+    training weights. Raises if the flag is set but no EMA weights are
+    present — a silent fallback would make eval runs hard to interpret.
+    """
     if isinstance(checkpoint, Mapping):
-        state_dict = checkpoint.get("state_dict", checkpoint)
+        if use_ema:
+            ema_sd = checkpoint.get("ema_state_dict")
+            if ema_sd is None:
+                msg = (
+                    "use_ema=True but checkpoint has no 'ema_state_dict'. "
+                    "Was EMACallback enabled during training?"
+                )
+                raise KeyError(msg)
+            state_dict = ema_sd
+        else:
+            state_dict = checkpoint.get("state_dict", checkpoint)
     else:
         state_dict = checkpoint
     if not isinstance(state_dict, Mapping):


### PR DESCRIPTION
This pull request adds support for using Exponential Moving Average (EMA) weights during evaluation and introduces a reusable EMA callback for PyTorch Lightning training. The main updates include implementing the `EMACallback` class, updating the training configuration to enable EMA, and modifying evaluation scripts to optionally load and use EMA weights.

**EMA Support and Callback Implementation:**

* Added a new `EMACallback` class in `src/autocast/callbacks/ema.py` that maintains and saves EMA weights during training, storing them under the `ema_state_dict` key in checkpoints.
* Updated the experiment configuration (`local_hydra/local_experiment/epd_diffusion_fm_256_dc_large_ema.yaml`) to enable the `EMACallback` during training with appropriate parameters.

**Evaluation Script Enhancements:**

* Modified `src/autocast/scripts/eval/encoder_processor_decoder.py` to add a `use_ema` flag, allowing evaluation scripts to load EMA weights from checkpoints if available, and raising clear errors if not. [[1]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR1037-R1049) [[2]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR1206-R1215) [[3]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bL1261-R1289) [[4]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bL1283-R1306)
* Updated the `extract_state_dict` function in `src/autocast/scripts/execution.py` to support extracting EMA weights when requested, ensuring evaluation uses the correct parameters.