### PR TITLE
Update Gray-Scott dataset

### DIFF
--- a/src/autocast/configs/datamodule/gray_scott.yaml
+++ b/src/autocast/configs/datamodule/gray_scott.yaml
@@ -1,5 +1,5 @@
 _target_: autocast.data.datamodule.SpatioTemporalDataModule
-data_path: "${oc.env:AUTOCAST_DATASETS,./datasets}/gray_scott_3e0b4ab"
+data_path: "${oc.env:AUTOCAST_DATASETS,./datasets}/gray_scott_68b0669"
 batch_size: 16
 n_steps_input: 1
 n_steps_output: 4


### PR DESCRIPTION
This pull request updates the data path used in the `gray_scott.yaml` configuration file to point to a new dataset version.

- Configuration update:
  * Changed the `data_path` in `src/autocast/configs/datamodule/gray_scott.yaml` to reference the `gray_scott_68b0669` dataset instead of `gray_scott_3e0b4ab`.