### PR TITLE
Add autoencoder configs and update defaults

### DIFF
--- a/local_hydra/local_experiment/ae/advection_diffusion/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/advection_diffusion/ae_dc_large.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: advection_diffusion
+  - override /model: autoencoder_dc_large
+  - override /optimizer: psgd
+  - _self_
+
+experiment_name: ae_dc_large_advection_diffusion
+
+datamodule:
+  use_normalization: true
+  batch_size: 64
+
+model:
+  encoder:
+    periodic: true
+  decoder:
+    periodic: true
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 1e-5
+  weight_decay: 0.0
+  scheduler: cosine
+
+trainer:
+  gradient_clip_val: 1.0

--- a/local_hydra/local_experiment/ae/advection_diffusion/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/advection_diffusion/ae_dc_large.yaml
@@ -10,7 +10,7 @@ experiment_name: ae_dc_large_advection_diffusion
 
 datamodule:
   use_normalization: true
-  batch_size: 64
+  batch_size: 16
 
 model:
   encoder:

--- a/local_hydra/local_experiment/ae/advection_diffusion/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/advection_diffusion/ae_dc_large.yaml
@@ -15,8 +15,10 @@ datamodule:
 model:
   encoder:
     periodic: true
+    pixel_shuffle: true
   decoder:
     periodic: true
+    pixel_shuffle: true
 
 logging:
   wandb:

--- a/local_hydra/local_experiment/ae/conditioned_navier_stokes/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/conditioned_navier_stokes/ae_dc_large.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: conditioned_navier_stokes
+  - override /model: autoencoder_dc_large
+  - override /optimizer: psgd
+  - _self_
+
+experiment_name: ae_dc_large_conditioned_navier_stokes
+
+datamodule:
+  use_normalization: true
+  batch_size: 64
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 1e-5
+  weight_decay: 0.0
+  scheduler: cosine
+
+trainer:
+  gradient_clip_val: 1.0

--- a/local_hydra/local_experiment/ae/conditioned_navier_stokes/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/conditioned_navier_stokes/ae_dc_large.yaml
@@ -10,7 +10,7 @@ experiment_name: ae_dc_large_conditioned_navier_stokes
 
 datamodule:
   use_normalization: true
-  batch_size: 64
+  batch_size: 16
 
 logging:
   wandb:

--- a/local_hydra/local_experiment/ae/conditioned_navier_stokes/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/conditioned_navier_stokes/ae_dc_large.yaml
@@ -14,8 +14,10 @@ datamodule:
 
 model:
   encoder:
+    periodic: false
     pixel_shuffle: true
   decoder:
+    periodic: false
     pixel_shuffle: true
 
 logging:

--- a/local_hydra/local_experiment/ae/conditioned_navier_stokes/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/conditioned_navier_stokes/ae_dc_large.yaml
@@ -12,6 +12,12 @@ datamodule:
   use_normalization: true
   batch_size: 16
 
+model:
+  encoder:
+    pixel_shuffle: true
+  decoder:
+    pixel_shuffle: true
+
 logging:
   wandb:
     enabled: true

--- a/local_hydra/local_experiment/ae/gpe_laser_wake_only/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/gpe_laser_wake_only/ae_dc_large.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: gpe_laser_only_wake
+  - override /model: autoencoder_dc_large
+  - override /optimizer: psgd
+  - _self_
+
+experiment_name: ae_dc_large_gpe_laser_only_wake
+
+datamodule:
+  use_normalization: true
+  batch_size: 64
+
+model:
+  encoder:
+    periodic: false
+  decoder:
+    periodic: false
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 1e-5
+  weight_decay: 0.0
+  scheduler: cosine
+
+trainer:
+  gradient_clip_val: 1.0

--- a/local_hydra/local_experiment/ae/gpe_laser_wake_only/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/gpe_laser_wake_only/ae_dc_large.yaml
@@ -10,7 +10,7 @@ experiment_name: ae_dc_large_gpe_laser_only_wake
 
 datamodule:
   use_normalization: true
-  batch_size: 64
+  batch_size: 16
 
 model:
   encoder:

--- a/local_hydra/local_experiment/ae/gpe_laser_wake_only/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/gpe_laser_wake_only/ae_dc_large.yaml
@@ -15,8 +15,10 @@ datamodule:
 model:
   encoder:
     periodic: false
+    pixel_shuffle: true
   decoder:
     periodic: false
+    pixel_shuffle: true
 
 logging:
   wandb:

--- a/local_hydra/local_experiment/ae/gray_scott/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/gray_scott/ae_dc_large.yaml
@@ -10,7 +10,7 @@ experiment_name: ae_dc_large_gray_scott
 
 datamodule:
   use_normalization: true
-  batch_size: 64
+  batch_size: 16
 
 model:
   encoder:

--- a/local_hydra/local_experiment/ae/gray_scott/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/gray_scott/ae_dc_large.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: gray_scott
+  - override /model: autoencoder_dc_large
+  - override /optimizer: psgd
+  - _self_
+
+experiment_name: ae_dc_large_gray_scott
+
+datamodule:
+  use_normalization: true
+  batch_size: 64
+
+model:
+  encoder:
+    periodic: true
+  decoder:
+    periodic: true
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 1e-5
+  weight_decay: 0.0
+  scheduler: cosine
+
+trainer:
+  gradient_clip_val: 1.0

--- a/local_hydra/local_experiment/ae/gray_scott/ae_dc_large.yaml
+++ b/local_hydra/local_experiment/ae/gray_scott/ae_dc_large.yaml
@@ -15,8 +15,10 @@ datamodule:
 model:
   encoder:
     periodic: true
+    pixel_shuffle: true
   decoder:
     periodic: true
+    pixel_shuffle: true
 
 logging:
   wandb:

--- a/src/autocast/configs/autoencoder.yaml
+++ b/src/autocast/configs/autoencoder.yaml
@@ -18,7 +18,7 @@ experiment_name: ae
 
 # torch.set_float32_matmul_precision: one of {highest, high, medium} or null.
 # See encoder_processor_decoder.yaml for details.
-float32_matmul_precision: null
+float32_matmul_precision: high
 
 datamodule:
   autoencoder_mode: true

--- a/src/autocast/configs/autoencoder.yaml
+++ b/src/autocast/configs/autoencoder.yaml
@@ -18,6 +18,7 @@ experiment_name: ae
 
 # torch.set_float32_matmul_precision: one of {highest, high, medium} or null.
 # See encoder_processor_decoder.yaml for details.
+# Default changed 2026-04-17 from `null` to `high`.
 float32_matmul_precision: high
 
 datamodule:

--- a/src/autocast/configs/datamodule/gpe_laser_only_wake.yaml
+++ b/src/autocast/configs/datamodule/gpe_laser_only_wake.yaml
@@ -8,4 +8,5 @@ verbose: false
 use_normalization: false
 normalization_path: ${.data_path}/stats.yml
 num_workers: 0
+# Added 2026-04-17: previously unset (all channels loaded).
 channel_idxs: [1, 2]

--- a/src/autocast/configs/datamodule/gpe_laser_only_wake.yaml
+++ b/src/autocast/configs/datamodule/gpe_laser_only_wake.yaml
@@ -8,3 +8,4 @@ verbose: false
 use_normalization: false
 normalization_path: ${.data_path}/stats.yml
 num_workers: 0
+channel_idxs: [1, 2]

--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -19,4 +19,10 @@ callbacks:
     save_on_train_epoch_end: true
     filename: "latest-5ep-{epoch:04d}"
     auto_insert_metric_name: false
+  - _target_: lightning.pytorch.callbacks.ModelCheckpoint
+    monitor: val_loss
+    mode: min
+    save_top_k: 1
+    filename: "best-val-{epoch:04d}-{val_loss:.4f}"
+    auto_insert_metric_name: false
 

--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -19,6 +19,9 @@ callbacks:
     save_on_train_epoch_end: true
     filename: "latest-5ep-{epoch:04d}"
     auto_insert_metric_name: false
+  # Added 2026-04-17. Drop with `~trainer.callbacks.1` to restore previous
+  # single-callback behaviour.
+  # TODO: refactor callbacks into composable groups so opt-out is index-free.
   - _target_: lightning.pytorch.callbacks.ModelCheckpoint
     monitor: val_loss
     mode: min


### PR DESCRIPTION
## Summary

Adds four dataset-specific autoencoder experiment configs under `local_hydra/` and tunes three defaults in `src/autocast/configs/` that are currently the right choices for the runs we're doing across datasets.

### New local experiment configs (`local_hydra/local_experiment/ae/<dataset>/ae_dc_large.yaml`)
- `advection_diffusion`
- `conditioned_navier_stokes`
- `gpe_laser_wake_only`
- `gray_scott`

### Default changes in `src/autocast/configs/` (documented inline)
| Config | Change | Restore previous behaviour |
|---|---|---|
| `autoencoder.yaml` | `float32_matmul_precision: null` -> `high` | `float32_matmul_precision=null` |
| `datamodule/gpe_laser_only_wake.yaml` | add `channel_idxs: [1, 2]` (real + imag of wave function) | `~datamodule.channel_idxs` |
| `trainer/default.yaml` | add `best-val-{epoch}-{val_loss}` `ModelCheckpoint` (top-1, monitors `val_loss`) | `~trainer.callbacks.1` |

Each change has a short inline comment dated 2026-04-17 noting what changed and how to opt out. A `TODO` in `trainer/default.yaml` flags a follow-up to refactor callbacks into composable config groups so the best-val opt-out does not rely on a list index.

### Note on dataset channel choices
The new `channel_idxs: [1, 2]` on `gpe_laser_only_wake` keeps the real and imaginary parts of the wavefunction (full state that the GPE simulator evolves).

## Test plan
- [x] CI passes
- [x] Spot-check that the four new `ae_dc_large.yaml` configs resolve via `uv run autocast ae --dry-run local_experiment=ae/<dataset>/ae_dc_large`