### PR TITLE
Update support for passing `global_cond` to ViT

### DIFF
--- a/local_hydra/local_experiment/processor/advection_diffusion/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/advection_diffusion/crps_vit_azula_large.yaml
@@ -34,6 +34,8 @@ model:
     n_layers: 12
     patch_size: 1
     n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
   loss_func:
     _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
   train_metrics:

--- a/local_hydra/local_experiment/processor/conditioned_navier_stokes/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/conditioned_navier_stokes/crps_vit_azula_large.yaml
@@ -34,6 +34,8 @@ model:
     n_layers: 12
     patch_size: 1
     n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
   loss_func:
     _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
   train_metrics:

--- a/local_hydra/local_experiment/processor/gpe_laser_wake_only/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/gpe_laser_wake_only/crps_vit_azula_large.yaml
@@ -34,6 +34,8 @@ model:
     n_layers: 12
     patch_size: 1
     n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
   loss_func:
     _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
   train_metrics:

--- a/local_hydra/local_experiment/processor/gray_scott/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/gray_scott/crps_vit_azula_large.yaml
@@ -34,6 +34,8 @@ model:
     n_layers: 12
     patch_size: 1
     n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
   loss_func:
     _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
   train_metrics:

--- a/src/autocast/configs/processor/vit_azula_large.yaml
+++ b/src/autocast/configs/processor/vit_azula_large.yaml
@@ -9,3 +9,4 @@ n_layers: 10
 patch_size: 4
 temporal_method: none
 n_noise_channels: 256
+include_global_cond: false

--- a/src/autocast/configs/processor/vit_azula_small.yaml
+++ b/src/autocast/configs/processor/vit_azula_small.yaml
@@ -9,3 +9,4 @@ n_layers: 10
 patch_size: 4
 temporal_method: none
 n_noise_channels: 256
+include_global_cond: false

--- a/src/autocast/processors/azula_vit.py
+++ b/src/autocast/processors/azula_vit.py
@@ -54,15 +54,6 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
             )
             raise ValueError(msg)
 
-        if self.include_global_cond and (
-            self.global_cond_channels is None or self.global_cond_channels <= 0
-        ):
-            msg = (
-                "include_global_cond=True requires global_cond_channels to be "
-                "set to a positive integer."
-            )
-            raise ValueError(msg)
-
         self.modulation_proj = None
         if (
             self.n_noise_channels

--- a/src/autocast/processors/azula_vit.py
+++ b/src/autocast/processors/azula_vit.py
@@ -32,6 +32,8 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         loss_func: nn.Module | None = None,
         n_noise_channels: int | None = None,
         n_noise_input_channels: int | None = None,
+        global_cond_channels: int | None = None,
+        include_global_cond: bool = False,
         checkpointing: bool = False,
     ):
         super().__init__()
@@ -42,11 +44,22 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
 
         self.n_noise_channels = n_noise_channels
         self.n_noise_input_channels = n_noise_input_channels or n_noise_channels
+        self.global_cond_channels = global_cond_channels
+        self.include_global_cond = include_global_cond
 
         if self.n_noise_channels is None and n_noise_input_channels is not None:
             msg = (
                 "n_noise_input_channels requires n_noise_channels to be set "
                 "for modulation."
+            )
+            raise ValueError(msg)
+
+        if self.include_global_cond and (
+            self.global_cond_channels is None or self.global_cond_channels <= 0
+        ):
+            msg = (
+                "include_global_cond=True requires global_cond_channels to be "
+                "set to a positive integer."
             )
             raise ValueError(msg)
 
@@ -68,8 +81,8 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
             n_steps_output=1,
             n_steps_input=1,
             mod_features=n_noise_channels or 256,
-            global_cond_channels=None,
-            include_global_cond=False,
+            global_cond_channels=global_cond_channels,
+            include_global_cond=include_global_cond,
             hid_channels=hidden_dim,
             hid_blocks=n_layers,
             attention_heads=num_heads,
@@ -82,12 +95,19 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
             use_precomputed_modulation=True,
         )
 
-    def forward(self, x: Tensor, x_noise: Tensor | None = None) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        x_noise: Tensor | None = None,
+        global_cond: Tensor | None = None,
+    ) -> Tensor:
         """Run TemporalViT with channel-first inputs and outputs.
 
         Args:
             x: Input tensor with shape (B, C, H, W).
             x_noise: Optional noise/modulation tensor.
+            global_cond: Optional global conditioning tensor with shape
+                (B, C_global). Used only when include_global_cond=True.
 
         Returns
         -------
@@ -107,22 +127,49 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
             )
             raise ValueError(msg)
 
+        if (
+            not self.n_noise_channels
+            and x_noise is not None
+            and x_noise.shape[-1] != self.model.mod_features
+        ):
+            msg = (
+                f"Expected x_noise with last dim {self.model.mod_features}, "
+                f"got {x_noise.shape[-1]}."
+            )
+            raise ValueError(msg)
+
+        model_global_cond = None
+        if self.include_global_cond:
+            if global_cond is None:
+                msg = "global_cond must be provided when include_global_cond=True."
+                raise ValueError(msg)
+            if global_cond.shape[-1] != self.global_cond_channels:
+                msg = (
+                    f"Expected global_cond with last dim "
+                    f"{self.global_cond_channels}, got "
+                    f"{global_cond.shape[-1]}."
+                )
+                raise ValueError(msg)
+            model_global_cond = global_cond
+
         x_in = rearrange(x, "b c h w -> b 1 h w c").contiguous()
-        y = self.model(x_in, t=x_noise, cond=None, global_cond=None)
+        y = self.model(x_in, t=x_noise, cond=None, global_cond=model_global_cond)
         return rearrange(y, "b 1 h w c -> b c h w").contiguous()
 
-    def map(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:  # noqa: ARG002
+    def map(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:
         noise_channels = self.n_noise_input_channels or self.n_noise_channels
+        if noise_channels is None:
+            noise_channels = self.model.mod_features
+
         if self.n_noise_channels:
-            if noise_channels is None:
-                msg = "n_noise_channels is set but no noise input width is available."
-                raise ValueError(msg)
             noise = torch.randn(
                 x.shape[0], noise_channels, dtype=x.dtype, device=x.device
             )
         else:
-            noise = torch.zeros(x.shape[0], dtype=x.dtype, device=x.device)
-        return self(x, noise)
+            noise = torch.zeros(
+                x.shape[0], noise_channels, dtype=x.dtype, device=x.device
+            )
+        return self(x, noise, global_cond=global_cond)
 
     def loss(self, batch: EncodedBatch) -> Tensor:
         pred = self.map(batch.encoded_inputs, batch.global_cond)


### PR DESCRIPTION
This pull request adds support for optional global conditioning in the Azula ViT processor and updates relevant configuration files to enable or disable this feature as appropriate. The changes make it possible to pass a global conditioning tensor to the model, with validation to ensure correct usage, and expose this functionality through both the configuration and the processor interface.

**Processor enhancements:**

* Added `global_cond_channels` and `include_global_cond` parameters to the `AzulaViTProcessor` class and its constructor, allowing the model to be optionally conditioned on a global tensor. [[1]](diffhunk://#diff-43845b367fcf5b865269180b42fa85b1a0d8e726352cbb4e47b7b875080e0736R35-R36) [[2]](diffhunk://#diff-43845b367fcf5b865269180b42fa85b1a0d8e726352cbb4e47b7b875080e0736R47-R48)
* Updated the `forward` and `map` methods to accept and validate a `global_cond` tensor when global conditioning is enabled, and to pass it to the underlying model. [[1]](diffhunk://#diff-43845b367fcf5b865269180b42fa85b1a0d8e726352cbb4e47b7b875080e0736L85-R101) [[2]](diffhunk://#diff-43845b367fcf5b865269180b42fa85b1a0d8e726352cbb4e47b7b875080e0736R121-R163)
* Ensured that the model is constructed with the correct global conditioning parameters.

**Configuration updates:**

* Enabled global conditioning (`global_cond_channels: auto`, `include_global_cond: true`) in the large Azula ViT configs for the following experiments: `advection_diffusion`, `conditioned_navier_stokes`, `gpe_laser_wake_only`, and `gray_scott`. [[1]](diffhunk://#diff-3fdd2f3ba8918f4f99fdf437e6b71f01558c5067974e69d786002311e8dd9766R37-R38) [[2]](diffhunk://#diff-dc6e72ecdc28ee3280be25bd41301a31e8f68f7a1a609fb756337254e7dac6efR37-R38) [[3]](diffhunk://#diff-8192b1bbbd14b7ca17348628992886d4f22ed7fa467acd843da0a1b2f2892b2eR37-R38) [[4]](diffhunk://#diff-d410d6e476e08e9caaf38389b2342dc0e593d11334c4017bc996da82acaef43aR37-R38)
* Explicitly disabled global conditioning (`include_global_cond: false`) in the base configs for both large and small Azula ViT processors. [[1]](diffhunk://#diff-a31f7cdf6ec0c6218ddeccdcbe775739837d060feddbaaca65a8b7e0c2132833R12) [[2]](diffhunk://#diff-faee38feed55dab51b8d385dfa1ab65cf1c1d69a77e447b8ff8735ead199143fR12)