### PR TITLE
Update support for `global cond` U-Net

### DIFF
--- a/src/autocast/configs/processor/unet_azula_large.yaml
+++ b/src/autocast/configs/processor/unet_azula_large.yaml
@@ -19,6 +19,7 @@ gradient_checkpointing: false  # Enable gradient checkpointing to save memory
 
 # Noise injection
 n_noise_channels: 256
+include_global_cond: false
 
 # Loss function (defaults to MSELoss if not specified)
 loss_func: null

--- a/src/autocast/configs/processor/unet_azula_small.yaml
+++ b/src/autocast/configs/processor/unet_azula_small.yaml
@@ -19,6 +19,7 @@ gradient_checkpointing: false  # Enable gradient checkpointing to save memory
 
 # Noise injection
 n_noise_channels: 256
+include_global_cond: false
 
 # Loss function (defaults to MSELoss if not specified)
 loss_func: null

--- a/src/autocast/nn/unet.py
+++ b/src/autocast/nn/unet.py
@@ -39,11 +39,14 @@ class TemporalUNetBackbone(TemporalBackboneBase):
         tcn_num_layers: int = 2,
         # UNet parameters
         stride: int | Sequence[int] = 2,
+        norm: str = "layer",
+        groups: int = 8,
         dropout: float = 0.0,
         ffn_factor: int = 1,
         identity_init: bool = False,
         attention_heads: Mapping[int, int] | None = None,
         checkpointing: bool = False,
+        use_precomputed_modulation: bool = False,
     ):
         """Initialize Temporal UNet Backbone.
 
@@ -91,6 +94,7 @@ class TemporalUNetBackbone(TemporalBackboneBase):
             temporal_attention_hidden_dim=temporal_attention_hidden_dim,
             tcn_kernel_size=tcn_kernel_size,
             tcn_num_layers=tcn_num_layers,
+            use_precomputed_modulation=use_precomputed_modulation,
         )
 
         # Build UNet backbone
@@ -99,6 +103,8 @@ class TemporalUNetBackbone(TemporalBackboneBase):
             hid_blocks=hid_blocks,
             kernel_size=kernel_size,
             stride=stride,
+            norm=norm,
+            groups=groups,
             spatial=spatial,
             periodic=periodic,
             dropout=dropout,
@@ -133,6 +139,8 @@ class TemporalUNetBackbone(TemporalBackboneBase):
         periodic = kwargs.pop("periodic")
         kernel_size = kwargs.pop("kernel_size", 3)
         stride = kwargs.pop("stride", 2)
+        norm = kwargs.pop("norm", "layer")
+        groups = kwargs.pop("groups", 8)
         dropout = kwargs.pop("dropout", 0.0)
         ffn_factor = kwargs.pop("ffn_factor", 4)
         identity_init = kwargs.pop("identity_init", False)
@@ -150,6 +158,8 @@ class TemporalUNetBackbone(TemporalBackboneBase):
             stride=stride,
             spatial=spatial,
             periodic=periodic,
+            norm=norm,
+            groups=groups,
             dropout=dropout,
             ffn_factor=ffn_factor,
             identity_init=identity_init,

--- a/src/autocast/processors/unet.py
+++ b/src/autocast/processors/unet.py
@@ -3,10 +3,11 @@ from collections.abc import Callable, Sequence
 from typing import Any, cast
 
 import torch
-from azula.nn.unet import UNet
+from einops import rearrange
 from torch import nn
 from torch.utils.checkpoint import checkpoint
 
+from autocast.nn.unet import TemporalUNetBackbone
 from autocast.processors.base import Processor
 from autocast.types import EncodedBatch, Tensor
 
@@ -319,8 +320,7 @@ class UNetProcessor(Processor[EncodedBatch]):
 class AzulaUNetProcessor(Processor[EncodedBatch]):
     """UNet Processor using Azula's modern UNet architecture.
 
-    This processor wraps the Azula UNet implementation which includes
-    additional features like residual connections and flexible normalization.
+    This processor wraps TemporalUNetBackbone with an Azula UNet backbone.
 
     Parameters
     ----------
@@ -393,39 +393,26 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
             )
             raise ValueError(msg)
 
-        if self.include_global_cond and self.n_noise_channels <= 0:
-            msg = (
-                "include_global_cond=True requires n_noise_channels to be set "
-                "to a positive integer."
-            )
-            raise ValueError(msg)
-
-        self.global_cond_embedding = None
-        if self.include_global_cond:
-            if self.global_cond_channels is None:
-                msg = "global_cond_channels must be set when include_global_cond=True."
-                raise ValueError(msg)
-            self.global_cond_embedding = nn.Sequential(
-                nn.Linear(self.global_cond_channels, self.n_noise_channels),
-                nn.SiLU(),
-                nn.Linear(self.n_noise_channels, self.n_noise_channels),
-            )
-
-        # instantiate Azula UNet
-        self.model = UNet(
+        self.model = TemporalUNetBackbone(
             in_channels=in_channels,
             out_channels=out_channels,
+            cond_channels=0,
+            n_steps_output=1,
+            n_steps_input=1,
+            global_cond_channels=global_cond_channels,
+            include_global_cond=include_global_cond,
+            mod_features=n_noise_channels or 256,
             hid_channels=hid_channels,
             hid_blocks=hid_blocks,
+            spatial=2,
+            periodic=periodic,
+            temporal_method="none",
             norm=norm,
             groups=groups,
-            ffn_factor=ffn_factor,
             dropout=dropout,
-            periodic=periodic,
-            # adaptive layer norm modulation based on noise channels
-            mod_features=self.n_noise_channels,
-            cond_channels=0,  # the default
+            ffn_factor=ffn_factor,
             checkpointing=gradient_checkpointing,
+            use_precomputed_modulation=True,
         )
 
         # Azula saves this as self.checkpointing
@@ -455,9 +442,13 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
         Tensor
             Output tensor of shape (B, C_out, *spatial_dims).
         """
+        if x.ndim != 4:
+            msg = "AzulaUNetProcessor expects input shape (B, C, H, W)."
+            raise ValueError(msg)
+
         if (
-            x_noise is not None
-            and self.n_noise_channels > 0
+            self.n_noise_channels
+            and x_noise is not None
             and x_noise.shape[-1] != self.n_noise_channels
         ):
             msg = (
@@ -466,7 +457,19 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
             )
             raise ValueError(msg)
 
+        if (
+            not self.n_noise_channels
+            and x_noise is not None
+            and x_noise.shape[-1] != self.model.mod_features
+        ):
+            msg = (
+                f"Expected x_noise with last dim {self.model.mod_features}, "
+                f"got {x_noise.shape[-1]}."
+            )
+            raise ValueError(msg)
+
         model_mod = x_noise
+        model_global_cond = None
         if self.include_global_cond:
             if global_cond is None:
                 msg = "global_cond must be provided when include_global_cond=True."
@@ -478,15 +481,11 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
                     f"{global_cond.shape[-1]}."
                 )
                 raise ValueError(msg)
+            model_global_cond = global_cond
 
-            if self.global_cond_embedding is None:
-                msg = "global_cond_embedding was not initialized."
-                raise RuntimeError(msg)
-
-            global_mod = self.global_cond_embedding(global_cond)
-            model_mod = global_mod if model_mod is None else model_mod + global_mod
-
-        return self.model(x, mod=model_mod)
+        x_in = rearrange(x, "b c h w -> b 1 h w c").contiguous()
+        y = self.model(x_in, t=model_mod, cond=None, global_cond=model_global_cond)
+        return rearrange(y, "b 1 h w c -> b c h w").contiguous()
 
     def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
         """Map input states to output states.
@@ -508,7 +507,9 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
                 x.shape[0], self.n_noise_channels, dtype=x.dtype, device=x.device
             )
         else:
-            noise = None
+            noise = torch.zeros(
+                x.shape[0], self.model.mod_features, dtype=x.dtype, device=x.device
+            )
         return self(x, x_noise=noise, global_cond=global_cond)
 
     def loss(self, batch: EncodedBatch) -> Tensor:

--- a/src/autocast/processors/unet.py
+++ b/src/autocast/processors/unet.py
@@ -352,6 +352,12 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
     n_noise_channels: int | None = None
         Number of noise channels for conditional normalization. If None, no
         noise conditioning is used. Default is None.
+    global_cond_channels: int | None, optional
+        Width of the optional global conditioning vector.
+    include_global_cond: bool, optional
+        Whether to inject global conditioning into modulation.
+        Uses the same two-layer embedding pattern as ViT temporal backbones.
+        Default is False.
     """
 
     def __init__(
@@ -368,11 +374,42 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
         gradient_checkpointing: bool = False,
         loss_func: nn.Module | None = None,
         n_noise_channels: int | None = None,
+        global_cond_channels: int | None = None,
+        include_global_cond: bool = False,
     ):
         super().__init__()
 
         # the default is 0 for no noise conditioning
         self.n_noise_channels = n_noise_channels or 0
+        self.global_cond_channels = global_cond_channels
+        self.include_global_cond = include_global_cond
+
+        if self.include_global_cond and (
+            self.global_cond_channels is None or self.global_cond_channels <= 0
+        ):
+            msg = (
+                "include_global_cond=True requires global_cond_channels to be "
+                "set to a positive integer."
+            )
+            raise ValueError(msg)
+
+        if self.include_global_cond and self.n_noise_channels <= 0:
+            msg = (
+                "include_global_cond=True requires n_noise_channels to be set "
+                "to a positive integer."
+            )
+            raise ValueError(msg)
+
+        self.global_cond_embedding = None
+        if self.include_global_cond:
+            if self.global_cond_channels is None:
+                msg = "global_cond_channels must be set when include_global_cond=True."
+                raise ValueError(msg)
+            self.global_cond_embedding = nn.Sequential(
+                nn.Linear(self.global_cond_channels, self.n_noise_channels),
+                nn.SiLU(),
+                nn.Linear(self.n_noise_channels, self.n_noise_channels),
+            )
 
         # instantiate Azula UNet
         self.model = UNet(
@@ -395,7 +432,12 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
         self.gradient_checkpointing = gradient_checkpointing
         self.loss_func = loss_func or nn.MSELoss()
 
-    def forward(self, x: Tensor, x_noise: Tensor | None = None) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        x_noise: Tensor | None = None,
+        global_cond: Tensor | None = None,
+    ) -> Tensor:
         """Forward pass through the Azula UNet.
 
         Parameters
@@ -404,13 +446,47 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
             Input tensor of shape (B, C_in, *spatial_dims).
         x_noise : Tensor | None
             Optional noise conditioning tensor of shape (B, n_noise_channels).
+        global_cond : Tensor | None
+            Optional global conditioning tensor of shape (B, C_global).
+            Used only when include_global_cond=True.
 
         Returns
         -------
         Tensor
             Output tensor of shape (B, C_out, *spatial_dims).
         """
-        return self.model(x, mod=x_noise)
+        if (
+            x_noise is not None
+            and self.n_noise_channels > 0
+            and x_noise.shape[-1] != self.n_noise_channels
+        ):
+            msg = (
+                f"Expected x_noise with last dim {self.n_noise_channels}, "
+                f"got {x_noise.shape[-1]}."
+            )
+            raise ValueError(msg)
+
+        model_mod = x_noise
+        if self.include_global_cond:
+            if global_cond is None:
+                msg = "global_cond must be provided when include_global_cond=True."
+                raise ValueError(msg)
+            if global_cond.shape[-1] != self.global_cond_channels:
+                msg = (
+                    f"Expected global_cond with last dim "
+                    f"{self.global_cond_channels}, got "
+                    f"{global_cond.shape[-1]}."
+                )
+                raise ValueError(msg)
+
+            if self.global_cond_embedding is None:
+                msg = "global_cond_embedding was not initialized."
+                raise RuntimeError(msg)
+
+            global_mod = self.global_cond_embedding(global_cond)
+            model_mod = global_mod if model_mod is None else model_mod + global_mod
+
+        return self.model(x, mod=model_mod)
 
     def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
         """Map input states to output states.
@@ -420,21 +496,20 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
         x : Tensor
             Input tensor of shape (B, C_in, *spatial_dims).
         global_cond : Tensor | None
-            Optional conditioning tensor, currently not used.
+            Optional conditioning vector. Used when include_global_cond=True.
 
         Returns
         -------
         Tensor
             Output tensor of shape (B, C_out, *spatial_dims).
         """
-        _ = global_cond
         if self.n_noise_channels > 0:
             noise = torch.randn(
                 x.shape[0], self.n_noise_channels, dtype=x.dtype, device=x.device
             )
         else:
             noise = None
-        return self(x, x_noise=noise)
+        return self(x, x_noise=noise, global_cond=global_cond)
 
     def loss(self, batch: EncodedBatch) -> Tensor:
         """Compute loss between output and target.

--- a/src/autocast/processors/unet.py
+++ b/src/autocast/processors/unet.py
@@ -384,15 +384,6 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
         self.global_cond_channels = global_cond_channels
         self.include_global_cond = include_global_cond
 
-        if self.include_global_cond and (
-            self.global_cond_channels is None or self.global_cond_channels <= 0
-        ):
-            msg = (
-                "include_global_cond=True requires global_cond_channels to be "
-                "set to a positive integer."
-            )
-            raise ValueError(msg)
-
         self.model = TemporalUNetBackbone(
             in_channels=in_channels,
             out_channels=out_channels,
@@ -468,7 +459,12 @@ class AzulaUNetProcessor(Processor[EncodedBatch]):
             )
             raise ValueError(msg)
 
-        model_mod = x_noise
+        if x_noise is None:
+            model_mod = torch.zeros(
+                x.shape[0], self.model.mod_features, dtype=x.dtype, device=x.device
+            )
+        else:
+            model_mod = x_noise
         model_global_cond = None
         if self.include_global_cond:
             if global_cond is None:


### PR DESCRIPTION
Analogous PR to #330 but for U-Net.

This pull request updates the Azula UNet processor to support global conditioning and improves flexibility in normalization and modulation. The main changes include adding support for an optional global conditioning vector, updating configuration files to control this feature, and refactoring the processor to use the new `TemporalUNetBackbone` with enhanced argument handling.

**Global conditioning support and configuration:**

* Added `include_global_cond` and `global_cond_channels` arguments to the `AzulaUNetProcessor` and corresponding YAML config files, allowing the model to optionally use a global conditioning vector. [[1]](diffhunk://#diff-0efcd7842284ffd5c0d2fb6d3db81c3e992b0ce5aa39b08b1c31ac7f3572ccb4R355-R360) [[2]](diffhunk://#diff-0efcd7842284ffd5c0d2fb6d3db81c3e992b0ce5aa39b08b1c31ac7f3572ccb4R377-R418) [[3]](diffhunk://#diff-fbb43713d0ba3420a9ce4eb87dea1ec5022fd2e08c3c1129d96d872d37ae2cecR22) [[4]](diffhunk://#diff-fb1498d94b64f36ea08685084bf0a223aa63929b1f4f42fee2393a88b3a3d715R22)
* Updated the processor's `forward` and `map` methods to handle global conditioning, including input validation and correct tensor passing. [[1]](diffhunk://#diff-0efcd7842284ffd5c0d2fb6d3db81c3e992b0ce5aa39b08b1c31ac7f3572ccb4R427-R484) [[2]](diffhunk://#diff-0efcd7842284ffd5c0d2fb6d3db81c3e992b0ce5aa39b08b1c31ac7f3572ccb4L423-R509)

**Processor and backbone refactoring:**

* Switched the processor implementation from the old `UNet` to the new `TemporalUNetBackbone`, introducing new arguments for normalization (`norm`, `groups`), modulation, and global conditioning. [[1]](diffhunk://#diff-0efcd7842284ffd5c0d2fb6d3db81c3e992b0ce5aa39b08b1c31ac7f3572ccb4L6-R10) [[2]](diffhunk://#diff-0efcd7842284ffd5c0d2fb6d3db81c3e992b0ce5aa39b08b1c31ac7f3572ccb4R377-R418)
* Updated the backbone and processor to support precomputed modulation and flexible normalization/grouping, propagating these arguments throughout the codebase. [[1]](diffhunk://#diff-4efcdb258836cad5fe98e8375fbb4f113084332b1d2994981df2ef50833e4c9aR42-R49) [[2]](diffhunk://#diff-4efcdb258836cad5fe98e8375fbb4f113084332b1d2994981df2ef50833e4c9aR97) [[3]](diffhunk://#diff-4efcdb258836cad5fe98e8375fbb4f113084332b1d2994981df2ef50833e4c9aR106-R107) [[4]](diffhunk://#diff-4efcdb258836cad5fe98e8375fbb4f113084332b1d2994981df2ef50833e4c9aR142-R143) [[5]](diffhunk://#diff-4efcdb258836cad5fe98e8375fbb4f113084332b1d2994981df2ef50833e4c9aR161-R162)

**Documentation improvements:**

* Expanded docstrings for the processor to clarify the new arguments and usage patterns. [[1]](diffhunk://#diff-0efcd7842284ffd5c0d2fb6d3db81c3e992b0ce5aa39b08b1c31ac7f3572ccb4L322-R323) [[2]](diffhunk://#diff-0efcd7842284ffd5c0d2fb6d3db81c3e992b0ce5aa39b08b1c31ac7f3572ccb4R355-R360)