### PR TITLE
Additional comparison config updates and processor step setup

### DIFF
--- a/local_hydra/local_experiment/epd/advection_diffusion/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/epd/advection_diffusion/crps_vit_azula_large.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/advection_diffusion/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/advection_diffusion/crps_vit_azula_large_ae_ambient.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/advection_diffusion/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/advection_diffusion/crps_vit_azula_large_ae_ambient.yaml
@@ -12,7 +12,12 @@ experiment_name: epd_crps_vit_azula_large_ae_ambient_advection_diffusion
 
 datamodule:
   use_normalization: true
-  batch_size: 32
+  # Microbatch to reduce memory in decoder-heavy AE ambient CRPS path.
+  # Effective batch remains 32 via trainer.accumulate_grad_batches=4.
+  batch_size: 8
+
+trainer:
+  accumulate_grad_batches: 4
 
 float32_matmul_precision: high
 

--- a/local_hydra/local_experiment/epd/advection_diffusion/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/advection_diffusion/crps_vit_azula_large_ae_ambient.yaml
@@ -1,0 +1,52 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: advection_diffusion
+  - override /encoder@model.encoder: dc_large
+  - override /decoder@model.decoder: dc_large
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: epd_crps_vit_azula_large_ae_ambient_advection_diffusion
+
+datamodule:
+  use_normalization: true
+  batch_size: 32
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  # Primary CRPS variant: process in AE latent space, decode to ambient, and
+  # compute CRPS in ambient space.
+  train_in_latent_space: false
+  freeze_encoder_decoder: true
+  n_members: 8
+  encoder:
+    periodic: true
+    pixel_shuffle: true
+  decoder:
+    periodic: true
+    pixel_shuffle: true
+  processor:
+    hidden_dim: 568
+    num_heads: 8
+    n_layers: 12
+    patch_size: 1
+    n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
+  loss_func:
+    _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
+  train_metrics:
+    crps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+  val_metrics: []

--- a/local_hydra/local_experiment/epd/advection_diffusion/fm_vit_large.yaml
+++ b/local_hydra/local_experiment/epd/advection_diffusion/fm_vit_large.yaml
@@ -25,6 +25,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 1e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_ae_ambient.yaml
@@ -1,0 +1,52 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: conditioned_navier_stokes
+  - override /encoder@model.encoder: dc_large
+  - override /decoder@model.decoder: dc_large
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: epd_crps_vit_azula_large_ae_ambient_conditioned_navier_stokes
+
+datamodule:
+  use_normalization: true
+  batch_size: 32
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  # Primary CRPS variant: process in AE latent space, decode to ambient, and
+  # compute CRPS in ambient space.
+  train_in_latent_space: false
+  freeze_encoder_decoder: true
+  n_members: 8
+  encoder:
+    periodic: false
+    pixel_shuffle: true
+  decoder:
+    periodic: false
+    pixel_shuffle: true
+  processor:
+    hidden_dim: 568
+    num_heads: 8
+    n_layers: 12
+    patch_size: 1
+    n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
+  loss_func:
+    _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
+  train_metrics:
+    crps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+  val_metrics: []

--- a/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_ae_ambient.yaml
@@ -12,7 +12,12 @@ experiment_name: epd_crps_vit_azula_large_ae_ambient_conditioned_navier_stokes
 
 datamodule:
   use_normalization: true
-  batch_size: 32
+  # Microbatch to reduce memory in decoder-heavy AE ambient CRPS path.
+  # Effective batch remains 32 via trainer.accumulate_grad_batches=4.
+  batch_size: 8
+
+trainer:
+  accumulate_grad_batches: 4
 
 float32_matmul_precision: high
 

--- a/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_ae_ambient.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_identity_global_cond.yaml
+++ b/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_identity_global_cond.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_identity_global_cond.yaml
+++ b/local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large_identity_global_cond.yaml
@@ -1,0 +1,44 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: conditioned_navier_stokes
+  - override /encoder@model.encoder: identity
+  - override /decoder@model.decoder: identity
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: epd_crps_vit_azula_large_identity_global_cond_conditioned_navier_stokes
+
+datamodule:
+  use_normalization: true
+  batch_size: 32
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  train_in_latent_space: false
+  n_members: 8
+  processor:
+    hidden_dim: 568
+    num_heads: 8
+    n_layers: 12
+    patch_size: 4
+    n_noise_channels: 1024
+    # Route conditioning through global_cond (AdaLN), not spatial concat.
+    global_cond_channels: auto
+    include_global_cond: true
+  loss_func:
+    _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
+  train_metrics:
+    crps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+  val_metrics: []

--- a/local_hydra/local_experiment/epd/conditioned_navier_stokes/fm_vit_large.yaml
+++ b/local_hydra/local_experiment/epd/conditioned_navier_stokes/fm_vit_large.yaml
@@ -25,6 +25,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 1e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/gpe_laser_wake_only/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/epd/gpe_laser_wake_only/crps_vit_azula_large.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/gpe_laser_wake_only/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/gpe_laser_wake_only/crps_vit_azula_large_ae_ambient.yaml
@@ -12,7 +12,12 @@ experiment_name: epd_crps_vit_azula_large_ae_ambient_gpe_laser_only_wake
 
 datamodule:
   use_normalization: true
-  batch_size: 32
+  # Microbatch to reduce memory in decoder-heavy AE ambient CRPS path.
+  # Effective batch remains 32 via trainer.accumulate_grad_batches=4.
+  batch_size: 8
+
+trainer:
+  accumulate_grad_batches: 4
 
 float32_matmul_precision: high
 

--- a/local_hydra/local_experiment/epd/gpe_laser_wake_only/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/gpe_laser_wake_only/crps_vit_azula_large_ae_ambient.yaml
@@ -1,0 +1,52 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: gpe_laser_only_wake
+  - override /encoder@model.encoder: dc_large
+  - override /decoder@model.decoder: dc_large
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: epd_crps_vit_azula_large_ae_ambient_gpe_laser_only_wake
+
+datamodule:
+  use_normalization: true
+  batch_size: 32
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  # Primary CRPS variant: process in AE latent space, decode to ambient, and
+  # compute CRPS in ambient space.
+  train_in_latent_space: false
+  freeze_encoder_decoder: true
+  n_members: 8
+  encoder:
+    periodic: false
+    pixel_shuffle: true
+  decoder:
+    periodic: false
+    pixel_shuffle: true
+  processor:
+    hidden_dim: 568
+    num_heads: 8
+    n_layers: 12
+    patch_size: 1
+    n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
+  loss_func:
+    _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
+  train_metrics:
+    crps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+  val_metrics: []

--- a/local_hydra/local_experiment/epd/gpe_laser_wake_only/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/gpe_laser_wake_only/crps_vit_azula_large_ae_ambient.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/gpe_laser_wake_only/fm_vit_large.yaml
+++ b/local_hydra/local_experiment/epd/gpe_laser_wake_only/fm_vit_large.yaml
@@ -25,6 +25,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 1e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/gray_scott/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/epd/gray_scott/crps_vit_azula_large.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/gray_scott/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/gray_scott/crps_vit_azula_large_ae_ambient.yaml
@@ -12,7 +12,12 @@ experiment_name: epd_crps_vit_azula_large_ae_ambient_gray_scott
 
 datamodule:
   use_normalization: true
-  batch_size: 32
+  # Microbatch to reduce memory in decoder-heavy AE ambient CRPS path.
+  # Effective batch remains 32 via trainer.accumulate_grad_batches=4.
+  batch_size: 8
+
+trainer:
+  accumulate_grad_batches: 4
 
 float32_matmul_precision: high
 

--- a/local_hydra/local_experiment/epd/gray_scott/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/gray_scott/crps_vit_azula_large_ae_ambient.yaml
@@ -20,6 +20,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/epd/gray_scott/crps_vit_azula_large_ae_ambient.yaml
+++ b/local_hydra/local_experiment/epd/gray_scott/crps_vit_azula_large_ae_ambient.yaml
@@ -1,0 +1,52 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: gray_scott
+  - override /encoder@model.encoder: dc_large
+  - override /decoder@model.decoder: dc_large
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: epd_crps_vit_azula_large_ae_ambient_gray_scott
+
+datamodule:
+  use_normalization: true
+  batch_size: 32
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  # Primary CRPS variant: process in AE latent space, decode to ambient, and
+  # compute CRPS in ambient space.
+  train_in_latent_space: false
+  freeze_encoder_decoder: true
+  n_members: 8
+  encoder:
+    periodic: true
+    pixel_shuffle: true
+  decoder:
+    periodic: true
+    pixel_shuffle: true
+  processor:
+    hidden_dim: 568
+    num_heads: 8
+    n_layers: 12
+    patch_size: 1
+    n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
+  loss_func:
+    _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
+  train_metrics:
+    crps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+  val_metrics: []

--- a/local_hydra/local_experiment/epd/gray_scott/fm_vit_large.yaml
+++ b/local_hydra/local_experiment/epd/gray_scott/fm_vit_large.yaml
@@ -25,6 +25,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 1e-4
   warmup: 0

--- a/local_hydra/local_experiment/processor/advection_diffusion/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/advection_diffusion/crps_vit_azula_large.yaml
@@ -22,6 +22,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/processor/advection_diffusion/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/advection_diffusion/crps_vit_azula_large.yaml
@@ -36,6 +36,8 @@ model:
     n_noise_channels: 1024
     global_cond_channels: auto
     include_global_cond: true
+    n_steps_input: ${datamodule.n_steps_input}
+    n_steps_output: ${datamodule.n_steps_output}
   loss_func:
     _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
   train_metrics:

--- a/local_hydra/local_experiment/processor/advection_diffusion/fm_vit_large.yaml
+++ b/local_hydra/local_experiment/processor/advection_diffusion/fm_vit_large.yaml
@@ -19,6 +19,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 1e-4
   warmup: 0

--- a/local_hydra/local_experiment/processor/conditioned_navier_stokes/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/conditioned_navier_stokes/crps_vit_azula_large.yaml
@@ -22,6 +22,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/processor/conditioned_navier_stokes/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/conditioned_navier_stokes/crps_vit_azula_large.yaml
@@ -36,6 +36,8 @@ model:
     n_noise_channels: 1024
     global_cond_channels: auto
     include_global_cond: true
+    n_steps_input: ${datamodule.n_steps_input}
+    n_steps_output: ${datamodule.n_steps_output}
   loss_func:
     _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
   train_metrics:

--- a/local_hydra/local_experiment/processor/conditioned_navier_stokes/fm_vit_large.yaml
+++ b/local_hydra/local_experiment/processor/conditioned_navier_stokes/fm_vit_large.yaml
@@ -19,6 +19,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 1e-4
   warmup: 0

--- a/local_hydra/local_experiment/processor/gpe_laser_wake_only/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/gpe_laser_wake_only/crps_vit_azula_large.yaml
@@ -22,6 +22,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/processor/gpe_laser_wake_only/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/gpe_laser_wake_only/crps_vit_azula_large.yaml
@@ -36,6 +36,8 @@ model:
     n_noise_channels: 1024
     global_cond_channels: auto
     include_global_cond: true
+    n_steps_input: ${datamodule.n_steps_input}
+    n_steps_output: ${datamodule.n_steps_output}
   loss_func:
     _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
   train_metrics:

--- a/local_hydra/local_experiment/processor/gpe_laser_wake_only/fm_vit_large.yaml
+++ b/local_hydra/local_experiment/processor/gpe_laser_wake_only/fm_vit_large.yaml
@@ -19,6 +19,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 1e-4
   warmup: 0

--- a/local_hydra/local_experiment/processor/gray_scott/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/gray_scott/crps_vit_azula_large.yaml
@@ -22,6 +22,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 2e-4
   warmup: 0

--- a/local_hydra/local_experiment/processor/gray_scott/crps_vit_azula_large.yaml
+++ b/local_hydra/local_experiment/processor/gray_scott/crps_vit_azula_large.yaml
@@ -36,6 +36,8 @@ model:
     n_noise_channels: 1024
     global_cond_channels: auto
     include_global_cond: true
+    n_steps_input: ${datamodule.n_steps_input}
+    n_steps_output: ${datamodule.n_steps_output}
   loss_func:
     _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
   train_metrics:

--- a/local_hydra/local_experiment/processor/gray_scott/fm_vit_large.yaml
+++ b/local_hydra/local_experiment/processor/gray_scott/fm_vit_large.yaml
@@ -19,6 +19,9 @@ logging:
   wandb:
     enabled: true
 
+output:
+  skip_test: true
+
 optimizer:
   learning_rate: 1e-4
   warmup: 0

--- a/slurm_scripts/comparison/README.md
+++ b/slurm_scripts/comparison/README.md
@@ -11,10 +11,11 @@ and latent space, across 4 datasets.
 | variant | subcommand | Hydra config | scripts |
 |---|---|---|---|
 | AE (shared) | `autocast ae` | `ae/<dataset>/dc_large.yaml` | `ae/` |
-| CRPS ambient | `autocast epd` | `epd/<dataset>/crps_vit_azula_large.yaml` | `epd/submit_crps_*.sh` |
+| CRPS ambient (baseline concat) | `autocast epd` | `epd/<dataset>/crps_vit_azula_large.yaml` | `epd/submit_crps_*.sh` |
+| CRPS via AE latent core (primary) | `autocast epd` | `epd/<dataset>/crps_vit_azula_large_ae_ambient.yaml` | `epd/submit_crps_ae_ambient_*.sh` |
 | FM ambient | `autocast epd` | `epd/<dataset>/fm_vit_large.yaml` | `epd/submit_fm_ambient_*.sh` |
-| CRPS latent | `autocast processor` | `processor/<dataset>/crps_vit_azula_large.yaml` | `cached_latents/submit_crps_latent_*.sh` |
-| FM latent | `autocast processor` | `processor/<dataset>/fm_vit_large.yaml` | `cached_latents/submit_fm_*.sh` |
+| CRPS latent (cached, ablation) | `autocast processor` | `processor/<dataset>/crps_vit_azula_large.yaml` | `cached_latents/submit_crps_latent_*.sh` |
+| FM latent (cached, primary FM latent) | `autocast processor` | `processor/<dataset>/fm_vit_large.yaml` | `cached_latents/submit_fm_*.sh` |
 
 Hydra configs live at `local_hydra/local_experiment/{ae,cache_latents,epd,processor}/<dataset>/`.
 Scripts in `cached_latents/` first cache latents via `submit_cache_latents.sh`,
@@ -25,8 +26,9 @@ then run the latent-space processor variants.
 1. `ae/submit_ae_timing.sh` — per-epoch timing for AE
 2. `ae/submit_ae_large.sh` — full AE training (provides `<ae_run_dir>`)
 3. `cached_latents/submit_cache_latents.sh` — cache latents from trained AE
-4. All remaining scripts in `epd/` and `cached_latents/` are independent and
-   can be submitted in parallel once their dependencies above are complete.
+4. Primary runs: `epd/submit_crps_ae_ambient_*.sh`,
+   `epd/submit_fm_ambient_*.sh`, and `cached_latents/submit_fm_*.sh`.
+5. `cached_latents/submit_crps_latent_*.sh` is kept as an ablation.
 
 ## Model-size matrix (~80M params, DiT-aligned)
 

--- a/slurm_scripts/comparison/README.md
+++ b/slurm_scripts/comparison/README.md
@@ -63,3 +63,50 @@ only 2×2=4 tokens — nearly no spatial structure. The
 `processor/<dataset>/crps_vit_azula_large.yaml` configs explicitly override
 `patch_size: 1` (64 tokens). The FM `vit` backbone already defaults to
 `patch_size=1`, so no override is needed for FM-latent.
+
+## Conditioning mechanism
+
+The four variants pass conditioning (e.g. `constant_scalars`) through two
+different paths, and this is intentional — not an oversight:
+
+| variant | encoder | global_cond on backbone | conditioning path |
+|---|---|---|---|
+| CRPS ambient | `permute_concat` (`with_constants: true`) | **off** (processor `include_global_cond: false`) | spatial channels |
+| FM ambient | `identity` | **on** (backbone default) | AdaLN modulation |
+| CRPS latent | — (cached latents) | **on** (explicit override) | AdaLN modulation |
+| FM latent | — (cached latents) | **on** (backbone default + auto-detect) | AdaLN modulation |
+
+Setup auto-fills `global_cond_channels` from `encoder.encode_cond(batch)` /
+`batch.global_cond`. For CRPS ambient, `AzulaViTProcessor.include_global_cond`
+is hard-coded false in `vit_azula_large.yaml`, so the auto-detected value is
+ignored — conditioning flows only through `permute_concat`'s spatial
+concatenation.
+
+Planned ablation (not in this submission round): CRPS ambient with
+`identity` encoder + `include_global_cond: true` to match FM ambient's
+conditioning path exactly and isolate the encoder effect.
+
+## Cosine schedule (per-dataset, 24h budget)
+
+Each `(variant, dataset)` pair gets its own `COSINE_EPOCHS` so every run
+fills its 24h wall-clock budget — no model is held back by another
+dataset's slower epoch times. This lets us claim each (method, dataset)
+result was given its best shot within the fixed 24h budget, which is the
+load-bearing constraint for the CRPS vs FM comparison. Values are
+extracted per-dataset from `*_timing.sh` via
+`uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24`
+and live in `COSINE_EPOCHS_BY_DATASET` at the top of each `*_large.sh`.
+
+Ambient (timing 2026-04-17):
+
+| variant | gray_scott | gpe_laser_only_wake | cond_navier_stokes | advection_diffusion |
+|---|---|---|---|---|
+| CRPS ambient | **398** (212.3 s/ep) | 477 (177.3) | 471 (179.5) | 486 (174.0) |
+| FM ambient | **2619** (32.3 s/ep) | 3097 (27.3) | 2917 (29.0) | 3279 (25.8) |
+
+Latent: placeholders (1080) pending `submit_{crps_latent,fm}_timing.sh`.
+
+Each script saves quarter-schedule checkpoints (every `cosine_epochs / 4`)
+plus `last.ckpt` at train-end (guaranteed final state). Quarter boundaries
+differ per dataset, which is fine — within-dataset curves are what we
+compare, and absolute losses are only compared within a dataset.

--- a/slurm_scripts/comparison/cached_latents/submit_crps_latent_cns_large.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_crps_latent_cns_large.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+# Ablation: final 24h CRPS-in-cached-latent run for
+# conditioned_navier_stokes only.
+# Model: AzulaViTProcessor / vit_azula_large (hidden_dim=568, n_layers=12,
+# num_heads=8, patch_size=1, n_noise_channels=1024). Head: AlphaFairCRPSLoss,
+# n_members=8. Optimizer: adamw_half (LR=2e-4, warmup=0). Batch: 32/GPU x
+# n_members=8 internal expansion.
+#
+# Replace COSINE_EPOCHS once timing is available from:
+#   submit_crps_latent_cns_timing.sh
+
+DATAMODULE="conditioned_navier_stokes"
+EXPERIMENT="processor/conditioned_navier_stokes/crps_vit_azula_large"
+AE_RUN_DIR="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8"
+COSINE_EPOCHS=1080  # placeholder
+
+BUDGET_MAX_TIME="00:23:59:00"
+# SLURM timeout with 1-min buffer beyond the 24h budget.
+TIMEOUT_MIN=1439
+RUN_DRY_STATES=("true" "false")
+
+cache_dir="${AE_RUN_DIR}/cached_latents"
+
+if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
+    echo "Skipping ${DATAMODULE}: cache missing train/valid/test under ${cache_dir}" >&2
+    exit 1
+fi
+
+# Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
+# save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
+# the final epoch even if it doesn't land on a quarter boundary.
+quarter_epochs=$((COSINE_EPOCHS / 4))
+
+for run_dry in "${RUN_DRY_STATES[@]}"; do
+    dry_run_arg=()
+    run_label="slurm"
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+        run_label="slurm --dry-run"
+    fi
+
+    echo "Submitting CRPS-in-latent ablation training"
+    echo "  mode: ${run_label}"
+    echo "  datamodule: ${DATAMODULE}"
+    echo "  local_experiment: ${EXPERIMENT}"
+    echo "  cache dir: ${cache_dir}"
+    echo "  cosine_epochs: ${COSINE_EPOCHS}"
+
+    uv run autocast processor --mode slurm "${dry_run_arg[@]}" \
+        local_experiment="${EXPERIMENT}" \
+        datamodule.data_path="${cache_dir}" \
+        logging.wandb.enabled=true \
+        optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+        hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+        trainer.max_time="${BUDGET_MAX_TIME}" \
+        +trainer.max_epochs="${COSINE_EPOCHS}" \
+        trainer.callbacks.0.every_n_epochs="${quarter_epochs}" \
+        trainer.callbacks.0.save_top_k=-1 \
+        trainer.callbacks.0.filename="quarter-{epoch:04d}"
+done

--- a/slurm_scripts/comparison/cached_latents/submit_crps_latent_cns_timing.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_crps_latent_cns_timing.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+# Ablation: submit CRPS-in-cached-latent timing run for
+# conditioned_navier_stokes only.
+# Model: AzulaViTProcessor / vit_azula_large (hidden_dim=568, n_layers=12,
+# num_heads=8, patch_size=1, n_noise_channels=1024). Optimizer: adamw_half
+# (LR=2e-4, warmup=0). Batch: 32/GPU x n_members=8 internal expansion;
+# AlphaFairCRPSLoss.
+
+EXPERIMENT="processor/conditioned_navier_stokes/crps_vit_azula_large"
+AE_RUN_DIR="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8"
+DATAMODULE="conditioned_navier_stokes"
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing"
+
+cache_dir="${AE_RUN_DIR}/cached_latents"
+
+if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
+    echo "Skipping ${DATAMODULE}: cache missing train/valid/test under ${cache_dir}" >&2
+    exit 1
+fi
+
+echo "Submitting CRPS-in-latent ablation timing run"
+echo "  datamodule: ${DATAMODULE}"
+echo "  local_experiment: ${EXPERIMENT}"
+echo "  cache dir: ${cache_dir}"
+echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+echo "  budget: ${BUDGET_HOURS}h"
+echo "  run_group: ${RUN_GROUP}"
+echo ""
+
+uv run autocast time-epochs --kind processor --mode slurm \
+    --run-group "${RUN_GROUP}" \
+    --run-id "crps_latent_ablation_b32_${DATAMODULE}" \
+    -n "${NUM_TIMING_EPOCHS}" \
+    -b "${BUDGET_HOURS}" \
+    local_experiment="${EXPERIMENT}" \
+    datamodule.data_path="${cache_dir}"
+
+echo ""
+echo "Once SLURM job completes, collect results with:"
+echo "  for f in outputs/${RUN_GROUP}/crps_latent_ablation_b32_${DATAMODULE}/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/comparison/cached_latents/submit_crps_latent_large.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_crps_latent_large.sh
@@ -9,18 +9,20 @@ set -euo pipefail
 # See local_hydra/local_experiment/processor/<dataset>/crps_vit_azula_large.yaml
 # for the authoritative hyperparameters.
 #
-# COSINE_EPOCHS is a placeholder pending timing runs — once
-# submit_crps_latent_timing.sh completes and per-epoch times are extracted via
+# Per-dataset cosine schedule: each (method, dataset) pair fills its own
+# 24h budget so each model gets its best shot within budget. PLACEHOLDERS
+# pending submit_crps_latent_timing.sh — extract per-dataset values via
 #   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
-# replace 1080 with the recommended value for the slowest dataset.
+# and replace each entry below.
 #
 # learning_rate (2e-4) and warmup (0) are baked into each per-dataset
 # local_experiment config; adjust the yaml to change them.
-COSINE_EPOCHS=1080
-# Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
-# save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
-# the final epoch even if it doesn't land on a quarter boundary.
-QUARTER_EPOCHS=$((COSINE_EPOCHS / 4))
+declare -A COSINE_EPOCHS_BY_DATASET=(
+    ["gray_scott"]=1080                 # placeholder
+    ["gpe_laser_only_wake"]=1080        # placeholder
+    ["conditioned_navier_stokes"]=1080  # placeholder
+    ["advection_diffusion"]=1080        # placeholder
+)
 BUDGET_MAX_TIME="00:23:59:00"
 # SLURM timeout with 1-min buffer beyond the 24h budget.
 TIMEOUT_MIN=1439
@@ -45,6 +47,11 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
     experiment="${EXPERIMENTS[$datamodule]}"
     ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
     cache_dir="${ae_run_dir}/cached_latents"
+    cosine_epochs="${COSINE_EPOCHS_BY_DATASET[$datamodule]}"
+    # Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
+    # save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
+    # the final epoch even if it doesn't land on a quarter boundary.
+    quarter_epochs=$((cosine_epochs / 4))
 
     if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
         echo "Skipping ${datamodule}: cache missing train/valid/test under ${cache_dir}" >&2
@@ -64,17 +71,17 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
         echo "  datamodule: ${datamodule}"
         echo "  local_experiment: ${experiment}"
         echo "  cache dir: ${cache_dir}"
-        echo "  cosine_epochs: ${COSINE_EPOCHS}"
+        echo "  cosine_epochs: ${cosine_epochs}"
 
         uv run autocast processor --mode slurm "${dry_run_arg[@]}" \
             local_experiment="${experiment}" \
             datamodule.data_path="${cache_dir}" \
             logging.wandb.enabled=true \
-            optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+            optimizer.cosine_epochs="${cosine_epochs}" \
             hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
             trainer.max_time="${BUDGET_MAX_TIME}" \
-            +trainer.max_epochs="${COSINE_EPOCHS}" \
-            trainer.callbacks.0.every_n_epochs="${QUARTER_EPOCHS}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_epochs="${quarter_epochs}" \
             trainer.callbacks.0.save_top_k=-1 \
             trainer.callbacks.0.filename="quarter-{epoch:04d}"
     done

--- a/slurm_scripts/comparison/cached_latents/submit_crps_latent_timing.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_crps_latent_timing.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
-# Submit CRPS-in-latent timing jobs for 4 target datasets.
+# Ablation: submit CRPS-in-cached-latent timing jobs for 4 target datasets.
 # Model: AzulaViTProcessor / vit_azula_large (hidden_dim=568, n_layers=12,
 # num_heads=8, patch_size=1, n_noise_channels=1024). Optimizer: adamw_half
 # (LR=2e-4, warmup=0). Batch: 32/GPU x n_members=8 internal expansion;
@@ -53,7 +53,7 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
 
     uv run autocast time-epochs --kind processor --mode slurm \
         --run-group "${RUN_GROUP}" \
-        --run-id "crps_latent_b32_${datamodule}" \
+        --run-id "crps_latent_ablation_b32_${datamodule}" \
         -n "${NUM_TIMING_EPOCHS}" \
         -b "${BUDGET_HOURS}" \
         local_experiment="${experiment}" \
@@ -67,4 +67,4 @@ done
 echo "All timing jobs submitted."
 echo ""
 echo "Once SLURM jobs complete, collect all results with:"
-echo "  for f in outputs/${RUN_GROUP}/crps_latent_b32_*/retrieve.sh; do bash \"\$f\"; done"
+echo "  for f in outputs/${RUN_GROUP}/crps_latent_ablation_b32_*/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/comparison/cached_latents/submit_fm_large.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_fm_large.sh
@@ -8,18 +8,20 @@ set -euo pipefail
 # See local_hydra/local_experiment/processor/<dataset>/fm_vit_large.yaml for
 # the authoritative hyperparameters.
 #
-# COSINE_EPOCHS is a placeholder pending timing runs — once
-# submit_fm_timing.sh completes and per-epoch times are extracted via
+# Per-dataset cosine schedule: each (method, dataset) pair fills its own
+# 24h budget so each model gets its best shot within budget. PLACEHOLDERS
+# pending submit_fm_timing.sh — extract per-dataset values via
 #   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
-# replace 1080 with the recommended value for the slowest dataset.
+# and replace each entry below.
 #
 # learning_rate (1e-4) and warmup (0) are baked into each per-dataset
 # local_experiment config; adjust the yaml to change them.
-COSINE_EPOCHS=1080
-# Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
-# save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
-# the final epoch even if it doesn't land on a quarter boundary.
-QUARTER_EPOCHS=$((COSINE_EPOCHS / 4))
+declare -A COSINE_EPOCHS_BY_DATASET=(
+    ["gray_scott"]=1080                 # placeholder
+    ["gpe_laser_only_wake"]=1080        # placeholder
+    ["conditioned_navier_stokes"]=1080  # placeholder
+    ["advection_diffusion"]=1080        # placeholder
+)
 BUDGET_MAX_TIME="00:23:59:00"
 # SLURM timeout with 1-min buffer beyond the 24h budget.
 TIMEOUT_MIN=1439
@@ -44,6 +46,11 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
     experiment="${EXPERIMENTS[$datamodule]}"
     ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
     cache_dir="${ae_run_dir}/cached_latents"
+    cosine_epochs="${COSINE_EPOCHS_BY_DATASET[$datamodule]}"
+    # Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
+    # save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
+    # the final epoch even if it doesn't land on a quarter boundary.
+    quarter_epochs=$((cosine_epochs / 4))
 
     if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
         echo "Skipping ${datamodule}: cache missing train/valid/test under ${cache_dir}" >&2
@@ -63,17 +70,17 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
         echo "  datamodule: ${datamodule}"
         echo "  local_experiment: ${experiment}"
         echo "  cache dir: ${cache_dir}"
-        echo "  cosine_epochs: ${COSINE_EPOCHS}"
+        echo "  cosine_epochs: ${cosine_epochs}"
 
         uv run autocast processor --mode slurm "${dry_run_arg[@]}" \
             local_experiment="${experiment}" \
             datamodule.data_path="${cache_dir}" \
             logging.wandb.enabled=true \
-            optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+            optimizer.cosine_epochs="${cosine_epochs}" \
             hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
             trainer.max_time="${BUDGET_MAX_TIME}" \
-            +trainer.max_epochs="${COSINE_EPOCHS}" \
-            trainer.callbacks.0.every_n_epochs="${QUARTER_EPOCHS}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_epochs="${quarter_epochs}" \
             trainer.callbacks.0.save_top_k=-1 \
             trainer.callbacks.0.filename="quarter-{epoch:04d}"
     done

--- a/slurm_scripts/comparison/epd/submit_crps_ae_ambient_large.sh
+++ b/slurm_scripts/comparison/epd/submit_crps_ae_ambient_large.sh
@@ -1,22 +1,15 @@
 #!/bin/bash
 
 set -euo pipefail
-# Ablation: final 24h CRPS-in-cached-latent runs for 4 target datasets.
-# Model: AzulaViTProcessor / vit_azula_large (hidden_dim=568, n_layers=12,
-# num_heads=8, patch_size=1, n_noise_channels=1024). Head: AlphaFairCRPSLoss,
-# n_members=8. Optimizer: adamw_half (LR=2e-4, warmup=0). Batch: 32/GPU x
-# n_members=8 internal expansion.
-# See local_hydra/local_experiment/processor/<dataset>/crps_vit_azula_large.yaml
-# for the authoritative hyperparameters.
+# Final 24h primary CRPS-via-AE runs for 4 target datasets.
+# This variant uses EPD with a pretrained autoencoder checkpoint for
+# encode/decode around the processor, while CRPS is still computed in ambient
+# space (train_in_latent_space=false).
 #
-# Per-dataset cosine schedule: each (method, dataset) pair fills its own
-# 24h budget so each model gets its best shot within budget. PLACEHOLDERS
-# pending submit_crps_latent_timing.sh — extract per-dataset values via
+# Replace the placeholder COSINE_EPOCHS values after running
+# submit_crps_ae_ambient_timing.sh and extracting:
 #   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
-# and replace each entry below.
-#
-# learning_rate (2e-4) and warmup (0) are baked into each per-dataset
-# local_experiment config; adjust the yaml to change them.
+
 declare -A COSINE_EPOCHS_BY_DATASET=(
     ["gray_scott"]=1080                 # placeholder
     ["gpe_laser_only_wake"]=1080        # placeholder
@@ -28,13 +21,11 @@ BUDGET_MAX_TIME="00:23:59:00"
 TIMEOUT_MIN=1439
 RUN_DRY_STATES=("true" "false")
 
-# Per-dataset local_experiment + AE run dir (cached latents live under
-# <ae_run_dir>/cached_latents/).
 declare -A EXPERIMENTS=(
-    ["gray_scott"]="processor/gray_scott/crps_vit_azula_large"
-    ["gpe_laser_only_wake"]="processor/gpe_laser_wake_only/crps_vit_azula_large"
-    ["conditioned_navier_stokes"]="processor/conditioned_navier_stokes/crps_vit_azula_large"
-    ["advection_diffusion"]="processor/advection_diffusion/crps_vit_azula_large"
+    ["gray_scott"]="epd/gray_scott/crps_vit_azula_large_ae_ambient"
+    ["gpe_laser_only_wake"]="epd/gpe_laser_wake_only/crps_vit_azula_large_ae_ambient"
+    ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large_ae_ambient"
+    ["advection_diffusion"]="epd/advection_diffusion/crps_vit_azula_large_ae_ambient"
 )
 declare -A AE_RUN_DIRS=(
     ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e"
@@ -46,17 +37,22 @@ declare -A AE_RUN_DIRS=(
 for datamodule in "${!EXPERIMENTS[@]}"; do
     experiment="${EXPERIMENTS[$datamodule]}"
     ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
-    cache_dir="${ae_run_dir}/cached_latents"
     cosine_epochs="${COSINE_EPOCHS_BY_DATASET[$datamodule]}"
+
+    ckpt="${ae_run_dir}/autoencoder.ckpt"
+    if [[ ! -f "${ckpt}" ]]; then
+        ckpt="$(ls -t "${ae_run_dir}"/autocast/*/checkpoints/latest-*.ckpt 2>/dev/null | head -n 1 || true)"
+        if [[ -z "${ckpt}" || ! -f "${ckpt}" ]]; then
+            echo "Skipping ${datamodule}: no autoencoder.ckpt or latest-*.ckpt under ${ae_run_dir}" >&2
+            continue
+        fi
+        echo "Using temp checkpoint (AE still training?): ${ckpt}" >&2
+    fi
+
     # Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
     # save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
     # the final epoch even if it doesn't land on a quarter boundary.
     quarter_epochs=$((cosine_epochs / 4))
-
-    if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
-        echo "Skipping ${datamodule}: cache missing train/valid/test under ${cache_dir}" >&2
-        continue
-    fi
 
     for run_dry in "${RUN_DRY_STATES[@]}"; do
         dry_run_arg=()
@@ -66,16 +62,16 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
             run_label="slurm --dry-run"
         fi
 
-        echo "Submitting CRPS-in-latent training"
+        echo "Submitting CRPS-via-AE (ambient loss) training"
         echo "  mode: ${run_label}"
         echo "  datamodule: ${datamodule}"
         echo "  local_experiment: ${experiment}"
-        echo "  cache dir: ${cache_dir}"
+        echo "  autoencoder checkpoint: ${ckpt}"
         echo "  cosine_epochs: ${cosine_epochs}"
 
-        uv run autocast processor --mode slurm "${dry_run_arg[@]}" \
+        uv run autocast epd --mode slurm "${dry_run_arg[@]}" \
             local_experiment="${experiment}" \
-            datamodule.data_path="${cache_dir}" \
+            autoencoder_checkpoint="${ckpt}" \
             logging.wandb.enabled=true \
             optimizer.cosine_epochs="${cosine_epochs}" \
             hydra.launcher.timeout_min="${TIMEOUT_MIN}" \

--- a/slurm_scripts/comparison/epd/submit_crps_ae_ambient_timing.sh
+++ b/slurm_scripts/comparison/epd/submit_crps_ae_ambient_timing.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+# Submit primary CRPS-via-AE timing jobs for 4 target datasets.
+# This variant uses EPD with a pretrained autoencoder checkpoint for
+# encode/decode around the processor, while CRPS is still computed in ambient
+# space (train_in_latent_space=false).
+#
+# FM cached-latent runs remain primary for FM.
+# CRPS cached-latent runs are retained separately as ablations.
+
+declare -A EXPERIMENTS=(
+    ["gray_scott"]="epd/gray_scott/crps_vit_azula_large_ae_ambient"
+    ["gpe_laser_only_wake"]="epd/gpe_laser_wake_only/crps_vit_azula_large_ae_ambient"
+    ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large_ae_ambient"
+    ["advection_diffusion"]="epd/advection_diffusion/crps_vit_azula_large_ae_ambient"
+)
+declare -A AE_RUN_DIRS=(
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e"
+    ["gpe_laser_only_wake"]="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f"
+    ["conditioned_navier_stokes"]="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300"
+)
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing"
+
+for datamodule in "${!EXPERIMENTS[@]}"; do
+    experiment="${EXPERIMENTS[$datamodule]}"
+    ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
+
+    ckpt="${ae_run_dir}/autoencoder.ckpt"
+    if [[ ! -f "${ckpt}" ]]; then
+        ckpt="$(ls -t "${ae_run_dir}"/autocast/*/checkpoints/latest-*.ckpt 2>/dev/null | head -n 1 || true)"
+        if [[ -z "${ckpt}" || ! -f "${ckpt}" ]]; then
+            echo "Skipping ${datamodule}: no autoencoder.ckpt or latest-*.ckpt under ${ae_run_dir}" >&2
+            continue
+        fi
+        echo "Using temp checkpoint (AE still training?): ${ckpt}" >&2
+    fi
+
+    echo "Submitting CRPS-via-AE (ambient loss) timing run"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  autoencoder checkpoint: ${ckpt}"
+    echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+    echo "  budget: ${BUDGET_HOURS}h"
+    echo "  run_group: ${RUN_GROUP}"
+    echo ""
+
+    uv run autocast time-epochs --kind epd --mode slurm \
+        --run-group "${RUN_GROUP}" \
+        --run-id "crps_ae_ambient_b32_${datamodule}" \
+        -n "${NUM_TIMING_EPOCHS}" \
+        -b "${BUDGET_HOURS}" \
+        local_experiment="${experiment}" \
+        autoencoder_checkpoint="${ckpt}"
+
+    echo ""
+    echo "---"
+    echo ""
+done
+
+echo "All timing jobs submitted."
+echo ""
+echo "Once SLURM jobs complete, collect all results with:"
+echo "  for f in outputs/${RUN_GROUP}/crps_ae_ambient_b32_*/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/comparison/epd/submit_crps_ambient_identity_global_cond_large.sh
+++ b/slurm_scripts/comparison/epd/submit_crps_ambient_identity_global_cond_large.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+# Final 24h CRPS-in-ambient ablation for conditioned_navier_stokes.
+# Model: vit_azula_large (hidden_dim=568, n_layers=12, num_heads=8,
+# patch_size=4, n_noise_channels=1024), n_members=8, AlphaFairCRPSLoss.
+# Ablation path: identity encoder/decoder + processor include_global_cond=true
+# (conditioning via global_cond/AdaLN, not spatial concatenation).
+# See local_hydra/local_experiment/epd/conditioned_navier_stokes/
+# crps_vit_azula_large_identity_global_cond.yaml for authoritative settings.
+#
+# Replace COSINE_EPOCHS value after running:
+#   submit_crps_ambient_identity_global_cond_timing.sh
+# and then extracting:
+#   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
+declare -A COSINE_EPOCHS_BY_DATASET=(
+    ["conditioned_navier_stokes"]=471  # seed from CRPS ambient baseline; update from timing
+)
+BUDGET_MAX_TIME="00:23:59:00"
+# SLURM timeout with 1-min buffer beyond the 24h budget.
+TIMEOUT_MIN=1439
+RUN_DRY_STATES=("true" "false")
+
+declare -A EXPERIMENTS=(
+    ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large_identity_global_cond"
+)
+
+for datamodule in "${!EXPERIMENTS[@]}"; do
+    experiment="${EXPERIMENTS[$datamodule]}"
+    cosine_epochs="${COSINE_EPOCHS_BY_DATASET[$datamodule]}"
+    # Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
+    # save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
+    # the final epoch even if it doesn't land on a quarter boundary.
+    quarter_epochs=$((cosine_epochs / 4))
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        dry_run_arg=()
+        run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting CRPS ambient identity+global_cond training"
+        echo "  mode: ${run_label}"
+        echo "  datamodule: ${datamodule}"
+        echo "  local_experiment: ${experiment}"
+        echo "  cosine_epochs: ${cosine_epochs}"
+
+        uv run autocast epd --mode slurm "${dry_run_arg[@]}" \
+            local_experiment="${experiment}" \
+            logging.wandb.enabled=true \
+            optimizer.cosine_epochs="${cosine_epochs}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+            trainer.max_time="${BUDGET_MAX_TIME}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_epochs="${quarter_epochs}" \
+            trainer.callbacks.0.save_top_k=-1 \
+            trainer.callbacks.0.filename="quarter-{epoch:04d}"
+    done
+done

--- a/slurm_scripts/comparison/epd/submit_crps_ambient_identity_global_cond_timing.sh
+++ b/slurm_scripts/comparison/epd/submit_crps_ambient_identity_global_cond_timing.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+# Submit CRPS-in-ambient timing ablation for conditioned_navier_stokes only.
+# Model: vit_azula_large (hidden_dim=568, n_layers=12, num_heads=8,
+# patch_size=4, n_noise_channels=1024), n_members=8, AlphaFairCRPSLoss.
+# Ablation path: identity encoder/decoder + processor include_global_cond=true
+# (conditioning via global_cond/AdaLN, not spatial concatenation).
+# See local_hydra/local_experiment/epd/conditioned_navier_stokes/
+# crps_vit_azula_large_identity_global_cond.yaml for authoritative settings.
+# Runs 5 epochs to estimate per-epoch wall-clock, then derive a 24h schedule:
+#   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
+
+declare -A EXPERIMENTS=(
+    ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large_identity_global_cond"
+)
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing"
+
+for datamodule in "${!EXPERIMENTS[@]}"; do
+    experiment="${EXPERIMENTS[$datamodule]}"
+
+    echo "Submitting CRPS ambient identity+global_cond timing run"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+    echo "  budget: ${BUDGET_HOURS}h"
+    echo "  run_group: ${RUN_GROUP}"
+    echo ""
+
+    uv run autocast time-epochs --kind epd --mode slurm \
+        --run-group "${RUN_GROUP}" \
+        --run-id "crps_ambient_identity_global_cond_b32_${datamodule}" \
+        -n "${NUM_TIMING_EPOCHS}" \
+        -b "${BUDGET_HOURS}" \
+        local_experiment="${experiment}"
+
+    echo ""
+    echo "---"
+    echo ""
+done
+
+echo "All timing jobs submitted."
+echo ""
+echo "Once SLURM jobs complete, collect all results with:"
+echo "  for f in outputs/${RUN_GROUP}/crps_ambient_identity_global_cond_b32_*/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/comparison/epd/submit_crps_large.sh
+++ b/slurm_scripts/comparison/epd/submit_crps_large.sh
@@ -7,21 +7,19 @@ set -euo pipefail
 # See local_hydra/local_experiment/epd/<dataset>/crps_vit_azula_large.yaml
 # for the authoritative hyperparameters.
 #
-# Fixed cosine schedule across datasets (LOLA App. B methodology):
-# all datasets train for the same number of epochs.
-#
-# COSINE_EPOCHS is a placeholder pending timing runs — once
-# submit_crps_timing.sh completes and per-epoch times are extracted via
+# Per-dataset cosine schedule: each (method, dataset) pair fills its own
+# 24h budget so each model gets its best shot within budget. Values from
+# submit_crps_timing.sh (2026-04-17) via
 #   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
-# replace 240 with the recommended value for the slowest dataset.
 #
 # learning_rate (2e-4) and warmup (0) are baked into each per-dataset
 # local_experiment config; adjust the yaml to change them.
-COSINE_EPOCHS=240
-# Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
-# save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
-# the final epoch even if it doesn't land on a quarter boundary.
-QUARTER_EPOCHS=$((COSINE_EPOCHS / 4))
+declare -A COSINE_EPOCHS_BY_DATASET=(
+    ["gray_scott"]=398                  # 212.3s/epoch
+    ["gpe_laser_only_wake"]=477         # 177.3s/epoch
+    ["conditioned_navier_stokes"]=471   # 179.5s/epoch
+    ["advection_diffusion"]=486         # 174.0s/epoch
+)
 BUDGET_MAX_TIME="00:23:59:00"
 # SLURM timeout with 1-min buffer beyond the 24h budget.
 TIMEOUT_MIN=1439
@@ -37,6 +35,11 @@ declare -A EXPERIMENTS=(
 
 for datamodule in "${!EXPERIMENTS[@]}"; do
     experiment="${EXPERIMENTS[$datamodule]}"
+    cosine_epochs="${COSINE_EPOCHS_BY_DATASET[$datamodule]}"
+    # Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
+    # save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
+    # the final epoch even if it doesn't land on a quarter boundary.
+    quarter_epochs=$((cosine_epochs / 4))
 
     for run_dry in "${RUN_DRY_STATES[@]}"; do
         dry_run_arg=()
@@ -50,16 +53,16 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
         echo "  mode: ${run_label}"
         echo "  datamodule: ${datamodule}"
         echo "  local_experiment: ${experiment}"
-        echo "  cosine_epochs: ${COSINE_EPOCHS}"
+        echo "  cosine_epochs: ${cosine_epochs}"
 
         uv run autocast epd --mode slurm "${dry_run_arg[@]}" \
             local_experiment="${experiment}" \
             logging.wandb.enabled=true \
-            optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+            optimizer.cosine_epochs="${cosine_epochs}" \
             hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
             trainer.max_time="${BUDGET_MAX_TIME}" \
-            +trainer.max_epochs="${COSINE_EPOCHS}" \
-            trainer.callbacks.0.every_n_epochs="${QUARTER_EPOCHS}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_epochs="${quarter_epochs}" \
             trainer.callbacks.0.save_top_k=-1 \
             trainer.callbacks.0.filename="quarter-{epoch:04d}"
     done

--- a/slurm_scripts/comparison/epd/submit_fm_ambient_large.sh
+++ b/slurm_scripts/comparison/epd/submit_fm_ambient_large.sh
@@ -4,24 +4,26 @@ set -euo pipefail
 # Final 24h FM-in-ambient runs for 4 target datasets.
 # Model: flow_matching_vit (vit backbone, hid_channels=704, hid_blocks=12,
 # attention_heads=8, patch_size=4, flow_ode_steps=50). Encoder/decoder:
-# permute_concat + channels_last (architecture parity with ambient CRPS).
+# identity (conditioning flows via backbone global_cond / AdaLN, not spatial
+# concatenation — distinct mechanism from CRPS ambient's permute_concat).
 # Optimizer: adamw_half (LR=1e-4, warmup=0). Batch size: 256/GPU
 # (effective-batch parity with CRPS bs=32 x n_members=8).
 # See local_hydra/local_experiment/epd/<dataset>/fm_vit_large.yaml for the
 # authoritative hyperparameters.
 #
-# COSINE_EPOCHS is a placeholder pending timing runs — once
-# submit_fm_ambient_timing.sh completes and per-epoch times are extracted via
+# Per-dataset cosine schedule: each (method, dataset) pair fills its own
+# 24h budget so each model gets its best shot within budget. Values from
+# submit_fm_ambient_timing.sh (2026-04-17) via
 #   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
-# replace 240 with the recommended value for the slowest dataset.
 #
 # learning_rate (1e-4) and warmup (0) are baked into each per-dataset
 # local_experiment config; adjust the yaml to change them.
-COSINE_EPOCHS=240
-# Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
-# save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
-# the final epoch even if it doesn't land on a quarter boundary.
-QUARTER_EPOCHS=$((COSINE_EPOCHS / 4))
+declare -A COSINE_EPOCHS_BY_DATASET=(
+    ["gray_scott"]=2619                 # 32.3s/epoch
+    ["gpe_laser_only_wake"]=3097        # 27.3s/epoch
+    ["conditioned_navier_stokes"]=2917  # 29.0s/epoch
+    ["advection_diffusion"]=3279        # 25.8s/epoch
+)
 BUDGET_MAX_TIME="00:23:59:00"
 # SLURM timeout with 1-min buffer beyond the 24h budget.
 TIMEOUT_MIN=1439
@@ -37,6 +39,11 @@ declare -A EXPERIMENTS=(
 
 for datamodule in "${!EXPERIMENTS[@]}"; do
     experiment="${EXPERIMENTS[$datamodule]}"
+    cosine_epochs="${COSINE_EPOCHS_BY_DATASET[$datamodule]}"
+    # Save checkpoints at 25/50/75/100% of the schedule (top_k=-1 keeps all).
+    # save_last: true (set in trainer/default.yaml) ensures last.ckpt captures
+    # the final epoch even if it doesn't land on a quarter boundary.
+    quarter_epochs=$((cosine_epochs / 4))
 
     for run_dry in "${RUN_DRY_STATES[@]}"; do
         dry_run_arg=()
@@ -50,16 +57,16 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
         echo "  mode: ${run_label}"
         echo "  datamodule: ${datamodule}"
         echo "  local_experiment: ${experiment}"
-        echo "  cosine_epochs: ${COSINE_EPOCHS}"
+        echo "  cosine_epochs: ${cosine_epochs}"
 
         uv run autocast epd --mode slurm "${dry_run_arg[@]}" \
             local_experiment="${experiment}" \
             logging.wandb.enabled=true \
-            optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+            optimizer.cosine_epochs="${cosine_epochs}" \
             hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
             trainer.max_time="${BUDGET_MAX_TIME}" \
-            +trainer.max_epochs="${COSINE_EPOCHS}" \
-            trainer.callbacks.0.every_n_epochs="${QUARTER_EPOCHS}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_epochs="${quarter_epochs}" \
             trainer.callbacks.0.save_top_k=-1 \
             trainer.callbacks.0.filename="quarter-{epoch:04d}"
     done

--- a/slurm_scripts/comparison/epd/submit_fm_ambient_timing.sh
+++ b/slurm_scripts/comparison/epd/submit_fm_ambient_timing.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 # Submit FM-in-ambient timing jobs for 4 target datasets.
 # Model: flow_matching_vit (vit backbone, hid_channels=704, hid_blocks=12,
 # attention_heads=8, patch_size=4, flow_ode_steps=50). Encoder/decoder:
-# permute_concat + channels_last (architecture parity with ambient CRPS).
+# identity (conditioning flows via backbone global_cond / AdaLN, not
+# spatial concatenation — distinct mechanism from CRPS ambient's
+# permute_concat).
 # Optimizer: adamw_half (LR=1e-4, warmup=0). Batch size: 256/GPU
 # (effective-batch parity with CRPS bs=32 x n_members=8).
 # See local_hydra/local_experiment/epd/<dataset>/fm_vit_large.yaml for the

--- a/src/autocast/models/processor.py
+++ b/src/autocast/models/processor.py
@@ -91,7 +91,7 @@ class ProcessorModel(
             batch_size=batch.encoded_inputs.shape[0],
         )
         if self.train_metrics is not None:
-            y_pred = self._predict(batch)
+            y_pred = self._predict_for_metrics(batch)
             y_true = batch.encoded_output_fields
             self._update_and_log_metrics(
                 self, self.train_metrics, y_pred, y_true, batch.encoded_inputs.shape[0]
@@ -112,7 +112,7 @@ class ProcessorModel(
             batch_size=batch.encoded_inputs.shape[0],
         )
         if self.val_metrics is not None:
-            y_pred = self._predict(batch)
+            y_pred = self._predict_for_metrics(batch)
             y_true = batch.encoded_output_fields
             y_pred = self.denormalize_tensor(y_pred)
             y_true = self.denormalize_tensor(y_true)
@@ -131,7 +131,7 @@ class ProcessorModel(
             batch_size=batch.encoded_inputs.shape[0],
         )
         if self.test_metrics is not None:
-            y_pred = self._predict(batch)
+            y_pred = self._predict_for_metrics(batch)
             y_true = batch.encoded_output_fields
             y_pred = self.denormalize_tensor(y_pred)
             y_true = self.denormalize_tensor(y_true)
@@ -155,6 +155,10 @@ class ProcessorModel(
 
     def _predict(self, batch: EncodedBatch) -> Tensor:
         return self.processor.map(batch.encoded_inputs, batch.global_cond)
+
+    def _predict_for_metrics(self, batch: EncodedBatch) -> Tensor:
+        """Prediction path used by training/validation/test metric updates."""
+        return self._predict(batch)
 
     def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
         """Map input tensor through the processor."""

--- a/src/autocast/models/processor_ensemble.py
+++ b/src/autocast/models/processor_ensemble.py
@@ -42,6 +42,17 @@ class ProcessorModelEnsemble(ProcessorModel):
         """Prediction for rollout (retains flattened batch dim)."""
         return super()._predict(batch)
 
+    def _predict_for_metrics(self, batch: EncodedBatch) -> Tensor:
+        """Prediction for metric updates.
+
+        Match EPD ensemble semantics: metrics should see predictions with an
+        explicit ensemble-member axis when n_members > 1, while rollout keeps
+        using the flattened _predict path for autoregressive compatibility.
+        """
+        if self.n_members > 1:
+            return self(batch.encoded_inputs, batch.global_cond)
+        return self._predict(batch)
+
     def loss(self, batch: EncodedBatch) -> Tensor:
         """Compute ensemble-aware loss.
 

--- a/src/autocast/processors/azula_vit.py
+++ b/src/autocast/processors/azula_vit.py
@@ -35,6 +35,8 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         global_cond_channels: int | None = None,
         include_global_cond: bool = False,
         checkpointing: bool = False,
+        n_steps_input: int = 1,
+        n_steps_output: int = 1,
     ):
         super().__init__()
         self.n_spatial_dims = len(spatial_resolution)
@@ -46,6 +48,8 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         self.n_noise_input_channels = n_noise_input_channels or n_noise_channels
         self.global_cond_channels = global_cond_channels
         self.include_global_cond = include_global_cond
+        self.n_steps_input = n_steps_input
+        self.n_steps_output = n_steps_output
 
         if self.n_noise_channels is None and n_noise_input_channels is not None:
             msg = (
@@ -65,9 +69,14 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
             )
 
         self.loss_func = loss_func or nn.MSELoss()
+        # Absorb input/output T into channel count so the backbone always runs
+        # with a single effective time token. Forward() folds T_in into C on
+        # 5D inputs and unfolds T_out from C on outputs; for 4D inputs the
+        # encoder has already done the fold, so n_steps_input/output=1 and
+        # this scaling is a no-op.
         self.model = TemporalViTBackbone(
-            in_channels=in_channels,
-            out_channels=out_channels,
+            in_channels=in_channels * n_steps_input,
+            out_channels=out_channels * n_steps_output,
             cond_channels=0,
             n_steps_output=1,
             n_steps_input=1,
@@ -96,10 +105,13 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
 
         Accepts both shapes so the same processor works in ambient mode (with
         encoders like ``PermuteConcat`` that fold T into C) and in latent mode
-        (cached latents that keep an explicit T dim):
+        (cached latents that keep an explicit T dim). In latent mode, T_in is
+        folded into C before the backbone and T_out is unfolded afterward, so
+        the backbone itself always runs with a single effective time token.
 
         Args:
-            x: Input tensor with shape (B, C, H, W) or (B, T, H, W, C).
+            x: Input tensor with shape (B, C, H, W) or
+                (B, T=n_steps_input, H, W, C).
             x_noise: Optional noise/modulation tensor.
             global_cond: Optional global conditioning tensor with shape
                 (B, C_global). Used only when include_global_cond=True.
@@ -107,7 +119,7 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         Returns
         -------
             Output tensor with the same rank as ``x``: (B, C, H, W) if ``x`` was
-            4D, (B, T, H, W, C) otherwise.
+            4D, (B, T=n_steps_output, H, W, C) otherwise.
         """
         if x_noise is not None and self.modulation_proj is not None:
             x_noise = self.modulation_proj(x_noise)
@@ -152,7 +164,7 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         if is_channel_first:
             x_in = rearrange(x, "b c h w -> b 1 h w c").contiguous()
         elif x.ndim == 5:
-            x_in = x.contiguous()
+            x_in = rearrange(x, "b t h w c -> b 1 h w (t c)").contiguous()
         else:
             msg = (
                 f"Expected x with 4 dims (B, C, H, W) or 5 dims (B, T, H, W, C), "
@@ -164,7 +176,9 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
 
         if is_channel_first:
             return rearrange(y, "b 1 h w c -> b c h w").contiguous()
-        return y.contiguous()
+        return rearrange(
+            y, "b 1 h w (t c) -> b t h w c", t=self.n_steps_output
+        ).contiguous()
 
     def map(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:
         noise_channels = self.n_noise_input_channels or self.n_noise_channels

--- a/src/autocast/processors/azula_vit.py
+++ b/src/autocast/processors/azula_vit.py
@@ -92,17 +92,22 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         x_noise: Tensor | None = None,
         global_cond: Tensor | None = None,
     ) -> Tensor:
-        """Run TemporalViT with channel-first inputs and outputs.
+        """Run TemporalViT with channel-first or channels-last-with-time inputs.
+
+        Accepts both shapes so the same processor works in ambient mode (with
+        encoders like ``PermuteConcat`` that fold T into C) and in latent mode
+        (cached latents that keep an explicit T dim):
 
         Args:
-            x: Input tensor with shape (B, C, H, W).
+            x: Input tensor with shape (B, C, H, W) or (B, T, H, W, C).
             x_noise: Optional noise/modulation tensor.
             global_cond: Optional global conditioning tensor with shape
                 (B, C_global). Used only when include_global_cond=True.
 
         Returns
         -------
-            Output tensor with shape (B, C, H, W).
+            Output tensor with the same rank as ``x``: (B, C, H, W) if ``x`` was
+            4D, (B, T, H, W, C) otherwise.
         """
         if x_noise is not None and self.modulation_proj is not None:
             x_noise = self.modulation_proj(x_noise)
@@ -143,9 +148,23 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
                 raise ValueError(msg)
             model_global_cond = global_cond
 
-        x_in = rearrange(x, "b c h w -> b 1 h w c").contiguous()
+        is_channel_first = x.ndim == 4
+        if is_channel_first:
+            x_in = rearrange(x, "b c h w -> b 1 h w c").contiguous()
+        elif x.ndim == 5:
+            x_in = x.contiguous()
+        else:
+            msg = (
+                f"Expected x with 4 dims (B, C, H, W) or 5 dims (B, T, H, W, C), "
+                f"got shape {tuple(x.shape)}."
+            )
+            raise ValueError(msg)
+
         y = self.model(x_in, t=x_noise, cond=None, global_cond=model_global_cond)
-        return rearrange(y, "b 1 h w c -> b c h w").contiguous()
+
+        if is_channel_first:
+            return rearrange(y, "b 1 h w c -> b c h w").contiguous()
+        return y.contiguous()
 
     def map(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:
         noise_channels = self.n_noise_input_channels or self.n_noise_channels

--- a/src/autocast/scripts/setup.py
+++ b/src/autocast/scripts/setup.py
@@ -448,8 +448,19 @@ def _build_processor(
         global_cond_channels=global_cond_channels,
         spatial_resolution=proc_kwargs.get("spatial_resolution"),
     )
+
+    # Keep explicit processor temporal-step settings canonical.
+    instantiation_kwargs = dict(proc_kwargs)
+    if processor_config is not None:
+        for key in ("n_steps_input", "n_steps_output"):
+            if key in processor_config and processor_config.get(key) not in (
+                None,
+                "auto",
+            ):
+                instantiation_kwargs.pop(key, None)
+
     target = processor_config.get("_target_") if processor_config else None
-    filtered_kwargs = _filter_kwargs_for_target(target, proc_kwargs)
+    filtered_kwargs = _filter_kwargs_for_target(target, instantiation_kwargs)
     return instantiate(processor_config, **filtered_kwargs)
 
 

--- a/src/autocast/scripts/setup.py
+++ b/src/autocast/scripts/setup.py
@@ -148,6 +148,23 @@ def _infer_latent_spatial_resolution(
     return spatial
 
 
+def _resolve_processor_temporal_steps(
+    encoder: EncoderWithCond,
+    *,
+    n_steps_input: int,
+    n_steps_output: int,
+) -> tuple[int, int]:
+    """Resolve processor temporal-step defaults for the given encoder.
+
+    Encoders like PermuteConcat expose ``outputs_time_channel_concat=True``
+    and already fold time into channels. For these, processors should run with
+    a single effective time token and let decoders handle unfolding.
+    """
+    if bool(getattr(encoder, "outputs_time_channel_concat", False)):
+        return 1, 1
+    return n_steps_input, n_steps_output
+
+
 def _apply_processor_channel_defaults(
     processor_config: DictConfig | None,
     *,
@@ -627,14 +644,20 @@ def setup_epd_model(
         encoded_example, encoder
     )
 
+    proc_n_steps_input, proc_n_steps_output = _resolve_processor_temporal_steps(
+        encoder,
+        n_steps_input=steps_in,
+        n_steps_output=steps_out,
+    )
+
     # TODO: currently "out_channels" and "in_channels" are only used in the config for
     # ViT and FNO, while "n_channels_out" is used in flow_matching and diffusions
     proc_kwargs = {
         "in_channels": latent_channels,
         "out_channels": latent_channels_out,
         "n_channels_out": latent_channels_out,
-        "n_steps_input": steps_in,
-        "n_steps_output": steps_out,
+        "n_steps_input": proc_n_steps_input,
+        "n_steps_output": proc_n_steps_output,
         "spatial_resolution": latent_spatial_resolution,
     }
     processor = _build_processor(model_config, proc_kwargs, global_cond_channels)

--- a/src/autocast/scripts/training.py
+++ b/src/autocast/scripts/training.py
@@ -468,11 +468,8 @@ def run_training(
         log.info("Starting training from scratch (no resume checkpoint).")
         trainer.fit(model=model, datamodule=datamodule)
 
-    # Run testing if not skipped
-    if not skip_test:
-        trainer.test(model=model, datamodule=datamodule)
-
-    # Save stable checkpoint target (prefer callback checkpoint)
+    # Save stable checkpoint target (prefer callback checkpoint) immediately
+    # after fit so a checkpoint exists even if optional test later fails.
     if trainer.is_global_zero:
         _save_or_link_checkpoint_target(trainer, checkpoint_path)
 
@@ -481,8 +478,12 @@ def run_training(
             checkpoint_path.unlink()
             trainer.save_checkpoint(checkpoint_path)
 
-    # Ensure non-zero ranks do not proceed with stale filesystem view.
+    # Ensure non-zero ranks observe the finalized checkpoint before test.
     trainer.strategy.barrier("checkpoint-alias-finalize")
+
+    # Run testing if not skipped.
+    if not skip_test:
+        trainer.test(model=model, datamodule=datamodule)
 
 
 @torch.no_grad()

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -67,7 +67,7 @@ def load_launcher_defaults(launcher_name: str) -> dict:
         if not path.exists():
             continue
         cfg = OmegaConf.load(path)
-        loaded = OmegaConf.to_container(cfg, resolve=True)
+        loaded = OmegaConf.to_container(cfg, resolve=False)
         if isinstance(loaded, dict):
             loaded.pop("defaults", None)
             return loaded
@@ -109,13 +109,17 @@ def _load_preset_launcher_cfg(overrides: list[str]) -> dict:
         path = cfg_root / "distributed" / f"{name}.yaml"
         if not path.exists():
             return {}
-        loaded = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+        loaded = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
         return loaded if isinstance(loaded, dict) else {}
 
     def _load_launcher_from_file(path: Path) -> dict:
         if not path.exists():
             return {}
-        raw = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+        # Do not resolve the whole experiment config here; it may contain
+        # interpolations that are valid only during full Hydra composition
+        # (e.g. model.processor.n_steps_input -> datamodule.n_steps_input).
+        # We only need the hydra.launcher subtree for submission defaults.
+        raw = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
         if not isinstance(raw, dict):
             return {}
         distributed = _extract_distributed_preset_name(raw)
@@ -124,7 +128,7 @@ def _load_preset_launcher_cfg(overrides: list[str]) -> dict:
             if distributed
             else raw
         )
-        cfg = OmegaConf.to_container(merged, resolve=True)
+        cfg = OmegaConf.to_container(merged, resolve=False)
         if not isinstance(cfg, dict):
             return {}
         hydra_cfg = cfg.get("hydra")

--- a/tests/models/test_processor_ensemble.py
+++ b/tests/models/test_processor_ensemble.py
@@ -3,6 +3,7 @@ import torch
 from torch import nn
 
 from autocast.losses.ensemble import CRPSLoss
+from autocast.metrics.ensemble import CRPS
 from autocast.models.processor_ensemble import ProcessorModelEnsemble
 from autocast.processors.base import Processor
 from autocast.types import EncodedBatch, Tensor
@@ -140,3 +141,37 @@ def test_processor_ensemble_predict_returns_flat_batch():
     # _predict returns flat (B, T, H, W, C) — ensemble expansion is handled by callers
     expected_shape = (batch_size, *output_field_shape)
     assert preds.shape == expected_shape
+
+
+def test_processor_ensemble_training_step_metrics_use_ensemble_predictions():
+    """Regression: CRPS metrics in training_step require a member axis on y_pred."""
+    n_members = 3
+    batch_size = 2
+    input_shape = (batch_size, 1, 8, 8, 4)
+    output_field_shape = (2, 8, 8, 4)
+    output_batch_shape = (batch_size, *output_field_shape)
+
+    inputs = torch.randn(*input_shape)
+    targets = torch.randn(*output_batch_shape)
+
+    batch = EncodedBatch(
+        encoded_inputs=inputs,
+        encoded_output_fields=targets,
+        global_cond=None,
+        encoded_info={},
+    )
+
+    processor = SimpleLinearProcessor(input_dim=4, output_dim=4, output_time_steps=2)
+    ensemble = ProcessorModelEnsemble(
+        processor=processor,
+        n_members=n_members,
+        loss_func=CRPSLoss(),
+        train_metrics=[CRPS(reduce_all=True)],
+    )
+
+    # Before the fix this path raised ValueError in CRPS _check_input because
+    # training metrics saw flat predictions without an ensemble member axis.
+    loss = ensemble.training_step(batch, batch_idx=0)
+
+    assert isinstance(loss, torch.Tensor)
+    assert loss.ndim == 0

--- a/tests/processors/test_vit.py
+++ b/tests/processors/test_vit.py
@@ -49,14 +49,14 @@ def test_vit_processor(encoded_batch, encoded_dummy_loader):
     )
 
 
-def test_azula_vit_processor_5d_input():
-    """Cached-latent path feeds (B, T, H, W, C); forward must preserve shape.
+def test_azula_vit_processor_5d_multistep():
+    """Cached-latent path: T_in=1, T_out=4. Processor folds T into C internally.
 
-    Regression test for the einops error triggered when CRPS-in-latent runs
-    called ``AzulaViTProcessor.map`` with a 5D tensor (previous implementation
-    assumed 4D BCHW from encoders like PermuteConcat).
+    Regression test for CRPS-in-latent: AzulaViTProcessor must produce a 5D
+    output with shape (B, n_steps_output, H, W, C) when given a 5D input,
+    mirroring what ``PermuteConcat + ChannelsLast`` achieves in ambient mode.
     """
-    b, t, h, w, c = 2, 1, 8, 8, 4
+    b, t_in, t_out, h, w, c = 2, 1, 4, 8, 8, 4
     processor = AzulaViTProcessor(
         in_channels=c,
         out_channels=c,
@@ -67,9 +67,11 @@ def test_azula_vit_processor_5d_input():
         patch_size=1,
         temporal_method="none",
         n_noise_channels=32,
+        n_steps_input=t_in,
+        n_steps_output=t_out,
     )
-    x = torch.randn(b, t, h, w, c)
-    targets = torch.randn(b, t, h, w, c)
+    x = torch.randn(b, t_in, h, w, c)
+    targets = torch.randn(b, t_out, h, w, c)
     batch = EncodedBatch(
         encoded_inputs=x,
         encoded_output_fields=targets,
@@ -78,7 +80,7 @@ def test_azula_vit_processor_5d_input():
     )
 
     pred = processor.map(x, global_cond=None)
-    assert pred.shape == x.shape
+    assert pred.shape == targets.shape
 
     model = ProcessorModel(
         processor=processor, optimizer_config=get_optimizer_config()

--- a/tests/processors/test_vit.py
+++ b/tests/processors/test_vit.py
@@ -82,9 +82,7 @@ def test_azula_vit_processor_5d_multistep():
     pred = processor.map(x, global_cond=None)
     assert pred.shape == targets.shape
 
-    model = ProcessorModel(
-        processor=processor, optimizer_config=get_optimizer_config()
-    )
+    model = ProcessorModel(processor=processor, optimizer_config=get_optimizer_config())
     train_loss = model.training_step(batch, 0)
     assert train_loss.shape == ()
     train_loss.backward()

--- a/tests/processors/test_vit.py
+++ b/tests/processors/test_vit.py
@@ -1,9 +1,11 @@
 import lightning as L
+import torch
 from conftest import get_optimizer_config
 
 from autocast.models.processor import ProcessorModel
 from autocast.processors.azula_vit import AzulaViTProcessor
 from autocast.processors.vit import AViTProcessor
+from autocast.types import EncodedBatch
 
 
 def test_vit_processor(encoded_batch, encoded_dummy_loader):
@@ -45,6 +47,45 @@ def test_vit_processor(encoded_batch, encoded_dummy_loader):
         train_dataloaders=encoded_dummy_loader,
         val_dataloaders=encoded_dummy_loader,
     )
+
+
+def test_azula_vit_processor_5d_input():
+    """Cached-latent path feeds (B, T, H, W, C); forward must preserve shape.
+
+    Regression test for the einops error triggered when CRPS-in-latent runs
+    called ``AzulaViTProcessor.map`` with a 5D tensor (previous implementation
+    assumed 4D BCHW from encoders like PermuteConcat).
+    """
+    b, t, h, w, c = 2, 1, 8, 8, 4
+    processor = AzulaViTProcessor(
+        in_channels=c,
+        out_channels=c,
+        spatial_resolution=(h, w),
+        hidden_dim=64,
+        num_heads=4,
+        n_layers=2,
+        patch_size=1,
+        temporal_method="none",
+        n_noise_channels=32,
+    )
+    x = torch.randn(b, t, h, w, c)
+    targets = torch.randn(b, t, h, w, c)
+    batch = EncodedBatch(
+        encoded_inputs=x,
+        encoded_output_fields=targets,
+        global_cond=None,
+        encoded_info={},
+    )
+
+    pred = processor.map(x, global_cond=None)
+    assert pred.shape == x.shape
+
+    model = ProcessorModel(
+        processor=processor, optimizer_config=get_optimizer_config()
+    )
+    train_loss = model.training_step(batch, 0)
+    assert train_loss.shape == ()
+    train_loss.backward()
 
 
 def test_azula_vit_processor_checkpointing(encoded_batch):

--- a/tests/scripts/test_setup.py
+++ b/tests/scripts/test_setup.py
@@ -8,6 +8,7 @@ from autocast.encoders.base import Encoder
 from autocast.scripts.setup import (
     _apply_processor_channel_defaults,
     _build_loss_func,
+    _build_processor,
     _filter_kwargs_for_target,
     _get_latent_channels,
     _get_module_device,
@@ -139,6 +140,66 @@ def test_apply_processor_handles_none_config():
         n_steps_output=2,
         n_channels_out=16,
     )
+
+
+def test_build_processor_prefers_explicit_processor_step_counts():
+    model_cfg = OmegaConf.create(
+        {
+            "processor": {
+                "_target_": "autocast.processors.vit_latent.AViTLatentProcessor",
+                "global_cond_channels": 0,
+                "include_global_cond": False,
+                "n_steps_input": 7,
+                "n_steps_output": 9,
+                "hidden_dim": 8,
+                "num_heads": 2,
+                "n_layers": 1,
+            }
+        }
+    )
+    proc_kwargs = {
+        "in_channels": 3,
+        "out_channels": 3,
+        "n_steps_input": 2,
+        "n_steps_output": 4,
+        "n_channels_out": 3,
+        "spatial_resolution": (8, 8),
+    }
+
+    processor = _build_processor(model_cfg, proc_kwargs)
+
+    assert processor.n_steps_input == 7
+    assert processor.n_steps_output == 9
+
+
+def test_build_processor_uses_inferred_steps_when_processor_steps_not_explicit():
+    model_cfg = OmegaConf.create(
+        {
+            "processor": {
+                "_target_": "autocast.processors.vit_latent.AViTLatentProcessor",
+                "global_cond_channels": 0,
+                "include_global_cond": False,
+                "n_steps_input": "auto",
+                "n_steps_output": None,
+                "hidden_dim": 8,
+                "num_heads": 2,
+                "n_layers": 1,
+            }
+        }
+    )
+    proc_kwargs = {
+        "in_channels": 3,
+        "out_channels": 3,
+        "n_steps_input": 2,
+        "n_steps_output": 4,
+        "n_channels_out": 3,
+        "spatial_resolution": (8, 8),
+    }
+
+    processor = _build_processor(model_cfg, proc_kwargs)
+
+    assert processor.n_steps_input == 2
+    assert processor.n_steps_output == 4
 
 
 # --- resolve_auto_params ---

--- a/tests/scripts/test_setup.py
+++ b/tests/scripts/test_setup.py
@@ -12,8 +12,8 @@ from autocast.scripts.setup import (
     _filter_kwargs_for_target,
     _get_latent_channels,
     _get_module_device,
-    _resolve_processor_temporal_steps,
     _resolve_module_device,
+    _resolve_processor_temporal_steps,
     _set_if_auto,
     resolve_auto_params,
     setup_autoencoder_components,
@@ -208,7 +208,7 @@ def test_resolve_processor_temporal_steps_for_time_concatenating_encoder():
         outputs_time_channel_concat = True
 
     steps_in, steps_out = _resolve_processor_temporal_steps(
-        TimeConcatEncoder(),
+        TimeConcatEncoder(),  # type: ignore - just testing resolution logic, not actual encoder behavior
         n_steps_input=4,
         n_steps_output=2,
     )
@@ -222,7 +222,7 @@ def test_resolve_processor_temporal_steps_for_regular_encoder():
         outputs_time_channel_concat = False
 
     steps_in, steps_out = _resolve_processor_temporal_steps(
-        RegularEncoder(),
+        RegularEncoder(),  # type: ignore - just testing resolution logic, not actual encoder behavior
         n_steps_input=4,
         n_steps_output=2,
     )
@@ -236,7 +236,7 @@ def test_resolve_processor_temporal_steps_defaults_to_non_concat_when_missing_at
         pass
 
     steps_in, steps_out = _resolve_processor_temporal_steps(
-        EncoderWithoutFlag(),
+        EncoderWithoutFlag(),  # type: ignore - just testing resolution logic, not actual encoder behavior
         n_steps_input=4,
         n_steps_output=2,
     )

--- a/tests/scripts/test_setup.py
+++ b/tests/scripts/test_setup.py
@@ -12,6 +12,7 @@ from autocast.scripts.setup import (
     _filter_kwargs_for_target,
     _get_latent_channels,
     _get_module_device,
+    _resolve_processor_temporal_steps,
     _resolve_module_device,
     _set_if_auto,
     resolve_auto_params,
@@ -200,6 +201,48 @@ def test_build_processor_uses_inferred_steps_when_processor_steps_not_explicit()
 
     assert processor.n_steps_input == 2
     assert processor.n_steps_output == 4
+
+
+def test_resolve_processor_temporal_steps_for_time_concatenating_encoder():
+    class TimeConcatEncoder:
+        outputs_time_channel_concat = True
+
+    steps_in, steps_out = _resolve_processor_temporal_steps(
+        TimeConcatEncoder(),
+        n_steps_input=4,
+        n_steps_output=2,
+    )
+
+    assert steps_in == 1
+    assert steps_out == 1
+
+
+def test_resolve_processor_temporal_steps_for_regular_encoder():
+    class RegularEncoder:
+        outputs_time_channel_concat = False
+
+    steps_in, steps_out = _resolve_processor_temporal_steps(
+        RegularEncoder(),
+        n_steps_input=4,
+        n_steps_output=2,
+    )
+
+    assert steps_in == 4
+    assert steps_out == 2
+
+
+def test_resolve_processor_temporal_steps_defaults_to_non_concat_when_missing_attr():
+    class EncoderWithoutFlag:
+        pass
+
+    steps_in, steps_out = _resolve_processor_temporal_steps(
+        EncoderWithoutFlag(),
+        n_steps_input=4,
+        n_steps_output=2,
+    )
+
+    assert steps_in == 4
+    assert steps_out == 2
 
 
 # --- resolve_auto_params ---

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -42,6 +42,7 @@ from autocast.scripts.workflow.overrides import (
     strip_hydra_sweep_controls,
 )
 from autocast.scripts.workflow.slurm import (
+    _load_preset_launcher_cfg,
     _parse_override_scalar,
     _should_use_srun,
     submit_manifest_via_sbatch,
@@ -184,6 +185,35 @@ def test_should_use_srun_respects_explicit_override():
         _should_use_srun({"tasks_per_node": 2, "gpus_per_node": 2, "use_srun": False})
         is False
     )
+
+
+def test_load_preset_launcher_cfg_ignores_unrelated_interpolation(
+    tmp_path: Path, monkeypatch
+):
+    local_cfg = tmp_path / "local_hydra" / "local_experiment" / "repro.yaml"
+    local_cfg.parent.mkdir(parents=True, exist_ok=True)
+    local_cfg.write_text(
+        "\n".join(
+            [
+                "defaults:",
+                "  - /distributed: ddp_4gpu_slurm",
+                "model:",
+                "  processor:",
+                "    n_steps_input: ${datamodule.n_steps_input}",
+                "hydra:",
+                "  launcher:",
+                "    partition: gpu",
+                "    timeout_min: 120",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    launcher_cfg = _load_preset_launcher_cfg(["local_experiment=repro"])
+
+    assert launcher_cfg.get("partition") == "gpu"
+    assert launcher_cfg.get("timeout_min") == 120
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces several new experiment configuration files for AE-ambient CRPS variants across multiple domains, and standardizes the output configuration in existing experiment YAMLs to skip test runs. Additionally, it updates certain processor model configurations to explicitly include step count parameters. These changes improve experiment reproducibility, resource management, and model flexibility.

**New experiment configurations for AE-ambient CRPS:**

* Added new AE-ambient CRPS experiment YAMLs for `advection_diffusion`, `conditioned_navier_stokes`, `gpe_laser_wake_only`, and `gray_scott` domains, including both standard and identity global conditioning variants. These provide tailored setups for running CRPS in ambient space with autoencoder-based models. [[1]](diffhunk://#diff-41950a9f2d9e8275f397c3110397de249dd1f4a9c89db0c2ca68f2caf4451707R1-R60) [[2]](diffhunk://#diff-a74e8d7fa0a0e72147c3353c4004f75629225bf75d45d615891b390b494a1e99R1-R60) [[3]](diffhunk://#diff-866cca1905bb7295d1b314d09fa85d8877050679cbf0e121beecdeabd0bb59e8R1-R47) [[4]](diffhunk://#diff-b5fc3246bd99d5e21993d7ce9b8597c9c35ae4ccbaa2a7e3ac35ae366dbff032R1-R60) [[5]](diffhunk://#diff-2eaeaf765d41cba9b69d77fabd0199ac9b33ce363967de1cbb81f848990454e5R1-R60)

**Standardization of output configuration:**

* Updated all relevant experiment YAMLs to set `output.skip_test: true`, ensuring that test runs are skipped by default to save resources during training. [[1]](diffhunk://#diff-e6ab2bf6c2fb85162cd9567926526ed30c8044684601cffa88704d858a44bc52R23-R25) [[2]](diffhunk://#diff-df2b48e233ac1eabb27f20fc6d549c75aff252389090e328e3effe69e6ce0766R28-R30) [[3]](diffhunk://#diff-bcecaed5f56f0ac53184120ee39de7941fc25799da622a101dd947f5b2b69bb3R23-R25) [[4]](diffhunk://#diff-3960ba3110b05a2f6b0ac16370a94c55e8da156f70ac6a916e62aed3905c7d16R23-R25) [[5]](diffhunk://#diff-06c74919f5b79e7adfb8f9ef930e2153012d496be409d055015390eb816c9242R23-R25) [[6]](diffhunk://#diff-6d98eff4b599d34358ab6eec64ec53969ad5102d853019d08e354748b769cd77R28-R30) [[7]](diffhunk://#diff-805fb465e0abbaa3d6071414fe603875de0310c05146885b7c60c6e0045b7c7cR28-R30) [[8]](diffhunk://#diff-3fdd2f3ba8918f4f99fdf437e6b71f01558c5067974e69d786002311e8dd9766R25-R27) [[9]](diffhunk://#diff-a75a968c1413029c5b46ba77ef150451d53ad09fa557c591a89c347820477100R22-R24) [[10]](diffhunk://#diff-dc6e72ecdc28ee3280be25bd41301a31e8f68f7a1a609fb756337254e7dac6efR25-R27) [[11]](diffhunk://#diff-4cc79f120a8f9c0dee195ea39e29dbcea3ce3cebc0581a43857b2db931b1cc6dR22-R24) [[12]](diffhunk://#diff-8192b1bbbd14b7ca17348628992886d4f22ed7fa467acd843da0a1b2f2892b2eR25-R27) [[13]](diffhunk://#diff-38531f766690583bf8f2f736aa093613d2a7b978262029d6b1276ea7455772bdR22-R24) [[14]](diffhunk://#diff-d410d6e476e08e9caaf38389b2342dc0e593d11334c4017bc996da82acaef43aR25-R27)

**Processor model configuration enhancements:**

* Added `n_steps_input` and `n_steps_output` parameters to the processor model configuration in several YAMLs, making the number of input/output steps explicit and configurable from the datamodule. [[1]](diffhunk://#diff-3fdd2f3ba8918f4f99fdf437e6b71f01558c5067974e69d786002311e8dd9766R42-R43) [[2]](diffhunk://#diff-dc6e72ecdc28ee3280be25bd41301a31e8f68f7a1a609fb756337254e7dac6efR42-R43) [[3]](diffhunk://#diff-8192b1bbbd14b7ca17348628992886d4f22ed7fa467acd843da0a1b2f2892b2eR42-R43) [[4]](diffhunk://#diff-d410d6e476e08e9caaf38389b2342dc0e593d11334c4017bc996da82acaef43aR42-R43)