### PR TITLE
Fix cached latents configs

### DIFF
--- a/local_hydra/local_experiment/cache_latents/advection_diffusion/cache_latents.yaml
+++ b/local_hydra/local_experiment/cache_latents/advection_diffusion/cache_latents.yaml
@@ -10,6 +10,9 @@ experiment_name: cache_latents_advection_diffusion
 
 # Must match the AE training config (ae/advection_diffusion/ae_dc_large.yaml)
 # so encoder/decoder architectures align with the checkpoint weights.
+datamodule:
+  use_normalization: true
+
 model:
   encoder:
     periodic: true

--- a/local_hydra/local_experiment/cache_latents/conditioned_navier_stokes/cache_latents.yaml
+++ b/local_hydra/local_experiment/cache_latents/conditioned_navier_stokes/cache_latents.yaml
@@ -10,6 +10,9 @@ experiment_name: cache_latents_conditioned_navier_stokes
 
 # Must match the AE training config (ae/conditioned_navier_stokes/ae_dc_large.yaml)
 # so encoder/decoder architectures align with the checkpoint weights.
+datamodule:
+  use_normalization: true
+
 model:
   encoder:
     periodic: false

--- a/local_hydra/local_experiment/cache_latents/gpe_laser_wake_only/cache_latents.yaml
+++ b/local_hydra/local_experiment/cache_latents/gpe_laser_wake_only/cache_latents.yaml
@@ -10,6 +10,9 @@ experiment_name: cache_latents_gpe_laser_only_wake
 
 # Must match the AE training config (ae/gpe_laser_wake_only/ae_dc_large.yaml)
 # so encoder/decoder architectures align with the checkpoint weights.
+datamodule:
+  use_normalization: true
+
 model:
   encoder:
     periodic: false

--- a/local_hydra/local_experiment/cache_latents/gray_scott/cache_latents.yaml
+++ b/local_hydra/local_experiment/cache_latents/gray_scott/cache_latents.yaml
@@ -10,6 +10,9 @@ experiment_name: cache_latents_gray_scott
 
 # Must match the AE training config (ae/gray_scott/ae_dc_large.yaml)
 # so encoder/decoder architectures align with the checkpoint weights.
+datamodule:
+  use_normalization: true
+
 model:
   encoder:
     periodic: true

--- a/slurm_scripts/comparison/README.md
+++ b/slurm_scripts/comparison/README.md
@@ -20,6 +20,11 @@ and latent space, across 4 datasets.
 Hydra configs live at `local_hydra/local_experiment/{ae,cache_latents,epd,processor}/<dataset>/`.
 Scripts in `cached_latents/` first cache latents via `submit_cache_latents.sh`,
 then run the latent-space processor variants.
+All latent submit scripts now fail fast if
+`<ae_run_dir>/cached_latents/autoencoder_config.yaml` does not match
+`<ae_run_dir>/resolved_autoencoder_config.yaml` for critical datamodule fields
+(`data_path`, `n_steps_input`, `n_steps_output`, `stride`, `use_normalization`,
+`normalization_path`).
 
 ## Submission order
 

--- a/slurm_scripts/comparison/README.md
+++ b/slurm_scripts/comparison/README.md
@@ -20,6 +20,9 @@ and latent space, across 4 datasets.
 Hydra configs live at `local_hydra/local_experiment/{ae,cache_latents,epd,processor}/<dataset>/`.
 Scripts in `cached_latents/` first cache latents via `submit_cache_latents.sh`,
 then run the latent-space processor variants.
+For cache generation, `local_hydra/local_experiment/cache_latents/...` remains
+the source of truth; scripts fail fast if its `datamodule.use_normalization`
+does not match `<ae_run_dir>/resolved_autoencoder_config.yaml`.
 All latent submit scripts now fail fast if
 `<ae_run_dir>/cached_latents/autoencoder_config.yaml` does not match
 `<ae_run_dir>/resolved_autoencoder_config.yaml` for critical datamodule fields

--- a/slurm_scripts/comparison/cached_latents/submit_cache_latents.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_cache_latents.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 # once submit_ae_large.sh has completed and autoencoder.ckpt is in place.
 #
 # Latents are written to <ae_run_dir>/cached_latents/{train,valid,test}.
+# Normalization must match AE training. We read use_normalization from
+# <ae_run_dir>/resolved_autoencoder_config.yaml when available and pass it
+# explicitly to cache-latents to avoid drifting datamodule defaults.
 declare -A EXPERIMENTS=(
     ["gray_scott"]="cache_latents/gray_scott/cache_latents"
     ["gpe_laser_only_wake"]="cache_latents/gpe_laser_wake_only/cache_latents"
@@ -31,6 +34,7 @@ declare -A AE_RUN_DIRS=(
 for datamodule in "${!EXPERIMENTS[@]}"; do
     experiment="${EXPERIMENTS[$datamodule]}"
     ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
+    ae_resolved_cfg="${ae_run_dir}/resolved_autoencoder_config.yaml"
 
     ckpt="${ae_run_dir}/autoencoder.ckpt"
 
@@ -45,6 +49,15 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
     fi
 
     cache_workdir="${ae_run_dir}/cached_latents"
+    if [[ ! -f "${ae_resolved_cfg}" ]]; then
+        echo "Skipping ${datamodule}: missing ${ae_resolved_cfg} (can't safely infer normalization)" >&2
+        continue
+    fi
+    ae_use_normalization="$(awk '/^[[:space:]]*use_normalization:[[:space:]]*/ {print $2; exit}' "${ae_resolved_cfg}")"
+    if [[ "${ae_use_normalization}" != "true" && "${ae_use_normalization}" != "false" ]]; then
+        echo "Skipping ${datamodule}: could not parse use_normalization from ${ae_resolved_cfg}" >&2
+        continue
+    fi
 
     if [[ -d "$cache_workdir" ]]; then
         echo "Warning: cache workdir already exists, will overwrite: $cache_workdir" >&2
@@ -54,6 +67,7 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
     echo "  datamodule: ${datamodule}"
     echo "  local_experiment: ${experiment}"
     echo "  autoencoder run: ${ae_run_dir}"
+    echo "  datamodule.use_normalization: ${ae_use_normalization}"
     echo "  cache workdir: ${cache_workdir}"
 
     uv run autocast cache-latents --mode slurm \
@@ -61,5 +75,6 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
         --output-dir "${cache_workdir}" \
         autoencoder_checkpoint="${ckpt}" \
         local_experiment="${experiment}" \
+        datamodule.use_normalization="${ae_use_normalization}" \
         hydra.launcher.timeout_min=120 || echo "FAILED to submit: ${datamodule}" >&2
 done

--- a/slurm_scripts/comparison/cached_latents/submit_cache_latents.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_cache_latents.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/validate_cached_latents_against_ae.sh"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # Cache autoencoder latents for the 4 target datasets.
 # Each entry pairs a local_experiment config (which bakes in the datamodule
 # + encoder/decoder architecture — periodic, pixel_shuffle — matching the
@@ -15,9 +17,8 @@ set -euo pipefail
 # once submit_ae_large.sh has completed and autoencoder.ckpt is in place.
 #
 # Latents are written to <ae_run_dir>/cached_latents/{train,valid,test}.
-# Normalization must match AE training. We read use_normalization from
-# <ae_run_dir>/resolved_autoencoder_config.yaml when available and pass it
-# explicitly to cache-latents to avoid drifting datamodule defaults.
+# The local_experiment yaml is source of truth; this script fails fast if
+# datamodule.use_normalization in the yaml mismatches AE training config.
 declare -A EXPERIMENTS=(
     ["gray_scott"]="cache_latents/gray_scott/cache_latents"
     ["gpe_laser_only_wake"]="cache_latents/gpe_laser_wake_only/cache_latents"
@@ -34,7 +35,6 @@ declare -A AE_RUN_DIRS=(
 for datamodule in "${!EXPERIMENTS[@]}"; do
     experiment="${EXPERIMENTS[$datamodule]}"
     ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
-    ae_resolved_cfg="${ae_run_dir}/resolved_autoencoder_config.yaml"
 
     ckpt="${ae_run_dir}/autoencoder.ckpt"
 
@@ -49,13 +49,8 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
     fi
 
     cache_workdir="${ae_run_dir}/cached_latents"
-    if [[ ! -f "${ae_resolved_cfg}" ]]; then
-        echo "Skipping ${datamodule}: missing ${ae_resolved_cfg} (can't safely infer normalization)" >&2
-        continue
-    fi
-    ae_use_normalization="$(awk '/^[[:space:]]*use_normalization:[[:space:]]*/ {print $2; exit}' "${ae_resolved_cfg}")"
-    if [[ "${ae_use_normalization}" != "true" && "${ae_use_normalization}" != "false" ]]; then
-        echo "Skipping ${datamodule}: could not parse use_normalization from ${ae_resolved_cfg}" >&2
+    if ! validate_cache_experiment_against_ae "${ae_run_dir}" "${experiment}" "${REPO_ROOT}"; then
+        echo "Skipping ${datamodule}: cache-latents experiment config mismatch vs AE training config" >&2
         continue
     fi
 
@@ -67,7 +62,6 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
     echo "  datamodule: ${datamodule}"
     echo "  local_experiment: ${experiment}"
     echo "  autoencoder run: ${ae_run_dir}"
-    echo "  datamodule.use_normalization: ${ae_use_normalization}"
     echo "  cache workdir: ${cache_workdir}"
 
     uv run autocast cache-latents --mode slurm \
@@ -75,6 +69,5 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
         --output-dir "${cache_workdir}" \
         autoencoder_checkpoint="${ckpt}" \
         local_experiment="${experiment}" \
-        datamodule.use_normalization="${ae_use_normalization}" \
         hydra.launcher.timeout_min=120 || echo "FAILED to submit: ${datamodule}" >&2
 done

--- a/slurm_scripts/comparison/cached_latents/submit_crps_latent_cns_large.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_crps_latent_cns_large.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/validate_cached_latents_against_ae.sh"
 # Ablation: final 24h CRPS-in-cached-latent run for
 # conditioned_navier_stokes only.
 # Model: AzulaViTProcessor / vit_azula_large (hidden_dim=568, n_layers=12,
@@ -25,6 +26,10 @@ cache_dir="${AE_RUN_DIR}/cached_latents"
 
 if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
     echo "Skipping ${DATAMODULE}: cache missing train/valid/test under ${cache_dir}" >&2
+    exit 1
+fi
+if ! validate_cached_latents_against_ae "${AE_RUN_DIR}"; then
+    echo "Skipping ${DATAMODULE}: cached-latents config mismatch vs AE training config" >&2
     exit 1
 fi
 

--- a/slurm_scripts/comparison/cached_latents/submit_crps_latent_cns_timing.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_crps_latent_cns_timing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/validate_cached_latents_against_ae.sh"
 # Ablation: submit CRPS-in-cached-latent timing run for
 # conditioned_navier_stokes only.
 # Model: AzulaViTProcessor / vit_azula_large (hidden_dim=568, n_layers=12,
@@ -20,6 +21,10 @@ cache_dir="${AE_RUN_DIR}/cached_latents"
 
 if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
     echo "Skipping ${DATAMODULE}: cache missing train/valid/test under ${cache_dir}" >&2
+    exit 1
+fi
+if ! validate_cached_latents_against_ae "${AE_RUN_DIR}"; then
+    echo "Skipping ${DATAMODULE}: cached-latents config mismatch vs AE training config" >&2
     exit 1
 fi
 

--- a/slurm_scripts/comparison/cached_latents/submit_crps_latent_large.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_crps_latent_large.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/validate_cached_latents_against_ae.sh"
 # Ablation: final 24h CRPS-in-cached-latent runs for 4 target datasets.
 # Model: AzulaViTProcessor / vit_azula_large (hidden_dim=568, n_layers=12,
 # num_heads=8, patch_size=1, n_noise_channels=1024). Head: AlphaFairCRPSLoss,
@@ -55,6 +56,10 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
 
     if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
         echo "Skipping ${datamodule}: cache missing train/valid/test under ${cache_dir}" >&2
+        continue
+    fi
+    if ! validate_cached_latents_against_ae "${ae_run_dir}"; then
+        echo "Skipping ${datamodule}: cached-latents config mismatch vs AE training config" >&2
         continue
     fi
 

--- a/slurm_scripts/comparison/cached_latents/submit_crps_latent_timing.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_crps_latent_timing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/validate_cached_latents_against_ae.sh"
 # Ablation: submit CRPS-in-cached-latent timing jobs for 4 target datasets.
 # Model: AzulaViTProcessor / vit_azula_large (hidden_dim=568, n_layers=12,
 # num_heads=8, patch_size=1, n_noise_channels=1024). Optimizer: adamw_half
@@ -39,6 +40,10 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
 
     if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
         echo "Skipping ${datamodule}: cache missing train/valid/test under ${cache_dir}" >&2
+        continue
+    fi
+    if ! validate_cached_latents_against_ae "${ae_run_dir}"; then
+        echo "Skipping ${datamodule}: cached-latents config mismatch vs AE training config" >&2
         continue
     fi
 

--- a/slurm_scripts/comparison/cached_latents/submit_fm_large.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_fm_large.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/validate_cached_latents_against_ae.sh"
 # Final 24h FM-in-latent runs for 4 target datasets.
 # Model: flow_matching_vit (vit backbone, hid_channels=704, hid_blocks=12,
 # attention_heads=8, patch_size=1, flow_ode_steps=50). Optimizer: adamw_half
@@ -53,6 +54,10 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
 
     if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
         echo "Skipping ${datamodule}: cache missing train/valid/test under ${cache_dir}" >&2
+        continue
+    fi
+    if ! validate_cached_latents_against_ae "${ae_run_dir}"; then
+        echo "Skipping ${datamodule}: cached-latents config mismatch vs AE training config" >&2
         continue
     fi
 

--- a/slurm_scripts/comparison/cached_latents/submit_fm_timing.sh
+++ b/slurm_scripts/comparison/cached_latents/submit_fm_timing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/validate_cached_latents_against_ae.sh"
 # Submit FM-in-latent timing jobs for 4 target datasets.
 # Model: flow_matching_vit (vit backbone, hid_channels=704, hid_blocks=12,
 # attention_heads=8, patch_size=1, flow_ode_steps=50). Optimizer: adamw_half
@@ -38,6 +39,10 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
 
     if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
         echo "Skipping ${datamodule}: cache missing train/valid/test under ${cache_dir}" >&2
+        continue
+    fi
+    if ! validate_cached_latents_against_ae "${ae_run_dir}"; then
+        echo "Skipping ${datamodule}: cached-latents config mismatch vs AE training config" >&2
         continue
     fi
 

--- a/slurm_scripts/comparison/cached_latents/validate_cached_latents_against_ae.sh
+++ b/slurm_scripts/comparison/cached_latents/validate_cached_latents_against_ae.sh
@@ -93,3 +93,45 @@ validate_cached_latents_against_ae() {
     echo "Validated cached-latent settings against AE config for ${ae_run_dir}"
     return 0
 }
+
+validate_cache_experiment_against_ae() {
+    local ae_run_dir="$1"
+    local local_experiment="$2"
+    local repo_root="$3"
+    local ae_cfg="${ae_run_dir}/resolved_autoencoder_config.yaml"
+    local experiment_cfg="${repo_root}/local_hydra/local_experiment/${local_experiment}.yaml"
+
+    if [[ ! -f "${ae_cfg}" ]]; then
+        echo "Missing AE resolved config: ${ae_cfg}" >&2
+        return 1
+    fi
+    if [[ ! -f "${experiment_cfg}" ]]; then
+        echo "Missing cache-latents experiment config: ${experiment_cfg}" >&2
+        return 1
+    fi
+
+    local ae_use_norm
+    local exp_use_norm
+    ae_use_norm="$(yaml_get_scalar_in_block "${ae_cfg}" "datamodule" "use_normalization")"
+    exp_use_norm="$(yaml_get_scalar_in_block "${experiment_cfg}" "datamodule" "use_normalization")"
+
+    if [[ "${ae_use_norm}" != "true" && "${ae_use_norm}" != "false" ]]; then
+        echo "Could not parse datamodule.use_normalization in ${ae_cfg}" >&2
+        return 1
+    fi
+    if [[ "${exp_use_norm}" != "true" && "${exp_use_norm}" != "false" ]]; then
+        echo "cache-latents experiment must explicitly set datamodule.use_normalization in ${experiment_cfg}" >&2
+        return 1
+    fi
+    if [[ "${ae_use_norm}" != "${exp_use_norm}" ]]; then
+        echo "Mismatch datamodule.use_normalization between AE and cache-latents experiment" >&2
+        echo "  AE config:        ${ae_use_norm}" >&2
+        echo "  Experiment config:${exp_use_norm}" >&2
+        echo "  AE cfg:           ${ae_cfg}" >&2
+        echo "  Experiment cfg:   ${experiment_cfg}" >&2
+        return 1
+    fi
+
+    echo "Validated cache-latents experiment normalization against AE config for ${ae_run_dir}"
+    return 0
+}

--- a/slurm_scripts/comparison/cached_latents/validate_cached_latents_against_ae.sh
+++ b/slurm_scripts/comparison/cached_latents/validate_cached_latents_against_ae.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Shared preflight check for cached-latent runs.
+# Ensures cached_latents/autoencoder_config.yaml matches the AE training
+# datamodule settings from resolved_autoencoder_config.yaml.
+
+yaml_get_scalar_in_block() {
+    local yaml_file="$1"
+    local block="$2"
+    local key="$3"
+
+    awk -v block="${block}" -v key="${key}" '
+        function ltrim(s) { sub(/^[ \t\r\n]+/, "", s); return s }
+        function rtrim(s) { sub(/[ \t\r\n]+$/, "", s); return s }
+        function trim(s) { return rtrim(ltrim(s)) }
+
+        {
+            line = $0
+            if (line ~ "^[[:space:]]*" block ":[[:space:]]*$") {
+                in_block = 1
+                block_indent = match(line, /[^ ]/) - 1
+                next
+            }
+
+            if (in_block) {
+                if (line ~ /^[[:space:]]*$/) {
+                    next
+                }
+                indent = match(line, /[^ ]/) - 1
+                if (indent <= block_indent) {
+                    in_block = 0
+                }
+            }
+
+            if (in_block && line ~ "^[[:space:]]*" key ":[[:space:]]*") {
+                sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "", line)
+                sub(/[[:space:]]+#.*$/, "", line)
+                line = trim(line)
+                if (line ~ /^".*"$/ || line ~ /^'\''.*'\''$/) {
+                    line = substr(line, 2, length(line) - 2)
+                }
+                print line
+                exit
+            }
+        }
+    ' "${yaml_file}"
+}
+
+validate_cached_latents_against_ae() {
+    local ae_run_dir="$1"
+    local ae_cfg="${ae_run_dir}/resolved_autoencoder_config.yaml"
+    local cache_cfg="${ae_run_dir}/cached_latents/autoencoder_config.yaml"
+
+    if [[ ! -f "${ae_cfg}" ]]; then
+        echo "Missing AE resolved config: ${ae_cfg}" >&2
+        return 1
+    fi
+    if [[ ! -f "${cache_cfg}" ]]; then
+        echo "Missing cached-latents config: ${cache_cfg}" >&2
+        return 1
+    fi
+
+    local -a keys=(
+        "data_path"
+        "n_steps_input"
+        "n_steps_output"
+        "stride"
+        "use_normalization"
+        "normalization_path"
+    )
+
+    local key
+    for key in "${keys[@]}"; do
+        local ae_val
+        local cache_val
+        ae_val="$(yaml_get_scalar_in_block "${ae_cfg}" "datamodule" "${key}")"
+        cache_val="$(yaml_get_scalar_in_block "${cache_cfg}" "datamodule" "${key}")"
+
+        if [[ -z "${ae_val}" || -z "${cache_val}" ]]; then
+            echo "Missing datamodule.${key} in ${ae_cfg} or ${cache_cfg}" >&2
+            return 1
+        fi
+        if [[ "${ae_val}" != "${cache_val}" ]]; then
+            echo "Mismatch datamodule.${key}" >&2
+            echo "  AE config:     ${ae_val}" >&2
+            echo "  Cached config: ${cache_val}" >&2
+            echo "  AE cfg:        ${ae_cfg}" >&2
+            echo "  Cache cfg:     ${cache_cfg}" >&2
+            return 1
+        fi
+    done
+
+    echo "Validated cached-latent settings against AE config for ${ae_run_dir}"
+    return 0
+}


### PR DESCRIPTION
This pull request introduces robust preflight validation to ensure cached latent-space data is always consistent with the corresponding autoencoder (AE) training configuration. It adds explicit normalization settings to all cache-latents experiment configs, and updates all relevant SLURM submission scripts to fail fast if there is any mismatch in critical datamodule fields between the cache and AE configs. The main changes are grouped below:

**Validation and Consistency Enforcement:**

* Added a new shared script, `validate_cached_latents_against_ae.sh`, which checks that critical datamodule fields (such as `data_path`, `n_steps_input`, `stride`, `use_normalization`, etc.) in cached-latents configs match those in the AE training config, and that normalization usage is explicitly set and consistent. This script is now sourced and used by all cached-latents submission scripts.
* All SLURM scripts for cached-latent runs (`submit_cache_latents.sh`, `submit_crps_latent_large.sh`, `submit_crps_latent_timing.sh`, `submit_crps_latent_cns_large.sh`, `submit_crps_latent_cns_timing.sh`, `submit_fm_large.sh`, `submit_fm_timing.sh`) now invoke this validation and will skip or abort if configs are inconsistent. [[1]](diffhunk://#diff-ecee4c8902c5927d5403eb8f2b4740aa0722f1e6a353babbd17d1fe82c93cef2R4-R5) [[2]](diffhunk://#diff-ecee4c8902c5927d5403eb8f2b4740aa0722f1e6a353babbd17d1fe82c93cef2R52-R55) [[3]](diffhunk://#diff-61e09d2eeb55b23ca14caa0fcb1b11750e8b387ad142e5610f9ad7a45e9f0d43R4) [[4]](diffhunk://#diff-61e09d2eeb55b23ca14caa0fcb1b11750e8b387ad142e5610f9ad7a45e9f0d43R31-R34) [[5]](diffhunk://#diff-ac896753641d598a8d277daf41f487f27e8fa978dec0a6dce936bd4b85fe9478R4) [[6]](diffhunk://#diff-ac896753641d598a8d277daf41f487f27e8fa978dec0a6dce936bd4b85fe9478R26-R29) [[7]](diffhunk://#diff-b38c408d63df025d4e988175a72fb3f62439ef6e2c67f241a8ab37d0f9ad9d6dR4) [[8]](diffhunk://#diff-b38c408d63df025d4e988175a72fb3f62439ef6e2c67f241a8ab37d0f9ad9d6dR61-R64) [[9]](diffhunk://#diff-5a539ed89202757a020bbf297ba138e0b75b887ad6f6a0d16a68d4c6499f4863R4) [[10]](diffhunk://#diff-5a539ed89202757a020bbf297ba138e0b75b887ad6f6a0d16a68d4c6499f4863R45-R48) [[11]](diffhunk://#diff-737c493a4ea3ef8c234ea8ee2d5aa31df935df1670792172837ceb90066c3b9fR4) [[12]](diffhunk://#diff-737c493a4ea3ef8c234ea8ee2d5aa31df935df1670792172837ceb90066c3b9fR59-R62) [[13]](diffhunk://#diff-92a459d876f7bb2cffdd8f7644f15fae558a5c31662915919a167c030f3cbbcaR4) [[14]](diffhunk://#diff-92a459d876f7bb2cffdd8f7644f15fae558a5c31662915919a167c030f3cbbcaR44-R47)

**Experiment Configuration Updates:**

* Explicitly set `datamodule.use_normalization: true` in all cache-latents experiment YAMLs, ensuring that normalization intent is always clear and validated. [[1]](diffhunk://#diff-e7fb993470371190425c801c0240aa865d8176d7fe4f63679db8a4c7e7862e1bR13-R15) [[2]](diffhunk://#diff-78ab8817e30a78d86816792e404930844249ce3a2b8e51e415a4c9e33891b04cR13-R15) [[3]](diffhunk://#diff-4931abfef07343d38939dba8514b2aa804b7a0b630eadec8fcb6766cd98244baR13-R15) [[4]](diffhunk://#diff-8ddf6a1f737fe495f4a306d40f0921ceabb156a2b1ac5e224b8c98cd063571f6R13-R15)

**Documentation:**

* Updated `slurm_scripts/comparison/README.md` to document the new validation checks and clarify that the cache-latents experiment configs are the source of truth for normalization and other datamodule settings. [[1]](diffhunk://#diff-8b26617c1802c75ce4d085003fc7274f11d3ce5443963d598729a1e54892e854R23-R30) [[2]](diffhunk://#diff-ecee4c8902c5927d5403eb8f2b4740aa0722f1e6a353babbd17d1fe82c93cef2R20-R21)

These changes collectively prevent silent mismatches between cached latents and AE configs, improving experiment reproducibility and reliability.