### PR TITLE
Add epoch summary logging and update documentation

### DIFF
--- a/docs/SCRIPTS_AND_CONFIGS.md
+++ b/docs/SCRIPTS_AND_CONFIGS.md
@@ -229,6 +229,11 @@ The calculation is conservative:
 Per-epoch times are extracted from the `TrainingTimerCallback` saved in the
 checkpoint, which excludes model setup and data loading overhead.
 
+Timing runs also emit a human-readable timing summary to logs at train end
+(epoch count, mean/min/max epoch seconds, and the per-epoch list for short
+runs), so you can quickly inspect timing quality without loading the
+checkpoint first.
+
 #### How `max_epochs` and `max_time` interact at runtime
 
 The recommended overrides set **two** stopping conditions:

--- a/src/autocast/scripts/training.py
+++ b/src/autocast/scripts/training.py
@@ -325,6 +325,26 @@ class TrainingTimerCallback(Callback):
         if self._train_start is not None:
             self.training_runtime_total_s = now - self._train_start
 
+        # Emit human-readable timing info into stdout/stderr logs so timing
+        # runs are inspectable without loading timing.ckpt.
+        if self._epoch_times_s:
+            n = len(self._epoch_times_s)
+            mean_epoch_s = sum(self._epoch_times_s) / n
+            min_epoch_s = min(self._epoch_times_s)
+            max_epoch_s = max(self._epoch_times_s)
+            log.info(
+                "TrainingTimerCallback: epochs=%d mean=%.1fs min=%.1fs max=%.1fs",
+                n,
+                mean_epoch_s,
+                min_epoch_s,
+                max_epoch_s,
+            )
+            if n <= 12:
+                log.info(
+                    "TrainingTimerCallback epoch_times_s: %s",
+                    ", ".join(f"{t:.1f}s" for t in self._epoch_times_s),
+                )
+
     def state_dict(self) -> dict:  # type: ignore[override]
         runtime_elapsed_s = self._current_elapsed_runtime_s()
         d: dict = {


### PR DESCRIPTION
This pull request improves the visibility of training timing information by adding a human-readable summary of epoch timings to the logs at the end of training. This allows users to quickly inspect timing quality without needing to load the checkpoint file.

**Logging and user experience improvements:**

* Added a summary log at the end of training that reports the number of epochs, mean, minimum, and maximum epoch durations, making it easier to assess training timing directly from logs. For short runs (≤12 epochs), the per-epoch times are also listed. (`src/autocast/scripts/training.py`)
* Updated documentation to describe the new timing summary log output, clarifying that users can inspect timing quality without loading the checkpoint. (`docs/SCRIPTS_AND_CONFIGS.md`)