### PR TITLE
Add encode_once eval mode and auto dispatcher

### DIFF
--- a/src/autocast/configs/eval/README.md
+++ b/src/autocast/configs/eval/README.md
@@ -44,9 +44,11 @@ python -m autocast.scripts.eval.encoder_processor_decoder \
 All eval configs support these parameters:
 
 - `checkpoint`: Path to model checkpoint (required for evaluation)
-- `mode`: Evaluation regime (`auto` | `ambient` | `latent`). Controls the
-  **rollout space**, not just the metrics space. See
-  [Ambient vs latent rollout](#ambient-vs-latent-rollout) below.
+- `mode`: Evaluation regime (`auto` (default) | `encode_once` | `ambient` |
+  `latent`). Controls the **rollout space**, not just the metrics space.
+  `auto` dispatches to a concrete mode at run time based on the checkpoint
+  and datamodule, so omitting the flag gives the fair default for every
+  run. See [Evaluation modes](#evaluation-modes) below.
 - `metrics`: List of metrics to compute (default includes mse/mae/rmse/vrmse,
   power spectrum scores `psrmse*`, cross-correlation spectrum scores `pscc*`,
   and ensemble scores `crps`, `fcrps`, `afcrps`, `energy`, `ssr`; `variogram`
@@ -83,50 +85,94 @@ process so Fabric DDP initialises automatically — no extra flags needed.
 - `max_rollout_steps`: Maximum number of rollout steps
 - `free_running_only`: Whether to disable teacher forcing
 
-## Ambient vs latent rollout
+## Evaluation modes
 
-Processor checkpoints trained on cached latents can be evaluated in two
-qualitatively different regimes. The `eval.mode` knob makes the choice
-explicit and surfaces clear errors when the rest of the config is
-inconsistent with the request.
+The `eval.mode` knob controls the **rollout space** and what the metrics
+compare against. The three concrete modes give the same answer on single-
+step (windowed test) metrics; they only diverge during free-running
+rollout. `auto` is a dispatcher that picks one of the concrete modes at
+run time.
 
-- `eval.mode=auto` (default) preserves historical behavior: the script picks
-  a path based on `(checkpoint type, datamodule batch type,
-  autoencoder_checkpoint)`.
-- `eval.mode=ambient` forces full `encoder -> processor -> decoder` rollout.
-  Each rollout step decodes to ambient fields and re-encodes on the next
-  step, so decode/encode drift is included in the metrics. **This is the
-  apples-to-apples regime for comparing against baselines that natively roll
-  out in data space (e.g. a CRPS comparison against a non-autoencoder
-  model).** Requires `autoencoder_checkpoint=<ae.ckpt>` and a raw-Batch
-  datamodule. When the current datamodule yields `EncodedBatch` (cached
-  latents), eval auto-substitutes the datamodule from
-  `<cache_dir>/autoencoder_config.yaml` saved by `autocast cache-latents`.
-  Pass `datamodule=...` explicitly to override the default.
-- `eval.mode=latent` forces latent-space rollout: the processor's predicted
-  latent is fed back as the next latent input; the encoder is invoked only
-  once. Metrics are decoded to data space via the decoder saved alongside
-  the cached latents when available, otherwise they are reported in latent
-  space. Requires an `EncodedBatch` / cached-latents datamodule.
+| mode          | encoder runs        | processor rolls out in | decoder runs | ground truth used                          | when to use                                                                                                        |
+| ------------- | ------------------- | ---------------------- | ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `encode_once` | **once** (step 0)   | latent space           | per step     | raw `batch.output_fields` (denormalized)   | fair processor-only eval that avoids decode/encode drift but still scores against real ground truth.               |
+| `ambient`     | per rollout step    | data space (re-encoded each step) | per step     | raw `batch.output_fields` (denormalized)   | apples-to-apples comparisons with pure-ambient baselines (e.g. CRPS vs. a non-autoencoder model).                  |
+| `latent`      | once (step 0)       | latent space           | only for metrics (or not at all) | **decoded cached latents** (autoencoder reconstruction of ground truth) | measure the processor against what the autoencoder sees -- isolates processor error but hides AE reconstruction error. |
 
-### Running the ambient ablation
+### `auto` (default)
+
+`eval.mode=auto` dispatches to the faithful concrete mode for the current
+run:
+
+- **Full EPD checkpoints** (including processor runs with stateless
+  encoder/decoder baked in, e.g. `permute_concat` + `identity`) -> `ambient`.
+  `encode_once` and `ambient` are numerically identical here; `auto`
+  picks `ambient` to keep logs quiet. Passing `eval.mode=encode_once`
+  explicitly on such a run still works but emits a warning.
+- **Processor trained on cached latents + autoencoder available**
+  (either via `autoencoder_checkpoint=<ae.ckpt>` or via
+  `<cache_dir>/autoencoder_config.yaml`) -> `encode_once`. Strictly fairer
+  than `ambient` (no drift penalty) **and** than `latent` (AE
+  reconstruction error is visible against raw ground truth).
+- **Processor trained on cached latents, autoencoder not reachable**
+  -> `latent`. The only faithful option when you can decode but not
+  re-encode.
+
+The resolved mode is logged at INFO as `eval.mode=auto resolved to <X>`.
+
+### Explicit modes
+
+#### Ambient: apples-to-apples with pure-ambient baselines
+
+`eval.mode=ambient` forces full `encoder -> processor -> decoder` at every
+rollout step. The decoded field is re-encoded as the next step's input, so
+autoencoder decode/encode drift compounds into the metrics. This is the
+right regime when the baseline model operates natively in data space and you
+want to charge the autoencoder for any error it introduces. Requires
+`autoencoder_checkpoint=<ae.ckpt>` and a raw-Batch datamodule. When the
+current datamodule yields `EncodedBatch` (cached latents), eval
+auto-substitutes the datamodule from `<cache_dir>/autoencoder_config.yaml`
+saved by `autocast cache-latents` (pass `datamodule=...` explicitly to
+override).
+
+#### Latent: measure the processor against the AE's view of the world
+
+`eval.mode=latent` forces latent-space rollout: the processor's predicted
+latent is fed back as the next latent input and the encoder is never
+invoked past step 0. Metrics are decoded to data space via the decoder
+saved alongside the cached latents when available, otherwise reported in
+latent space, and **compared against decoded cached latents** -- i.e. an
+autoencoder reconstruction of ground truth, not the raw fields. Use this
+when you want to isolate the processor's rollout quality in its own
+training distribution and explicitly accept that AE reconstruction error is
+hidden from the metric.
+
+### Running the ablations
 
 Given an autoencoder checkpoint and a processor checkpoint trained on its
-cached latents, a minimal invocation is:
+cached latents:
 
 ```bash
-# Ambient (encoder -> processor -> decoder at every rollout step)
+# Default: auto -> encode_once here (fair processor-only eval, raw ground truth).
+autocast eval --workdir <processor_workdir> \
+  eval.checkpoint=<processor.ckpt> \
+  autoencoder_checkpoint=<autoencoder.ckpt>
+
+# Apples-to-apples with pure-ambient baselines (charges AE drift).
 autocast eval --workdir <processor_workdir> \
   eval.mode=ambient \
   eval.checkpoint=<processor.ckpt> \
   autoencoder_checkpoint=<autoencoder.ckpt>
 
-# Latent (processor rollout stays in latent space; decoded only for metrics)
+# Processor-only latent view; no raw ground truth, hides AE reconstruction error.
 autocast eval --workdir <processor_workdir> \
   eval.mode=latent \
   eval.checkpoint=<processor.ckpt>
 ```
 
-The ambient run will differ from the latent run by exactly the
-decode/encode drift accumulated over rollout steps, which is the relevant
-delta when comparing against purely-ambient baselines.
+The three runs differ on rollout metrics as follows:
+
+- `ambient - encode_once` = decode/encode drift accumulated over rollout
+  steps (charged to the autoencoder).
+- `encode_once - latent` = visibility of AE reconstruction error against the
+  raw field (absent from `latent`, included in `encode_once`).

--- a/src/autocast/configs/eval/README.md
+++ b/src/autocast/configs/eval/README.md
@@ -97,7 +97,7 @@ run time.
 | ------------- | ------------------- | ---------------------- | ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
 | `encode_once` | **once** (step 0)   | latent space           | per step     | raw `batch.output_fields` (denormalized)   | fair processor-only eval that avoids decode/encode drift but still scores against real ground truth.               |
 | `ambient`     | per rollout step    | data space (re-encoded each step) | per step     | raw `batch.output_fields` (denormalized)   | apples-to-apples comparisons with pure-ambient baselines (e.g. CRPS vs. a non-autoencoder model).                  |
-| `latent`      | once (step 0)       | latent space           | only for metrics (or not at all) | **decoded cached latents** (autoencoder reconstruction of ground truth) | measure the processor against what the autoencoder sees -- isolates processor error but hides AE reconstruction error. |
+| `latent`      | once (step 0)       | latent space           | only for metrics (or skipped via `latent_space_metrics=true`) | **decoded cached latents** (autoencoder reconstruction of ground truth) | measure the processor against what the autoencoder sees -- isolates processor error but hides AE reconstruction error. |
 
 ### `auto` (default)
 
@@ -116,7 +116,10 @@ run:
   reconstruction error is visible against raw ground truth).
 - **Processor trained on cached latents, autoencoder not reachable**
   -> `latent`. The only faithful option when you can decode but not
-  re-encode.
+  re-encode. If no decoder can be built either, `auto` does not silently
+  fall through to latent-only metrics -- it fails fast so you either fix
+  the autoencoder path or opt in explicitly via
+  `eval.mode=latent eval.latent_space_metrics=true`.
 
 The resolved mode is logged at INFO as `eval.mode=auto resolved to <X>`.
 
@@ -140,12 +143,37 @@ override).
 `eval.mode=latent` forces latent-space rollout: the processor's predicted
 latent is fed back as the next latent input and the encoder is never
 invoked past step 0. Metrics are decoded to data space via the decoder
-saved alongside the cached latents when available, otherwise reported in
-latent space, and **compared against decoded cached latents** -- i.e. an
-autoencoder reconstruction of ground truth, not the raw fields. Use this
-when you want to isolate the processor's rollout quality in its own
-training distribution and explicitly accept that AE reconstruction error is
-hidden from the metric.
+saved alongside the cached latents and **compared against decoded cached
+latents** -- i.e. an autoencoder reconstruction of ground truth, not the
+raw fields. Use this when you want to isolate the processor's rollout
+quality in its own training distribution and explicitly accept that AE
+reconstruction error is hidden from the metric.
+
+A reachable decoder is required; if the cache directory's
+`autoencoder_config.yaml` or checkpoint is missing the run fails fast
+rather than silently falling back to computing metrics in raw latent
+space (those numbers were never comparable across runs).
+
+##### Dev sense-check: latent-only metrics
+
+Sometimes you want to iterate on a small processor paired with a large /
+expensive autoencoder and skip the decoder entirely. Pass
+`eval.mode=latent eval.latent_space_metrics=true` to opt in:
+
+```bash
+autocast eval --workdir <processor_workdir> \
+  eval.mode=latent \
+  eval.latent_space_metrics=true \
+  eval.checkpoint=<processor.ckpt>
+```
+
+This skips the decoder lookup and compares processor predictions against
+cached latents directly in the autoencoder's raw latent space. Treat the
+numbers as a cheap sanity check only: they are **not comparable across
+runs** (latent space is basis-dependent) and physics-aware metrics
+(`psrmse*`, `pscc*`, `variogram`) are not meaningful. The flag is
+rejected for any other `eval.mode` because the raw-space modes (`auto`,
+`ambient`, `encode_once`) require a decoder by definition.
 
 ### Running the ablations
 

--- a/src/autocast/configs/eval/default.yaml
+++ b/src/autocast/configs/eval/default.yaml
@@ -2,62 +2,16 @@
 # Path to checkpoint for evaluation (required for eval)
 checkpoint: null
 
-# Evaluation mode selector (controls rollout space, not just metrics space).
-#
-#   auto         (default) Dispatch to a concrete mode based on the
-#                checkpoint + datamodule + autoencoder availability so that
-#                every run gets a fair eval without extra flags:
-#                  - full EPD (or stateless encoder/decoder baked into a
-#                    processor run)                -> ambient
-#                  - processor-only + autoencoder  -> encode_once
-#                  - processor-only + cached latents, no AE -> latent
-#                The chosen mode is logged at INFO. Prefer this for most
-#                runs; use an explicit mode only to force a specific
-#                rollout regime or to compare runs under identical
-#                semantics.
-#   encode_once  Encoder runs once on raw inputs, processor rolls out in
-#                latent space, decoder runs per step; metrics are computed
-#                against the raw denormalized ground-truth fields. Isolates
-#                processor error from autoencoder decode/encode drift
-#                while still scoring against real ground truth. On full
-#                EPD / stateless-AE runs this aliases to `ambient` and
-#                emits a warning (there is no separate latent rollout to
-#                isolate). Requires `autoencoder_checkpoint=<ae.ckpt>` when
-#                the processor was trained on cached latents; in that case
-#                the cached-latent datamodule is auto-swapped for the raw
-#                datamodule from `<cache_dir>/autoencoder_config.yaml`.
-#   ambient      Force full encoder -> processor -> decoder rollout at every
-#                step. Each step decodes and re-encodes, so autoencoder
-#                decode/encode drift is charged to the metrics -- this is
-#                the apples-to-apples regime for comparing against models
-#                that natively roll out in ambient/data space (e.g. pure-
-#                ambient CRPS baselines). Same datamodule-swap behavior as
-#                `encode_once` when starting from cached latents.
-#   latent       Force latent-space rollout (processor predictions are fed
-#                back as latents; encoder is never invoked). Metrics are
-#                decoded to data space via the decoder saved alongside the
-#                cached latents. Requires an EncodedBatch datamodule
-#                (cached latents) and intentionally measures against decoded
-#                cached latents (i.e. an autoencoder reconstruction of
-#                ground truth) rather than against raw ground truth.
-#                When no decoder can be built this mode fails fast; set
-#                `eval.latent_space_metrics=true` to opt into computing
-#                metrics directly in latent space as a dev sense-check.
+# Evaluation mode selector; controls rollout space, not just metrics space.
+# Values: auto (default dispatcher) | encode_once | ambient | latent.
+# See `autocast/configs/eval/README.md` for the full comparison and the
+# auto-dispatch rules; the resolved mode is logged at INFO.
 mode: auto
 
-# Opt-in flag for computing evaluation metrics in raw latent space.
-#
-# When true AND `eval.mode=latent`, the decoder step is skipped entirely:
-# predictions and cached-latent targets are compared in the autoencoder's
-# raw latent space. This is intended as a cheap sense-check for iterating
-# on a small processor paired with a large / expensive autoencoder; the
-# resulting numbers are NOT comparable across runs (latent space is basis-
-# dependent) and physics-aware metrics (psrmse*, pscc*, variogram) are not
-# meaningful there.
-#
-# Rejected for `eval.mode` in (auto, ambient, encode_once) because those
-# modes require a decoder to produce raw-space predictions by definition.
-# Leave this as `false` for any results you plan to publish or compare.
+# Dev sense-check: compute metrics directly in raw latent space. Only
+# honored with an explicit `eval.mode=latent` and skips the decoder
+# entirely. Numbers are not comparable across runs and physics-aware
+# metrics are not meaningful -- leave as `false` for real evals.
 latent_space_metrics: false
 
 # Evaluation metrics to compute

--- a/src/autocast/configs/eval/default.yaml
+++ b/src/autocast/configs/eval/default.yaml
@@ -36,12 +36,29 @@ checkpoint: null
 #   latent       Force latent-space rollout (processor predictions are fed
 #                back as latents; encoder is never invoked). Metrics are
 #                decoded to data space via the decoder saved alongside the
-#                cached latents if available, otherwise computed in latent
-#                space. Requires an EncodedBatch datamodule (cached latents)
-#                and intentionally measures against decoded cached latents
-#                (i.e. an autoencoder reconstruction of ground truth) rather
-#                than against raw ground truth.
+#                cached latents. Requires an EncodedBatch datamodule
+#                (cached latents) and intentionally measures against decoded
+#                cached latents (i.e. an autoencoder reconstruction of
+#                ground truth) rather than against raw ground truth.
+#                When no decoder can be built this mode fails fast; set
+#                `eval.latent_space_metrics=true` to opt into computing
+#                metrics directly in latent space as a dev sense-check.
 mode: auto
+
+# Opt-in flag for computing evaluation metrics in raw latent space.
+#
+# When true AND `eval.mode=latent`, the decoder step is skipped entirely:
+# predictions and cached-latent targets are compared in the autoencoder's
+# raw latent space. This is intended as a cheap sense-check for iterating
+# on a small processor paired with a large / expensive autoencoder; the
+# resulting numbers are NOT comparable across runs (latent space is basis-
+# dependent) and physics-aware metrics (psrmse*, pscc*, variogram) are not
+# meaningful there.
+#
+# Rejected for `eval.mode` in (auto, ambient, encode_once) because those
+# modes require a decoder to produce raw-space predictions by definition.
+# Leave this as `false` for any results you plan to publish or compare.
+latent_space_metrics: false
 
 # Evaluation metrics to compute
 metrics:

--- a/src/autocast/configs/eval/default.yaml
+++ b/src/autocast/configs/eval/default.yaml
@@ -4,22 +4,43 @@ checkpoint: null
 
 # Evaluation mode selector (controls rollout space, not just metrics space).
 #
-#   auto     (default) infer from checkpoint type + batch type + autoencoder_checkpoint.
-#            Preserves historical behavior.
-#   ambient  Force full encoder -> processor -> decoder rollout. Each rollout step
-#            decodes and re-encodes, so decode/encode drift is included in the
-#            metrics -- this is the apples-to-apples regime for comparing against
-#            models that natively roll out in ambient/data space (e.g. CRPS baselines).
-#            Requires `autoencoder_checkpoint=<ae.ckpt>` and a raw-Batch datamodule.
-#            When the datamodule yields EncodedBatch (cached latents), the eval
-#            script auto-substitutes the datamodule from
-#            `<cache_dir>/autoencoder_config.yaml` written by `autocast cache-latents`.
-#            Pass `datamodule=...` explicitly to override that default.
-#   latent   Force latent-space rollout (processor predictions are fed back as
-#            latents; encoder is not re-invoked). Metrics are decoded to data
-#            space via the decoder saved alongside the cached latents if
-#            available, otherwise computed in latent space. Requires an
-#            EncodedBatch datamodule (cached latents).
+#   auto         (default) Dispatch to a concrete mode based on the
+#                checkpoint + datamodule + autoencoder availability so that
+#                every run gets a fair eval without extra flags:
+#                  - full EPD (or stateless encoder/decoder baked into a
+#                    processor run)                -> ambient
+#                  - processor-only + autoencoder  -> encode_once
+#                  - processor-only + cached latents, no AE -> latent
+#                The chosen mode is logged at INFO. Prefer this for most
+#                runs; use an explicit mode only to force a specific
+#                rollout regime or to compare runs under identical
+#                semantics.
+#   encode_once  Encoder runs once on raw inputs, processor rolls out in
+#                latent space, decoder runs per step; metrics are computed
+#                against the raw denormalized ground-truth fields. Isolates
+#                processor error from autoencoder decode/encode drift
+#                while still scoring against real ground truth. On full
+#                EPD / stateless-AE runs this aliases to `ambient` and
+#                emits a warning (there is no separate latent rollout to
+#                isolate). Requires `autoencoder_checkpoint=<ae.ckpt>` when
+#                the processor was trained on cached latents; in that case
+#                the cached-latent datamodule is auto-swapped for the raw
+#                datamodule from `<cache_dir>/autoencoder_config.yaml`.
+#   ambient      Force full encoder -> processor -> decoder rollout at every
+#                step. Each step decodes and re-encodes, so autoencoder
+#                decode/encode drift is charged to the metrics -- this is
+#                the apples-to-apples regime for comparing against models
+#                that natively roll out in ambient/data space (e.g. pure-
+#                ambient CRPS baselines). Same datamodule-swap behavior as
+#                `encode_once` when starting from cached latents.
+#   latent       Force latent-space rollout (processor predictions are fed
+#                back as latents; encoder is never invoked). Metrics are
+#                decoded to data space via the decoder saved alongside the
+#                cached latents if available, otherwise computed in latent
+#                space. Requires an EncodedBatch datamodule (cached latents)
+#                and intentionally measures against decoded cached latents
+#                (i.e. an autoencoder reconstruction of ground truth) rather
+#                than against raw ground truth.
 mode: auto
 
 # Evaluation metrics to compute

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -140,19 +140,16 @@ MEMORY_INTENSIVE_METRICS = {"variogram"}
 
 EVAL_MODES = ("auto", "encode_once", "ambient", "latent")
 DEFAULT_EVAL_MODE = "auto"
-# Concrete modes `auto` can resolve to. `auto` is a dispatcher, never a path.
-RESOLVABLE_EVAL_MODES = ("encode_once", "ambient", "latent")
 
 # Resolved eval paths exposed for validation / testing. Each corresponds to
 # exactly one branch in `run_evaluation`'s model-selection / rollout block.
-EVAL_PATH_AMBIENT_EPD = "ambient_epd"  # full EPD checkpoint or processor+AE (ambient)
-EVAL_PATH_ENCODE_ONCE = "encode_once"  # processor+AE, latent rollout, raw truth
-EVAL_PATH_LATENT_CACHED_WITH_DECODER = "latent_cached_with_decoder"  # latent+decoder
-# Dev sense-check path: metrics computed directly in the autoencoder's raw
-# latent space. Only reachable via an explicit opt-in
-# (``eval.latent_space_metrics=true`` combined with ``eval.mode=latent``);
-# see ``_validate_latent_space_metrics`` below.
-EVAL_PATH_LATENT_CACHED_LATENT_ONLY = "latent_cached_latent_only"  # latent-only
+# See `configs/eval/README.md` for the user-facing mode semantics.
+EVAL_PATH_AMBIENT_EPD = "ambient_epd"
+EVAL_PATH_ENCODE_ONCE = "encode_once"
+EVAL_PATH_LATENT_CACHED_WITH_DECODER = "latent_cached_with_decoder"
+# Opt-in dev sense check: metrics in raw latent space. Only reachable when
+# `eval.mode=latent` is paired with `eval.latent_space_metrics=true`.
+EVAL_PATH_LATENT_CACHED_LATENT_ONLY = "latent_cached_latent_only"
 
 
 def _decode_tensor(
@@ -227,17 +224,12 @@ def _build_encode_once_rollout_predict(
 ) -> Callable[[Any], tuple[torch.Tensor, torch.Tensor | None]]:
     """Build a rollout closure that encodes once and compares against raw truth.
 
-    The loop is: raw ``Batch`` in -> encoder runs **once** -> processor rolls
-    out in latent space (reusing the standard ``ProcessorModel.rollout``
-    machinery so teacher-forcing / stride semantics stay identical to native
-    processor training) -> decoder runs per step to map predictions back to
-    data space -> metrics are computed against the raw denormalized
-    ``batch.output_fields``.
-
-    This isolates processor error from autoencoder decode/encode drift while
-    still scoring against real (not autoencoder-reconstructed) ground truth.
-    For full EPD checkpoints this path is not selected; see
-    ``_resolve_eval_path`` for the dispatch.
+    Encoder runs once on the raw ``Batch``, the processor rolls out in latent
+    space via ``ProcessorModel.rollout`` (keeping teacher-forcing / stride
+    semantics identical to native processor training), then the decoder maps
+    each predicted latent back to data space for metrics against denormalized
+    ``batch.output_fields``. Not used for full EPD checkpoints; see
+    ``_resolve_eval_path``.
     """
     underlying = _unwrap_module(model)
     encoder_decoder = underlying.encoder_decoder
@@ -1244,23 +1236,11 @@ def _maybe_inject_encoder_decoder_from_autoencoder_checkpoint(
 
 
 def _normalize_eval_mode(mode: Any) -> str:
-    """Normalize and validate the eval.mode config value.
+    """Normalize and validate ``eval.mode``.
 
-    ``eval.mode`` defaults to ``auto``, which picks a concrete mode from
-    ``(processor_only, example_batch, autoencoder_checkpoint)`` at run time:
-
-    * Full EPD checkpoints (or processor runs with a stateless encoder/
-      decoder baked in) -> ``ambient``. There is no separate latent rollout
-      to isolate for these runs, so ambient is the faithful choice.
-    * Processor-only + autoencoder reachable -> ``encode_once``. Isolates
-      processor error from autoencoder drift while still scoring against
-      raw ground truth.
-    * Processor-only + cached latents without autoencoder -> ``latent``.
-      Only faithful option when we cannot re-encode.
-
-    Passing an explicit mode (``encode_once`` / ``ambient`` / ``latent``)
-    disables this dispatch and asserts the resolved eval path matches. See
-    ``autocast/configs/eval/README.md`` for the full mode comparison.
+    Accepts ``auto`` (default dispatcher) or one of the concrete modes
+    ``encode_once`` / ``ambient`` / ``latent``; see
+    ``configs/eval/README.md`` for the semantics.
     """
     if mode is None:
         return DEFAULT_EVAL_MODE
@@ -1279,31 +1259,18 @@ def _resolve_auto_eval_mode(
 ) -> str:
     """Map ``eval.mode=auto`` to a concrete mode for the current run.
 
-    This is called once, early in ``run_evaluation``, before the datamodule
-    swap. The decision uses the pre-swap state only: after this function
-    returns, the rest of the pipeline sees a concrete mode.
+    Called once, early in ``run_evaluation`` before the datamodule swap; the
+    rest of the pipeline then sees a concrete mode. Full EPD checkpoints
+    resolve to ``ambient`` (encode_once and ambient are numerically
+    identical there). Processor-only runs prefer ``encode_once`` whenever
+    an autoencoder checkpoint is reachable, otherwise ``latent``. A run
+    that resolves to ``latent`` without a reachable decoder fails fast
+    downstream; see ``_require_decoder_unless_latent_metrics_opt_in``.
     """
     if not processor_only:
-        # Full EPD (or stateless AE baked into the processor). Encode_once and
-        # ambient are numerically identical here -- prefer ambient to skip the
-        # encode_once-on-ambient-run warning.
         return "ambient"
-    if isinstance(example_batch, Batch) and has_autoencoder_checkpoint:
+    if has_autoencoder_checkpoint and isinstance(example_batch, (Batch, EncodedBatch)):
         return "encode_once"
-    if isinstance(example_batch, EncodedBatch):
-        # Processor trained on cached latents. Use encode_once when the
-        # autoencoder checkpoint is available so we score against raw
-        # ground truth; otherwise fall back to latent. If no decoder can
-        # then be built from the cached-latents directory the run will
-        # fail fast downstream (see
-        # ``_require_decoder_unless_latent_metrics_opt_in``); the user can
-        # pin ``eval.mode=latent eval.latent_space_metrics=true`` to
-        # opt into a latent-only sense check.
-        if has_autoencoder_checkpoint:
-            return "encode_once"
-        return "latent"
-    # Processor-only + raw Batch + no AE ckpt: unusual; defer to latent,
-    # which will raise a descriptive error downstream if it is inconsistent.
     return "latent"
 
 
@@ -1313,22 +1280,15 @@ def _maybe_swap_to_ambient_datamodule(
     eval_mode: str,
     example_batch: Any,
 ) -> DictConfig:
-    """Substitute the raw-data datamodule from `autoencoder_config.yaml`.
+    """Substitute the raw-data datamodule from ``autoencoder_config.yaml``.
 
-    Both ``eval.mode=ambient`` and ``eval.mode=encode_once`` feed raw fields
-    into the encoder; they cannot consume ``EncodedBatch`` (cached latents)
-    directly.  When the current datamodule yields cached latents we read the
-    ``autoencoder_config.yaml`` written next to those latents by
-    ``autocast cache-latents`` and overwrite ``cfg.datamodule`` with the
-    datamodule the autoencoder was trained on, which guarantees matching
-    normalization and field layout.
-
-    ``eval.mode=latent`` stays on the cached-latents datamodule (the encoder
-    is never invoked), so this helper is a no-op for that mode.
-
-    Returns the (possibly-modified) ``cfg`` in-place. Raises a descriptive
-    error when the swap is needed but ``autoencoder_config.yaml`` is absent;
-    callers should pass ``datamodule=...`` explicitly in that case.
+    ``ambient`` and ``encode_once`` need the encoder on raw fields, so when
+    the current datamodule yields ``EncodedBatch`` we overwrite
+    ``cfg.datamodule`` with the autoencoder's training datamodule read from
+    ``<cache_dir>/autoencoder_config.yaml``. No-op for ``eval.mode=latent``
+    (the encoder is never invoked) and for raw-Batch datamodules. Raises if
+    the swap is needed but the config is absent; pass ``datamodule=...``
+    explicitly in that case.
     """
     needs_raw = eval_mode in ("ambient", "encode_once")
     if not needs_raw or not isinstance(example_batch, EncodedBatch):
@@ -1403,20 +1363,12 @@ def _resolve_eval_path(
 ) -> str:
     """Map the (eval.mode, checkpoint, datamodule) combination to a code path.
 
-    Full EPD checkpoints always resolve to ``ambient_epd`` -- there is no
-    separate latent-rollout path for them because the encoder is part of the
-    model.  Callers should emit a warning when ``eval.mode=encode_once`` is
-    aliased to ``ambient_epd`` in this way so the user knows the two are
-    numerically identical for that checkpoint type.
-
-    Processor-only checkpoints with an autoencoder available (``has_ae`` and
-    raw ``Batch`` datamodule) can run either of two closely-related paths:
-    ``ambient_epd`` (re-encode every step) or ``encode_once`` (encode once,
-    stay in latent, decode at the end, compare against raw ground truth).
-    The ``eval_mode`` argument selects between them.
-
-    Processor-only checkpoints on cached latents fall back to the latent-
-    space paths (with or without a decoder) as before.
+    Full EPD checkpoints always resolve to ``ambient_epd`` (there is no
+    separate latent-rollout path). For processor-only + autoencoder + raw
+    ``Batch``, ``eval_mode`` selects between ``ambient_epd`` (re-encode
+    every step) and ``encode_once`` (encode once, decode per step, compare
+    against raw truth). Processor-only + cached latents routes to the
+    latent paths.
     """
     if not processor_only:
         return EVAL_PATH_AMBIENT_EPD
@@ -1458,13 +1410,10 @@ def _validate_resolved_eval_path(*, eval_mode: str, resolved_path: str) -> None:
         EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
     ):
         msg = (
-            "eval.mode=encode_once but the resolved eval path is "
-            f"{resolved_path!r}. encode_once needs the encoder *and* decoder "
-            "reachable so it can compare decoded rollouts against raw ground "
-            "truth. Either pass autoencoder_checkpoint=<ae.ckpt> (the encoder "
-            "will run once on raw inputs), or switch to eval.mode=latent if "
-            "you want to measure the processor against decoded cached "
-            "latents rather than against raw ground truth."
+            f"eval.mode=encode_once but the resolved eval path is "
+            f"{resolved_path!r}. encode_once needs both encoder and decoder "
+            "to score decoded rollouts against raw ground truth. Pass "
+            "autoencoder_checkpoint=<ae.ckpt> or switch to eval.mode=latent."
         )
         raise ValueError(msg)
 
@@ -1474,25 +1423,16 @@ def _validate_latent_space_metrics_flag(
     requested_eval_mode: str,
     latent_space_metrics: bool,
 ) -> None:
-    """Reject ``eval.latent_space_metrics=true`` when it cannot apply.
+    """Reject ``latent_space_metrics=true`` unless ``eval.mode=latent``.
 
-    The flag only makes sense paired with an explicit ``eval.mode=latent``;
-    every other mode is defined to score against raw (data-space) ground
-    truth and so fundamentally requires a working decoder. ``auto`` is
-    rejected as well because the dispatch decision is made per-run and the
-    flag would silently change metric semantics depending on which concrete
-    mode ``auto`` happens to pick.
+    Other modes (including ``auto``) are defined to score against raw
+    ground truth and require a decoder by construction.
     """
-    if not latent_space_metrics:
-        return
-    if requested_eval_mode != "latent":
+    if latent_space_metrics and requested_eval_mode != "latent":
         msg = (
-            "eval.latent_space_metrics=true is only valid with an explicit "
-            f"eval.mode=latent, but eval.mode={requested_eval_mode!r} was "
-            "requested. Raw-space modes (auto / ambient / encode_once) "
-            "require a decoder by definition. Either drop "
-            "latent_space_metrics, or pin eval.mode=latent to opt in to "
-            "latent-only metrics as a development sense check."
+            "eval.latent_space_metrics=true requires an explicit "
+            f"eval.mode=latent (got {requested_eval_mode!r}). Raw-space "
+            "modes need a decoder by definition."
         )
         raise ValueError(msg)
 
@@ -1502,38 +1442,22 @@ def _require_decoder_unless_latent_metrics_opt_in(
     resolved_path: str,
     latent_space_metrics: bool,
 ) -> None:
-    """Fail fast when the resolved path has no decoder and the opt-in is off.
-
-    Previously ``eval.mode=latent`` would silently fall back to computing
-    metrics directly in raw latent space whenever no decoder could be
-    built. That produced numbers that look like evaluation results but are
-    not comparable across runs, so we now require the user to opt in via
-    ``eval.latent_space_metrics=true`` before taking that branch.
-    """
+    """Fail fast when the resolved path has no decoder and the opt-in is off."""
     if resolved_path != EVAL_PATH_LATENT_CACHED_LATENT_ONLY:
         return
     if latent_space_metrics:
         log.warning(
-            "eval.latent_space_metrics=true: computing metrics in the "
-            "autoencoder's raw latent space because no decoder could be "
-            "built from the cached-latents directory. These numbers are a "
-            "development sense check only -- they are not comparable "
-            "across runs (latent space is basis-dependent) and physics-"
-            "aware metrics (psrmse*, pscc*, variogram) are not meaningful "
-            "here. Provide a reachable decoder and set "
-            "latent_space_metrics=false (default) for publishable results."
+            "eval.latent_space_metrics=true: metrics computed in raw latent "
+            "space. Dev sense check only -- not comparable across runs and "
+            "physics-aware metrics (psrmse*, pscc*, variogram) are not "
+            "meaningful. Provide a reachable decoder for publishable results."
         )
         return
     msg = (
-        "eval.mode=latent could not build a decoder from the cached-"
-        "latents directory, so metrics would be computed directly in the "
-        "autoencoder's raw latent space. That fallback used to be silent "
-        "but produces numbers that are not comparable across runs, so it "
-        "now requires an explicit opt-in. Either:\n"
-        "  * make the decoder reachable (ensure autoencoder_config.yaml "
-        "and the AE checkpoint are present in the cache directory), or\n"
-        "  * pass eval.latent_space_metrics=true to confirm you want a "
-        "latent-only dev sense check."
+        "eval.mode=latent could not build a decoder from the cached-latents "
+        "directory. Either ensure autoencoder_config.yaml + AE checkpoint "
+        "are present, or pass eval.latent_space_metrics=true to opt into a "
+        "dev sense check."
     )
     raise RuntimeError(msg)
 
@@ -1695,13 +1619,10 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     # Setup datamodule and resolve config
     datamodule, cfg, stats = setup_datamodule(cfg)
 
-    # If the user asked for ambient eval but the resolved datamodule yields
-    # EncodedBatch (cached_latents), substitute the raw-data datamodule stored
-    # in the cache dir's autoencoder_config.yaml and rebuild. Honors an
-    # explicit `datamodule=...` override implicitly: when the override targets
-    # a raw-Batch datamodule the swap becomes a no-op.
-    # Resolve `auto` to a concrete mode now that we know the checkpoint type
-    # and datamodule shape. Downstream code sees a concrete mode only.
+    # Resolve `auto` once we know the checkpoint/datamodule shape, then
+    # swap to the autoencoder's raw-data datamodule if ambient/encode_once
+    # is about to run on cached-latent inputs (explicit `datamodule=...`
+    # overrides are honored implicitly: the swap is a no-op for raw Batch).
     if eval_mode == "auto":
         eval_mode = _resolve_auto_eval_mode(
             processor_only=processor_only,
@@ -1728,43 +1649,13 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
             "Overriding model.n_members with %s from eval config", eval_cfg.n_members
         )
 
-    # Setup model and weights based on checkpoint type and datamodule.
-    #
-    # Mode 1 - full EPD from two checkpoints (ambient or encode_once):
-    #   Triggered when the processor ckpt is processor-only AND the config
-    #   contains `autoencoder_checkpoint` AND the datamodule yields raw Batch
-    #   objects (i.e. not cached latents).  The encoder+decoder are loaded from
-    #   `autoencoder_checkpoint`; only the processor weights come from the
-    #   processor checkpoint.  Typical invocation:
-    #     autocast eval --workdir <ae_workdir> eval.checkpoint=<processor.ckpt>
-    #   The rollout closure then branches on `eval.mode`:
-    #     * ambient      -> encoder->processor->decoder at every step (drift
-    #                       is charged to the metrics; directly comparable to
-    #                       pure-ambient baselines).
-    #     * encode_once  -> encoder runs once; processor rolls out in latent
-    #                       space; decoder runs per step for metrics; ground
-    #                       truth is raw denormalized `batch.output_fields`.
-    #                       This is the default: it isolates processor error
-    #                       from autoencoder drift while still scoring against
-    #                       real ground truth.
-    #
-    # Mode 2 - latent-space eval via processor + decoder (cached latents):
-    #   Triggered when the processor ckpt is processor-only AND the datamodule
-    #   yields EncodedBatch objects (cached latents).  The processor is loaded
-    #   from the processor ckpt; the decoder is loaded from `autoencoder_config.yaml`
-    #   saved in the cache directory by `autocast cache-latents`.
-    #   Predictions and ground-truth latents are both decoded before metrics.
-    #   Requires `eval.mode=latent` (encode_once is rejected for this path
-    #   because it can never see raw ground truth here).
-    #
-    # Dev sense-check - latent-only metrics (opt-in):
-    #   `eval.mode=latent` + `eval.latent_space_metrics=true`.  Skips the
-    #   decoder entirely and compares processor predictions against cached
-    #   latents directly in the autoencoder's raw latent space. Intended as a
-    #   cheap check for small processors paired with expensive autoencoders;
-    #   results are not comparable across runs and physics-aware metrics are
-    #   not meaningful.  Any other combination (no decoder + flag off) is now
-    #   rejected by `_require_decoder_unless_latent_metrics_opt_in`.
+    # Setup model and weights. The eval path was resolved above; see the
+    # EVAL_PATH_* constants and `configs/eval/README.md` for the full
+    # matrix. Briefly:
+    #   * ambient_epd     -- full EPD (ambient) or processor+AE reconstructed.
+    #   * encode_once     -- processor+AE, encoder runs once, decode per step.
+    #   * latent_cached_* -- processor-only on cached latents; with decoder
+    #                        (data-space metrics) or opt-in latent-only.
 
     example_batch = stats.get("example_batch")
 
@@ -1812,24 +1703,15 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
             )
             if isinstance(example_batch, EncodedBatch):
                 if latent_space_metrics:
-                    log.info(
-                        "Mode 2 eval: processor (cached latents) + "
-                        "latent_space_metrics=true → skipping decoder lookup."
-                    )
+                    log.info("latent_space_metrics=true: skipping decoder.")
                 else:
-                    # Mode 2: try to load decoder for data-space evaluation
                     decoder_module, decode_fn = _try_build_decode_fn(cfg)
                     if decode_fn is not None:
-                        log.info(
-                            "Mode 2 eval: processor (cached latents) + "
-                            "decoder → data-space metrics."
-                        )
+                        log.info("Loaded decoder for data-space metrics.")
                     else:
                         log.info(
-                            "Mode 2 eval: no decoder found; "
-                            "_require_decoder_unless_latent_metrics_opt_in "
-                            "will decide whether to fail fast or emit a "
-                            "latent-space dev-sense-check warning."
+                            "No decoder found; fail-fast vs opt-in check "
+                            "runs after path resolution."
                         )
     else:
         model = setup_epd_model(cfg, stats, datamodule=datamodule)
@@ -1866,12 +1748,9 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
         and resolved_eval_path == EVAL_PATH_AMBIENT_EPD
     ):
         log.warning(
-            "eval.mode=encode_once resolved to ambient_epd for this setup "
-            "(full EPD checkpoint, or stateless encoder/decoder baked into "
-            "the processor run). There is no separate latent rollout to "
-            "isolate, so encode_once is numerically identical to "
-            "eval.mode=ambient here. Omit eval.mode (eval.mode=auto) or "
-            "pass eval.mode=ambient explicitly to suppress this warning."
+            "eval.mode=encode_once aliased to ambient for full-EPD / "
+            "stateless-AE runs (no separate latent rollout to isolate); "
+            "use eval.mode=auto or eval.mode=ambient to silence this."
         )
 
     # Get eval parameters from config

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -138,13 +138,17 @@ DEFAULT_EVAL_METRICS = [
 
 MEMORY_INTENSIVE_METRICS = {"variogram"}
 
-EVAL_MODES = ("auto", "ambient", "latent")
+EVAL_MODES = ("auto", "encode_once", "ambient", "latent")
+DEFAULT_EVAL_MODE = "auto"
+# Concrete modes `auto` can resolve to. `auto` is a dispatcher, never a path.
+RESOLVABLE_EVAL_MODES = ("encode_once", "ambient", "latent")
 
 # Resolved eval paths exposed for validation / testing. Each corresponds to
-# exactly one branch in `run_evaluation`'s model-selection block.
-EVAL_PATH_AMBIENT_EPD = "ambient_epd"  # full EPD checkpoint or processor+AE
-EVAL_PATH_LATENT_CACHED_WITH_DECODER = "latent_cached_with_decoder"  # Mode 2
-EVAL_PATH_LATENT_CACHED_LATENT_ONLY = "latent_cached_latent_only"  # fallback
+# exactly one branch in `run_evaluation`'s model-selection / rollout block.
+EVAL_PATH_AMBIENT_EPD = "ambient_epd"  # full EPD checkpoint or processor+AE (ambient)
+EVAL_PATH_ENCODE_ONCE = "encode_once"  # processor+AE, latent rollout, raw truth
+EVAL_PATH_LATENT_CACHED_WITH_DECODER = "latent_cached_with_decoder"  # latent+decoder
+EVAL_PATH_LATENT_CACHED_LATENT_ONLY = "latent_cached_latent_only"  # latent-only
 
 
 def _decode_tensor(
@@ -206,6 +210,76 @@ def _build_eval_predict_fn(
         return predict_fn
 
     return model
+
+
+def _build_encode_once_rollout_predict(
+    model: Any,
+    *,
+    rollout_stride: int,
+    max_rollout_steps: int,
+    free_running_only: bool,
+    n_members: int | None,
+    device: Any,
+) -> Callable[[Any], tuple[torch.Tensor, torch.Tensor | None]]:
+    """Build a rollout closure that encodes once and compares against raw truth.
+
+    The loop is: raw ``Batch`` in -> encoder runs **once** -> processor rolls
+    out in latent space (reusing the standard ``ProcessorModel.rollout``
+    machinery so teacher-forcing / stride semantics stay identical to native
+    processor training) -> decoder runs per step to map predictions back to
+    data space -> metrics are computed against the raw denormalized
+    ``batch.output_fields``.
+
+    This isolates processor error from autoencoder decode/encode drift while
+    still scoring against real (not autoencoder-reconstructed) ground truth.
+    For full EPD checkpoints this path is not selected; see
+    ``_resolve_eval_path`` for the dispatch.
+    """
+    underlying = _unwrap_module(model)
+    encoder_decoder = underlying.encoder_decoder
+    processor = underlying.processor
+
+    if n_members is not None and n_members > 1:
+        processor_wrapper: ProcessorModel = ProcessorModelEnsemble(
+            processor=processor,
+            stride=rollout_stride,
+            norm=None,
+            n_members=n_members,
+        )
+    else:
+        processor_wrapper = ProcessorModel(
+            processor=processor,
+            stride=rollout_stride,
+            norm=None,
+        )
+    processor_wrapper.to(device).eval()
+
+    def _decode_to_raw(x: torch.Tensor) -> torch.Tensor:
+        return underlying.denormalize_tensor(encoder_decoder.decoder.decode(x))
+
+    def rollout_predict_encode_once(
+        batch: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        with torch.no_grad():
+            encoded_batch = encoder_decoder.encoder.encode_batch(batch)
+            preds_latent, _ = processor_wrapper.rollout(
+                encoded_batch,
+                stride=rollout_stride,
+                max_rollout_steps=max_rollout_steps,
+                free_running_only=free_running_only,
+                n_members=n_members if n_members and n_members > 1 else None,
+            )
+            preds = _decode_tensor(
+                preds_latent,
+                _decode_to_raw,
+                n_members=n_members if n_members and n_members > 1 else None,
+            )
+            trues = underlying.denormalize_tensor(batch.output_fields)
+
+        min_len = min(preds.shape[1], trues.shape[1])
+        return preds[:, :min_len], trues[:, :min_len]
+
+    return rollout_predict_encode_once
 
 
 def _resolve_csv_path(eval_cfg: DictConfig, work_dir: Path) -> Path:
@@ -1166,14 +1240,62 @@ def _maybe_inject_encoder_decoder_from_autoencoder_checkpoint(
 
 
 def _normalize_eval_mode(mode: Any) -> str:
-    """Normalize and validate the eval.mode config value."""
+    """Normalize and validate the eval.mode config value.
+
+    ``eval.mode`` defaults to ``auto``, which picks a concrete mode from
+    ``(processor_only, example_batch, autoencoder_checkpoint)`` at run time:
+
+    * Full EPD checkpoints (or processor runs with a stateless encoder/
+      decoder baked in) -> ``ambient``. There is no separate latent rollout
+      to isolate for these runs, so ambient is the faithful choice.
+    * Processor-only + autoencoder reachable -> ``encode_once``. Isolates
+      processor error from autoencoder drift while still scoring against
+      raw ground truth.
+    * Processor-only + cached latents without autoencoder -> ``latent``.
+      Only faithful option when we cannot re-encode.
+
+    Passing an explicit mode (``encode_once`` / ``ambient`` / ``latent``)
+    disables this dispatch and asserts the resolved eval path matches. See
+    ``autocast/configs/eval/README.md`` for the full mode comparison.
+    """
     if mode is None:
-        return "auto"
+        return DEFAULT_EVAL_MODE
     mode_str = str(mode).strip().lower()
     if mode_str not in EVAL_MODES:
         msg = f"Unknown eval.mode={mode!r}. Valid values: {', '.join(EVAL_MODES)}."
         raise ValueError(msg)
     return mode_str
+
+
+def _resolve_auto_eval_mode(
+    *,
+    processor_only: bool,
+    example_batch: Any,
+    has_autoencoder_checkpoint: bool,
+) -> str:
+    """Map ``eval.mode=auto`` to a concrete mode for the current run.
+
+    This is called once, early in ``run_evaluation``, before the datamodule
+    swap. The decision uses the pre-swap state only: after this function
+    returns, the rest of the pipeline sees a concrete mode.
+    """
+    if not processor_only:
+        # Full EPD (or stateless AE baked into the processor). Encode_once and
+        # ambient are numerically identical here -- prefer ambient to skip the
+        # encode_once-on-ambient-run warning.
+        return "ambient"
+    if isinstance(example_batch, Batch) and has_autoencoder_checkpoint:
+        return "encode_once"
+    if isinstance(example_batch, EncodedBatch):
+        # Processor trained on cached latents. Use encode_once when the
+        # autoencoder checkpoint is available so we score against raw
+        # ground truth; otherwise fall back to latent.
+        if has_autoencoder_checkpoint:
+            return "encode_once"
+        return "latent"
+    # Processor-only + raw Batch + no AE ckpt: unusual; defer to latent,
+    # which will raise a descriptive error downstream if it is inconsistent.
+    return "latent"
 
 
 def _maybe_swap_to_ambient_datamodule(
@@ -1184,34 +1306,39 @@ def _maybe_swap_to_ambient_datamodule(
 ) -> DictConfig:
     """Substitute the raw-data datamodule from `autoencoder_config.yaml`.
 
-    When the user requests ``eval.mode=ambient`` but the current datamodule
-    yields ``EncodedBatch`` (cached latents), we cannot run encoder->processor
-    ->decoder in ambient space: the encoder needs raw fields.  This helper
-    reads the ``autoencoder_config.yaml`` written next to the cached latents
-    by ``autocast cache-latents`` and overwrites ``cfg.datamodule`` with the
+    Both ``eval.mode=ambient`` and ``eval.mode=encode_once`` feed raw fields
+    into the encoder; they cannot consume ``EncodedBatch`` (cached latents)
+    directly.  When the current datamodule yields cached latents we read the
+    ``autoencoder_config.yaml`` written next to those latents by
+    ``autocast cache-latents`` and overwrite ``cfg.datamodule`` with the
     datamodule the autoencoder was trained on, which guarantees matching
     normalization and field layout.
+
+    ``eval.mode=latent`` stays on the cached-latents datamodule (the encoder
+    is never invoked), so this helper is a no-op for that mode.
 
     Returns the (possibly-modified) ``cfg`` in-place. Raises a descriptive
     error when the swap is needed but ``autoencoder_config.yaml`` is absent;
     callers should pass ``datamodule=...`` explicitly in that case.
     """
-    if eval_mode != "ambient" or not isinstance(example_batch, EncodedBatch):
+    needs_raw = eval_mode in ("ambient", "encode_once")
+    if not needs_raw or not isinstance(example_batch, EncodedBatch):
         return cfg
 
     data_path = cfg.get("datamodule", {}).get("data_path")
     if not data_path:
         msg = (
-            "eval.mode=ambient requires a raw-data datamodule, but the current "
-            "datamodule yields EncodedBatch and has no data_path to locate the "
-            "original autoencoder config. Pass datamodule=<raw> explicitly."
+            f"eval.mode={eval_mode} requires a raw-data datamodule, but the "
+            "current datamodule yields EncodedBatch and has no data_path to "
+            "locate the original autoencoder config. Pass datamodule=<raw> "
+            "explicitly."
         )
         raise ValueError(msg)
 
     ae_cfg = _load_autoencoder_config_from_cache(Path(data_path))
     if ae_cfg is None:
         msg = (
-            "eval.mode=ambient requested but the cached-latents directory "
+            f"eval.mode={eval_mode} requested but the cached-latents directory "
             f"{data_path} has no 'autoencoder_config.yaml'. Either regenerate "
             "the cache with a recent `autocast cache-latents` (which saves the "
             "autoencoder config), or pass datamodule=<raw> explicitly."
@@ -1223,8 +1350,8 @@ def _maybe_swap_to_ambient_datamodule(
     if ae_datamodule is None:
         msg = (
             f"autoencoder_config.yaml at {data_path} is missing a 'datamodule' "
-            "section; cannot auto-wire ambient eval. Pass datamodule=<raw> "
-            "explicitly."
+            f"section; cannot auto-wire eval.mode={eval_mode}. Pass "
+            "datamodule=<raw> explicitly."
         )
         raise ValueError(msg)
 
@@ -1246,9 +1373,10 @@ def _maybe_swap_to_ambient_datamodule(
                 OmegaConf.update(swapped_datamodule, step_key, step_value, merge=True)
 
     log.info(
-        "eval.mode=ambient: substituting cached_latents datamodule with the "
+        "eval.mode=%s: substituting cached_latents datamodule with the "
         "raw-data datamodule from %s/autoencoder_config.yaml so the encoder "
         "sees the same fields/normalization it was trained on.",
+        eval_mode,
         data_path,
     )
     with open_dict(cfg):
@@ -1258,15 +1386,34 @@ def _maybe_swap_to_ambient_datamodule(
 
 def _resolve_eval_path(
     *,
+    eval_mode: str,
     processor_only: bool,
     example_batch: Any,
     has_autoencoder_checkpoint: bool,
     decode_fn_loaded: bool,
 ) -> str:
-    """Map the auto-detected branch in `run_evaluation` to a stable label."""
+    """Map the (eval.mode, checkpoint, datamodule) combination to a code path.
+
+    Full EPD checkpoints always resolve to ``ambient_epd`` -- there is no
+    separate latent-rollout path for them because the encoder is part of the
+    model.  Callers should emit a warning when ``eval.mode=encode_once`` is
+    aliased to ``ambient_epd`` in this way so the user knows the two are
+    numerically identical for that checkpoint type.
+
+    Processor-only checkpoints with an autoencoder available (``has_ae`` and
+    raw ``Batch`` datamodule) can run either of two closely-related paths:
+    ``ambient_epd`` (re-encode every step) or ``encode_once`` (encode once,
+    stay in latent, decode at the end, compare against raw ground truth).
+    The ``eval_mode`` argument selects between them.
+
+    Processor-only checkpoints on cached latents fall back to the latent-
+    space paths (with or without a decoder) as before.
+    """
     if not processor_only:
         return EVAL_PATH_AMBIENT_EPD
     if isinstance(example_batch, Batch) and has_autoencoder_checkpoint:
+        if eval_mode == "encode_once":
+            return EVAL_PATH_ENCODE_ONCE
         return EVAL_PATH_AMBIENT_EPD
     if decode_fn_loaded:
         return EVAL_PATH_LATENT_CACHED_WITH_DECODER
@@ -1275,8 +1422,6 @@ def _resolve_eval_path(
 
 def _validate_resolved_eval_path(*, eval_mode: str, resolved_path: str) -> None:
     """Raise if the resolved code path disagrees with the user-requested mode."""
-    if eval_mode == "auto":
-        return
     if eval_mode == "ambient" and resolved_path != EVAL_PATH_AMBIENT_EPD:
         msg = (
             "eval.mode=ambient but the resolved eval path is "
@@ -1287,13 +1432,30 @@ def _validate_resolved_eval_path(*, eval_mode: str, resolved_path: str) -> None:
             "datamodule=."
         )
         raise ValueError(msg)
-    if eval_mode == "latent" and resolved_path == EVAL_PATH_AMBIENT_EPD:
+    if eval_mode == "latent" and resolved_path not in (
+        EVAL_PATH_LATENT_CACHED_WITH_DECODER,
+        EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
+    ):
         msg = (
             "eval.mode=latent but the resolved eval path is "
             f"{resolved_path!r}. Latent-space eval requires a processor-only "
             "checkpoint paired with an EncodedBatch (cached_latents) "
             "datamodule. Use datamodule=cached_latents and remove "
-            "autoencoder_checkpoint=, or switch to eval.mode=ambient/auto."
+            "autoencoder_checkpoint=, or switch to eval.mode=encode_once/ambient."
+        )
+        raise ValueError(msg)
+    if eval_mode == "encode_once" and resolved_path in (
+        EVAL_PATH_LATENT_CACHED_WITH_DECODER,
+        EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
+    ):
+        msg = (
+            "eval.mode=encode_once but the resolved eval path is "
+            f"{resolved_path!r}. encode_once needs the encoder *and* decoder "
+            "reachable so it can compare decoded rollouts against raw ground "
+            "truth. Either pass autoencoder_checkpoint=<ae.ckpt> (the encoder "
+            "will run once on raw inputs), or switch to eval.mode=latent if "
+            "you want to measure the processor against decoded cached "
+            "latents rather than against raw ground truth."
         )
         raise ValueError(msg)
 
@@ -1407,13 +1569,14 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     eval_batch_size: int = eval_cfg.get("batch_size", 1)
     max_test_batches = eval_cfg.get("max_test_batches")
     max_rollout_batches = _resolve_rollout_batch_limit(eval_cfg)
-    eval_mode = _normalize_eval_mode(eval_cfg.get("mode", "auto"))
+    requested_eval_mode = _normalize_eval_mode(eval_cfg.get("mode"))
+    eval_mode = requested_eval_mode
     log.info(
         "Batch limits: max_test_batches=%s, max_rollout_batches=%s",
         max_test_batches,
         max_rollout_batches,
     )
-    log.info("eval.mode=%s", eval_mode)
+    log.info("eval.mode=%s", requested_eval_mode)
 
     checkpoint_path = resolve_checkpoint_path(
         eval_cfg,
@@ -1454,12 +1617,24 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     # in the cache dir's autoencoder_config.yaml and rebuild. Honors an
     # explicit `datamodule=...` override implicitly: when the override targets
     # a raw-Batch datamodule the swap becomes a no-op.
+    # Resolve `auto` to a concrete mode now that we know the checkpoint type
+    # and datamodule shape. Downstream code sees a concrete mode only.
+    if eval_mode == "auto":
+        eval_mode = _resolve_auto_eval_mode(
+            processor_only=processor_only,
+            example_batch=stats.get("example_batch"),
+            has_autoencoder_checkpoint=bool(cfg.get("autoencoder_checkpoint")),
+        )
+        log.info("eval.mode=auto resolved to %s for this run", eval_mode)
+
     cfg = _maybe_swap_to_ambient_datamodule(
         cfg,
         eval_mode=eval_mode,
         example_batch=stats.get("example_batch"),
     )
-    if eval_mode == "ambient" and isinstance(stats.get("example_batch"), EncodedBatch):
+    if eval_mode in ("ambient", "encode_once") and isinstance(
+        stats.get("example_batch"), EncodedBatch
+    ):
         datamodule, cfg, stats = setup_datamodule(cfg)
 
     # Override model n_members from eval config if specified
@@ -1472,24 +1647,36 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
 
     # Setup model and weights based on checkpoint type and datamodule.
     #
-    # Mode 1 - ambient/data-space EPD from two checkpoints:
+    # Mode 1 - full EPD from two checkpoints (ambient or encode_once):
     #   Triggered when the processor ckpt is processor-only AND the config
     #   contains `autoencoder_checkpoint` AND the datamodule yields raw Batch
     #   objects (i.e. not cached latents).  The encoder+decoder are loaded from
     #   `autoencoder_checkpoint`; only the processor weights come from the
     #   processor checkpoint.  Typical invocation:
     #     autocast eval --workdir <ae_workdir> eval.checkpoint=<processor.ckpt>
+    #   The rollout closure then branches on `eval.mode`:
+    #     * ambient      -> encoder->processor->decoder at every step (drift
+    #                       is charged to the metrics; directly comparable to
+    #                       pure-ambient baselines).
+    #     * encode_once  -> encoder runs once; processor rolls out in latent
+    #                       space; decoder runs per step for metrics; ground
+    #                       truth is raw denormalized `batch.output_fields`.
+    #                       This is the default: it isolates processor error
+    #                       from autoencoder drift while still scoring against
+    #                       real ground truth.
     #
-    # Mode 2 - data-space eval via processor + decoder (cached latents):
+    # Mode 2 - latent-space eval via processor + decoder (cached latents):
     #   Triggered when the processor ckpt is processor-only AND the datamodule
     #   yields EncodedBatch objects (cached latents).  The processor is loaded
     #   from the processor ckpt; the decoder is loaded from `autoencoder_config.yaml`
     #   saved in the cache directory by `autocast cache-latents`.
     #   Predictions and ground-truth latents are both decoded before metrics.
+    #   Requires `eval.mode=latent` (encode_once is rejected for this path
+    #   because it can never see raw ground truth here).
     #
-    # Fallback - latent-space processor eval:
+    # Fallback - pure latent-space processor eval:
     #   No `autoencoder_checkpoint` / no `autoencoder_config.yaml` available.
-    #   Metrics are computed in latent space.
+    #   Metrics are computed in latent space. Requires `eval.mode=latent`.
 
     example_batch = stats.get("example_batch")
 
@@ -1562,6 +1749,7 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
         raise RuntimeError(msg)
 
     resolved_eval_path = _resolve_eval_path(
+        eval_mode=eval_mode,
         processor_only=processor_only,
         example_batch=example_batch,
         has_autoencoder_checkpoint=bool(cfg.get("autoencoder_checkpoint")),
@@ -1572,6 +1760,18 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
         eval_mode=eval_mode,
         resolved_path=resolved_eval_path,
     )
+    if (
+        requested_eval_mode == "encode_once"
+        and resolved_eval_path == EVAL_PATH_AMBIENT_EPD
+    ):
+        log.warning(
+            "eval.mode=encode_once resolved to ambient_epd for this setup "
+            "(full EPD checkpoint, or stateless encoder/decoder baked into "
+            "the processor run). There is no separate latent rollout to "
+            "isolate, so encode_once is numerically identical to "
+            "eval.mode=ambient here. Omit eval.mode (eval.mode=auto) or "
+            "pass eval.mode=ambient explicitly to suppress this warning."
+        )
 
     # Get eval parameters from config
     metrics_list = eval_cfg.get("metrics", DEFAULT_EVAL_METRICS)
@@ -1790,7 +1990,7 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
                 eval_cfg.get("metric_windows_rollout", [(0, 1), (6, 12), (13, 30)])
             )
 
-            def rollout_predict(batch):
+            def _standard_rollout_predict(batch):
                 preds, trues = model.rollout(
                     batch,
                     stride=rollout_stride,
@@ -1814,6 +2014,19 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
 
                 min_len = min(preds.shape[1], trues.shape[1])
                 return preds[:, :min_len], trues[:, :min_len]
+
+            rollout_predict: Callable[[Any], Any]
+            if resolved_eval_path == EVAL_PATH_ENCODE_ONCE:
+                rollout_predict = _build_encode_once_rollout_predict(
+                    model,
+                    rollout_stride=rollout_stride,
+                    max_rollout_steps=max_rollout_steps,
+                    free_running_only=eval_cfg.get("free_running_only", True),
+                    n_members=n_members if n_members and n_members > 1 else None,
+                    device=fabric.device,
+                )
+            else:
+                rollout_predict = _standard_rollout_predict
 
             rollout_metrics_loader = _limit_batches(
                 fabric.setup_dataloaders(

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -148,6 +148,10 @@ RESOLVABLE_EVAL_MODES = ("encode_once", "ambient", "latent")
 EVAL_PATH_AMBIENT_EPD = "ambient_epd"  # full EPD checkpoint or processor+AE (ambient)
 EVAL_PATH_ENCODE_ONCE = "encode_once"  # processor+AE, latent rollout, raw truth
 EVAL_PATH_LATENT_CACHED_WITH_DECODER = "latent_cached_with_decoder"  # latent+decoder
+# Dev sense-check path: metrics computed directly in the autoencoder's raw
+# latent space. Only reachable via an explicit opt-in
+# (``eval.latent_space_metrics=true`` combined with ``eval.mode=latent``);
+# see ``_validate_latent_space_metrics`` below.
 EVAL_PATH_LATENT_CACHED_LATENT_ONLY = "latent_cached_latent_only"  # latent-only
 
 
@@ -1289,7 +1293,12 @@ def _resolve_auto_eval_mode(
     if isinstance(example_batch, EncodedBatch):
         # Processor trained on cached latents. Use encode_once when the
         # autoencoder checkpoint is available so we score against raw
-        # ground truth; otherwise fall back to latent.
+        # ground truth; otherwise fall back to latent. If no decoder can
+        # then be built from the cached-latents directory the run will
+        # fail fast downstream (see
+        # ``_require_decoder_unless_latent_metrics_opt_in``); the user can
+        # pin ``eval.mode=latent eval.latent_space_metrics=true`` to
+        # opt into a latent-only sense check.
         if has_autoencoder_checkpoint:
             return "encode_once"
         return "latent"
@@ -1460,6 +1469,75 @@ def _validate_resolved_eval_path(*, eval_mode: str, resolved_path: str) -> None:
         raise ValueError(msg)
 
 
+def _validate_latent_space_metrics_flag(
+    *,
+    requested_eval_mode: str,
+    latent_space_metrics: bool,
+) -> None:
+    """Reject ``eval.latent_space_metrics=true`` when it cannot apply.
+
+    The flag only makes sense paired with an explicit ``eval.mode=latent``;
+    every other mode is defined to score against raw (data-space) ground
+    truth and so fundamentally requires a working decoder. ``auto`` is
+    rejected as well because the dispatch decision is made per-run and the
+    flag would silently change metric semantics depending on which concrete
+    mode ``auto`` happens to pick.
+    """
+    if not latent_space_metrics:
+        return
+    if requested_eval_mode != "latent":
+        msg = (
+            "eval.latent_space_metrics=true is only valid with an explicit "
+            f"eval.mode=latent, but eval.mode={requested_eval_mode!r} was "
+            "requested. Raw-space modes (auto / ambient / encode_once) "
+            "require a decoder by definition. Either drop "
+            "latent_space_metrics, or pin eval.mode=latent to opt in to "
+            "latent-only metrics as a development sense check."
+        )
+        raise ValueError(msg)
+
+
+def _require_decoder_unless_latent_metrics_opt_in(
+    *,
+    resolved_path: str,
+    latent_space_metrics: bool,
+) -> None:
+    """Fail fast when the resolved path has no decoder and the opt-in is off.
+
+    Previously ``eval.mode=latent`` would silently fall back to computing
+    metrics directly in raw latent space whenever no decoder could be
+    built. That produced numbers that look like evaluation results but are
+    not comparable across runs, so we now require the user to opt in via
+    ``eval.latent_space_metrics=true`` before taking that branch.
+    """
+    if resolved_path != EVAL_PATH_LATENT_CACHED_LATENT_ONLY:
+        return
+    if latent_space_metrics:
+        log.warning(
+            "eval.latent_space_metrics=true: computing metrics in the "
+            "autoencoder's raw latent space because no decoder could be "
+            "built from the cached-latents directory. These numbers are a "
+            "development sense check only -- they are not comparable "
+            "across runs (latent space is basis-dependent) and physics-"
+            "aware metrics (psrmse*, pscc*, variogram) are not meaningful "
+            "here. Provide a reachable decoder and set "
+            "latent_space_metrics=false (default) for publishable results."
+        )
+        return
+    msg = (
+        "eval.mode=latent could not build a decoder from the cached-"
+        "latents directory, so metrics would be computed directly in the "
+        "autoencoder's raw latent space. That fallback used to be silent "
+        "but produces numbers that are not comparable across runs, so it "
+        "now requires an explicit opt-in. Either:\n"
+        "  * make the decoder reachable (ensure autoencoder_config.yaml "
+        "and the AE checkpoint are present in the cache directory), or\n"
+        "  * pass eval.latent_space_metrics=true to confirm you want a "
+        "latent-only dev sense check."
+    )
+    raise RuntimeError(msg)
+
+
 def _try_build_decode_fn(
     cfg: DictConfig,
 ) -> "tuple[Any, Any] | tuple[None, None]":
@@ -1571,6 +1649,11 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     max_rollout_batches = _resolve_rollout_batch_limit(eval_cfg)
     requested_eval_mode = _normalize_eval_mode(eval_cfg.get("mode"))
     eval_mode = requested_eval_mode
+    latent_space_metrics = bool(eval_cfg.get("latent_space_metrics", False))
+    _validate_latent_space_metrics_flag(
+        requested_eval_mode=requested_eval_mode,
+        latent_space_metrics=latent_space_metrics,
+    )
     log.info(
         "Batch limits: max_test_batches=%s, max_rollout_batches=%s",
         max_test_batches,
@@ -1674,9 +1757,14 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     #   Requires `eval.mode=latent` (encode_once is rejected for this path
     #   because it can never see raw ground truth here).
     #
-    # Fallback - pure latent-space processor eval:
-    #   No `autoencoder_checkpoint` / no `autoencoder_config.yaml` available.
-    #   Metrics are computed in latent space. Requires `eval.mode=latent`.
+    # Dev sense-check - latent-only metrics (opt-in):
+    #   `eval.mode=latent` + `eval.latent_space_metrics=true`.  Skips the
+    #   decoder entirely and compares processor predictions against cached
+    #   latents directly in the autoencoder's raw latent space. Intended as a
+    #   cheap check for small processors paired with expensive autoencoders;
+    #   results are not comparable across runs and physics-aware metrics are
+    #   not meaningful.  Any other combination (no decoder + flag off) is now
+    #   rejected by `_require_decoder_unless_latent_metrics_opt_in`.
 
     example_batch = stats.get("example_batch")
 
@@ -1723,17 +1811,26 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
                 extract_state_dict(checkpoint_payload, use_ema=use_ema), strict=True
             )
             if isinstance(example_batch, EncodedBatch):
-                # Mode 2: try to load decoder for data-space evaluation
-                decoder_module, decode_fn = _try_build_decode_fn(cfg)
-                if decode_fn is not None:
+                if latent_space_metrics:
                     log.info(
-                        "Mode 2 eval: processor (cached latents) + decoder → "
-                        "data-space metrics."
+                        "Mode 2 eval: processor (cached latents) + "
+                        "latent_space_metrics=true → skipping decoder lookup."
                     )
                 else:
-                    log.info(
-                        "Mode fallback: no decoder found — evaluating in latent space."
-                    )
+                    # Mode 2: try to load decoder for data-space evaluation
+                    decoder_module, decode_fn = _try_build_decode_fn(cfg)
+                    if decode_fn is not None:
+                        log.info(
+                            "Mode 2 eval: processor (cached latents) + "
+                            "decoder → data-space metrics."
+                        )
+                    else:
+                        log.info(
+                            "Mode 2 eval: no decoder found; "
+                            "_require_decoder_unless_latent_metrics_opt_in "
+                            "will decide whether to fail fast or emit a "
+                            "latent-space dev-sense-check warning."
+                        )
     else:
         model = setup_epd_model(cfg, stats, datamodule=datamodule)
         load_result = model.load_state_dict(
@@ -1759,6 +1856,10 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     _validate_resolved_eval_path(
         eval_mode=eval_mode,
         resolved_path=resolved_eval_path,
+    )
+    _require_decoder_unless_latent_metrics_opt_in(
+        resolved_path=resolved_eval_path,
+        latent_space_metrics=latent_space_metrics,
     )
     if (
         requested_eval_mode == "encode_once"

--- a/tests/scripts/test_eval_encoder_processor_decoder.py
+++ b/tests/scripts/test_eval_encoder_processor_decoder.py
@@ -610,25 +610,22 @@ def test_validate_resolved_eval_path_happy_paths():
 
 @pytest.mark.parametrize("mode", ["auto", "ambient", "encode_once"])
 def test_validate_latent_space_metrics_flag_rejects_non_latent_modes(mode):
-    with pytest.raises(ValueError, match=r"eval\.latent_space_metrics=true"):
+    with pytest.raises(ValueError, match=r"eval\.latent_space_metrics"):
         _validate_latent_space_metrics_flag(
             requested_eval_mode=mode,
             latent_space_metrics=True,
         )
+    # flag=False is always a no-op, regardless of mode.
+    _validate_latent_space_metrics_flag(
+        requested_eval_mode=mode,
+        latent_space_metrics=False,
+    )
 
 
 def test_validate_latent_space_metrics_flag_allows_explicit_latent():
     _validate_latent_space_metrics_flag(
         requested_eval_mode="latent",
         latent_space_metrics=True,
-    )
-
-
-@pytest.mark.parametrize("mode", ["auto", "ambient", "encode_once", "latent"])
-def test_validate_latent_space_metrics_flag_noop_when_false(mode):
-    _validate_latent_space_metrics_flag(
-        requested_eval_mode=mode,
-        latent_space_metrics=False,
     )
 
 
@@ -646,26 +643,22 @@ def test_require_decoder_allows_opt_in_and_warns(caplog):
             resolved_path=EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
             latent_space_metrics=True,
         )
+    # Decoded paths are no-ops whether or not the flag is set.
+    for path in (
+        EVAL_PATH_AMBIENT_EPD,
+        EVAL_PATH_ENCODE_ONCE,
+        EVAL_PATH_LATENT_CACHED_WITH_DECODER,
+    ):
+        _require_decoder_unless_latent_metrics_opt_in(
+            resolved_path=path, latent_space_metrics=False
+        )
+        _require_decoder_unless_latent_metrics_opt_in(
+            resolved_path=path, latent_space_metrics=True
+        )
 
     assert any(
         "latent_space_metrics=true" in record.message for record in caplog.records
     ), "expected a prominent warning about latent-only metrics"
-
-
-@pytest.mark.parametrize(
-    "resolved_path",
-    [
-        EVAL_PATH_AMBIENT_EPD,
-        EVAL_PATH_ENCODE_ONCE,
-        EVAL_PATH_LATENT_CACHED_WITH_DECODER,
-    ],
-)
-@pytest.mark.parametrize("flag", [True, False])
-def test_require_decoder_is_noop_for_decoded_paths(resolved_path, flag):
-    _require_decoder_unless_latent_metrics_opt_in(
-        resolved_path=resolved_path,
-        latent_space_metrics=flag,
-    )
 
 
 def test_maybe_swap_to_ambient_datamodule_is_noop_for_raw_batch(tmp_path):

--- a/tests/scripts/test_eval_encoder_processor_decoder.py
+++ b/tests/scripts/test_eval_encoder_processor_decoder.py
@@ -22,6 +22,7 @@ from autocast.scripts.eval.encoder_processor_decoder import (
     _normalize_per_batch_rows,
     _reindex_per_batch_rows_by_rank,
     _render_rollouts,
+    _require_decoder_unless_latent_metrics_opt_in,
     _resolve_auto_eval_mode,
     _resolve_eval_path,
     _resolve_rollout_batch_limit,
@@ -30,6 +31,7 @@ from autocast.scripts.eval.encoder_processor_decoder import (
     _should_skip_metric,
     _split_metric_and_metadata_rows,
     _training_runtime_rows,
+    _validate_latent_space_metrics_flag,
     _validate_resolved_eval_path,
 )
 from autocast.types import Batch, EncodedBatch
@@ -603,6 +605,66 @@ def test_validate_resolved_eval_path_happy_paths():
     _validate_resolved_eval_path(
         eval_mode="latent",
         resolved_path=EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
+    )
+
+
+@pytest.mark.parametrize("mode", ["auto", "ambient", "encode_once"])
+def test_validate_latent_space_metrics_flag_rejects_non_latent_modes(mode):
+    with pytest.raises(ValueError, match=r"eval\.latent_space_metrics=true"):
+        _validate_latent_space_metrics_flag(
+            requested_eval_mode=mode,
+            latent_space_metrics=True,
+        )
+
+
+def test_validate_latent_space_metrics_flag_allows_explicit_latent():
+    _validate_latent_space_metrics_flag(
+        requested_eval_mode="latent",
+        latent_space_metrics=True,
+    )
+
+
+@pytest.mark.parametrize("mode", ["auto", "ambient", "encode_once", "latent"])
+def test_validate_latent_space_metrics_flag_noop_when_false(mode):
+    _validate_latent_space_metrics_flag(
+        requested_eval_mode=mode,
+        latent_space_metrics=False,
+    )
+
+
+def test_require_decoder_fails_fast_without_opt_in():
+    with pytest.raises(RuntimeError, match=r"latent_space_metrics=true"):
+        _require_decoder_unless_latent_metrics_opt_in(
+            resolved_path=EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
+            latent_space_metrics=False,
+        )
+
+
+def test_require_decoder_allows_opt_in_and_warns(caplog):
+    with caplog.at_level("WARNING"):
+        _require_decoder_unless_latent_metrics_opt_in(
+            resolved_path=EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
+            latent_space_metrics=True,
+        )
+
+    assert any(
+        "latent_space_metrics=true" in record.message for record in caplog.records
+    ), "expected a prominent warning about latent-only metrics"
+
+
+@pytest.mark.parametrize(
+    "resolved_path",
+    [
+        EVAL_PATH_AMBIENT_EPD,
+        EVAL_PATH_ENCODE_ONCE,
+        EVAL_PATH_LATENT_CACHED_WITH_DECODER,
+    ],
+)
+@pytest.mark.parametrize("flag", [True, False])
+def test_require_decoder_is_noop_for_decoded_paths(resolved_path, flag):
+    _require_decoder_unless_latent_metrics_opt_in(
+        resolved_path=resolved_path,
+        latent_space_metrics=flag,
     )
 
 

--- a/tests/scripts/test_eval_encoder_processor_decoder.py
+++ b/tests/scripts/test_eval_encoder_processor_decoder.py
@@ -9,7 +9,9 @@ from omegaconf import OmegaConf
 
 from autocast.metrics.ensemble import CRPS, AlphaFairCRPS, SpreadSkillRatio
 from autocast.scripts.eval.encoder_processor_decoder import (
+    DEFAULT_EVAL_MODE,
     EVAL_PATH_AMBIENT_EPD,
+    EVAL_PATH_ENCODE_ONCE,
     EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
     EVAL_PATH_LATENT_CACHED_WITH_DECODER,
     _build_eval_predict_fn,
@@ -20,6 +22,7 @@ from autocast.scripts.eval.encoder_processor_decoder import (
     _normalize_per_batch_rows,
     _reindex_per_batch_rows_by_rank,
     _render_rollouts,
+    _resolve_auto_eval_mode,
     _resolve_eval_path,
     _resolve_rollout_batch_limit,
     _resolve_rollout_channel_names,
@@ -428,9 +431,14 @@ def test_render_rollouts_resolves_indices_within_batched_samples(tmp_path, monke
 # ---------------------------------------------------------------------------
 
 
+def test_default_eval_mode_is_auto():
+    assert DEFAULT_EVAL_MODE == "auto"
+
+
 def test_normalize_eval_mode_accepts_known_values_and_none():
     assert _normalize_eval_mode(None) == "auto"
-    assert _normalize_eval_mode("auto") == "auto"
+    assert _normalize_eval_mode("Auto") == "auto"
+    assert _normalize_eval_mode("Encode_Once") == "encode_once"
     assert _normalize_eval_mode("Ambient") == "ambient"
     assert _normalize_eval_mode("LATENT") == "latent"
 
@@ -440,52 +448,106 @@ def test_normalize_eval_mode_rejects_unknown():
         _normalize_eval_mode("something-else")
 
 
-@pytest.mark.parametrize(
-    ("processor_only", "batch_type", "ae_ckpt", "decoder_loaded", "expected"),
-    [
-        (False, "batch", False, False, EVAL_PATH_AMBIENT_EPD),
-        (False, "encoded", False, False, EVAL_PATH_AMBIENT_EPD),
-        (True, "batch", True, False, EVAL_PATH_AMBIENT_EPD),
-        (True, "encoded", False, True, EVAL_PATH_LATENT_CACHED_WITH_DECODER),
-        (True, "encoded", False, False, EVAL_PATH_LATENT_CACHED_LATENT_ONLY),
-    ],
-)
-def test_resolve_eval_path_matches_run_evaluation_branches(
-    processor_only, batch_type, ae_ckpt, decoder_loaded, expected
-):
-    example_batch = (
-        Batch(
+def _example_batch(kind):
+    if kind == "batch":
+        return Batch(
             input_fields=torch.zeros(1, 1, 2, 2, 1),
             output_fields=torch.zeros(1, 1, 2, 2, 1),
             constant_scalars=None,
             constant_fields=None,
         )
-        if batch_type == "batch"
-        else EncodedBatch(
-            encoded_inputs=torch.zeros(1, 1, 2, 2, 1),
-            encoded_output_fields=torch.zeros(1, 1, 2, 2, 1),
-            global_cond=None,
-            encoded_info={},
-        )
+    return EncodedBatch(
+        encoded_inputs=torch.zeros(1, 1, 2, 2, 1),
+        encoded_output_fields=torch.zeros(1, 1, 2, 2, 1),
+        global_cond=None,
+        encoded_info={},
     )
 
-    resolved = _resolve_eval_path(
+
+@pytest.mark.parametrize(
+    ("processor_only", "batch_type", "ae_ckpt", "expected"),
+    [
+        # Full EPD (or stateless AE baked into processor) -> ambient.
+        (False, "batch", False, "ambient"),
+        (False, "encoded", False, "ambient"),
+        (False, "batch", True, "ambient"),
+        # Processor-only on raw Batch with AE -> encode_once.
+        (True, "batch", True, "encode_once"),
+        # Processor-only on cached latents with AE -> encode_once (a swap will
+        # happen downstream); without AE -> latent.
+        (True, "encoded", True, "encode_once"),
+        (True, "encoded", False, "latent"),
+        # Processor-only on raw Batch without AE: falls back to latent.
+        (True, "batch", False, "latent"),
+    ],
+)
+def test_resolve_auto_eval_mode_picks_faithful_default(
+    processor_only, batch_type, ae_ckpt, expected
+):
+    resolved = _resolve_auto_eval_mode(
         processor_only=processor_only,
-        example_batch=example_batch,
+        example_batch=_example_batch(batch_type),
         has_autoencoder_checkpoint=ae_ckpt,
-        decode_fn_loaded=decoder_loaded,
     )
 
     assert resolved == expected
 
 
-def test_validate_resolved_eval_path_auto_is_always_ok():
-    for path in (
-        EVAL_PATH_AMBIENT_EPD,
+_RESOLVE_EVAL_PATH_CASES = [
+    # Full EPD: always resolves to ambient_epd regardless of mode.
+    ("ambient", False, "batch", False, False, EVAL_PATH_AMBIENT_EPD),
+    ("encode_once", False, "batch", False, False, EVAL_PATH_AMBIENT_EPD),
+    ("ambient", False, "encoded", False, False, EVAL_PATH_AMBIENT_EPD),
+    # Processor-only + raw Batch + AE ckpt: mode selects the path.
+    ("ambient", True, "batch", True, False, EVAL_PATH_AMBIENT_EPD),
+    ("encode_once", True, "batch", True, False, EVAL_PATH_ENCODE_ONCE),
+    # Processor-only + cached latents: latent paths, independent of mode.
+    ("latent", True, "encoded", False, True, EVAL_PATH_LATENT_CACHED_WITH_DECODER),
+    ("latent", True, "encoded", False, False, EVAL_PATH_LATENT_CACHED_LATENT_ONLY),
+    # encode_once on cached latents still maps to the latent paths here;
+    # _validate_resolved_eval_path is what rejects the combination.
+    (
+        "encode_once",
+        True,
+        "encoded",
+        False,
+        True,
         EVAL_PATH_LATENT_CACHED_WITH_DECODER,
+    ),
+    (
+        "encode_once",
+        True,
+        "encoded",
+        False,
+        False,
         EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
-    ):
-        _validate_resolved_eval_path(eval_mode="auto", resolved_path=path)
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    (
+        "eval_mode",
+        "processor_only",
+        "batch_type",
+        "ae_ckpt",
+        "decoder_loaded",
+        "expected",
+    ),
+    _RESOLVE_EVAL_PATH_CASES,
+)
+def test_resolve_eval_path_matches_run_evaluation_branches(
+    eval_mode, processor_only, batch_type, ae_ckpt, decoder_loaded, expected
+):
+    resolved = _resolve_eval_path(
+        eval_mode=eval_mode,
+        processor_only=processor_only,
+        example_batch=_example_batch(batch_type),
+        has_autoencoder_checkpoint=ae_ckpt,
+        decode_fn_loaded=decoder_loaded,
+    )
+
+    assert resolved == expected
 
 
 def test_validate_resolved_eval_path_ambient_rejects_latent_path():
@@ -504,10 +566,35 @@ def test_validate_resolved_eval_path_latent_rejects_ambient_path():
         )
 
 
+def test_validate_resolved_eval_path_latent_rejects_encode_once_path():
+    with pytest.raises(ValueError, match=r"eval\.mode=latent"):
+        _validate_resolved_eval_path(
+            eval_mode="latent",
+            resolved_path=EVAL_PATH_ENCODE_ONCE,
+        )
+
+
+def test_validate_resolved_eval_path_encode_once_rejects_latent_paths():
+    for path in (
+        EVAL_PATH_LATENT_CACHED_WITH_DECODER,
+        EVAL_PATH_LATENT_CACHED_LATENT_ONLY,
+    ):
+        with pytest.raises(ValueError, match=r"eval\.mode=encode_once"):
+            _validate_resolved_eval_path(eval_mode="encode_once", resolved_path=path)
+
+
 def test_validate_resolved_eval_path_happy_paths():
     _validate_resolved_eval_path(
         eval_mode="ambient",
         resolved_path=EVAL_PATH_AMBIENT_EPD,
+    )
+    _validate_resolved_eval_path(
+        eval_mode="encode_once",
+        resolved_path=EVAL_PATH_AMBIENT_EPD,
+    )
+    _validate_resolved_eval_path(
+        eval_mode="encode_once",
+        resolved_path=EVAL_PATH_ENCODE_ONCE,
     )
     _validate_resolved_eval_path(
         eval_mode="latent",
@@ -555,11 +642,49 @@ def test_maybe_swap_to_ambient_datamodule_is_noop_for_non_ambient(tmp_path):
     )
 
     result = _maybe_swap_to_ambient_datamodule(
-        cfg, eval_mode="auto", example_batch=encoded
+        cfg, eval_mode="latent", example_batch=encoded
     )
 
     assert result is cfg
     assert cfg.datamodule._target_ == "cached.LatentDataModule"
+
+
+def test_maybe_swap_to_ambient_datamodule_swaps_for_encode_once(tmp_path):
+    # encode_once also needs raw inputs (encoder runs once); same swap as ambient.
+    ae_cfg_path = tmp_path / "autoencoder_config.yaml"
+    OmegaConf.save(
+        OmegaConf.create(
+            {
+                "datamodule": {
+                    "_target_": "raw.TheWellDataModule",
+                    "data_path": "/path/to/raw",
+                    "use_normalization": True,
+                }
+            }
+        ),
+        ae_cfg_path,
+    )
+    cfg = OmegaConf.create(
+        {
+            "datamodule": {
+                "_target_": "cached.LatentDataModule",
+                "data_path": str(tmp_path),
+            }
+        }
+    )
+    encoded = EncodedBatch(
+        encoded_inputs=torch.zeros(1, 1, 2, 2, 1),
+        encoded_output_fields=torch.zeros(1, 1, 2, 2, 1),
+        global_cond=None,
+        encoded_info={},
+    )
+
+    _maybe_swap_to_ambient_datamodule(
+        cfg, eval_mode="encode_once", example_batch=encoded
+    )
+
+    assert cfg.datamodule._target_ == "raw.TheWellDataModule"
+    assert cfg.datamodule.data_path == "/path/to/raw"
 
 
 def test_maybe_swap_to_ambient_datamodule_loads_from_cache_dir(tmp_path):


### PR DESCRIPTION
## Summary

Add a new evaluation mode, `encode_once`, that gives a fair apples-to-apples comparison for processors trained in latent space. The processor rolls out entirely in its native latent space (no decode/encode drift charged to it), but metrics are computed against the original raw denormalized ground truth -- so latent-rollout models can be scored directly against pure-ambient baselines without either side getting an unfair penalty or advantage.

- **New `encode_once` mode**: encoder runs once on raw inputs, processor rolls out in latent space, decoder runs per step; metrics compare decoded predictions against denormalized raw `batch.output_fields`.
- **`eval.mode=auto` (new default)** dispatches to the faithful concrete mode per run:
  - full EPD / stateless AE -> `ambient`
  - processor-only + autoencoder reachable -> `encode_once`
  - processor-only + cached latents, no AE -> `latent`

  Resolved mode is logged at INFO. `encode_once` on a full EPD aliases back to `ambient` with a warning (no separate latent rollout to isolate).
- **`eval.latent_space_metrics` flag** replaces the previous silent "no decoder, compute in raw latent space" fallback. When `eval.mode=latent` cannot build a decoder the run now fails fast and asks the user to either fix the AE path or set `eval.latent_space_metrics=true` for a dev sense check. Rejected for `auto`/`ambient`/`encode_once` (those modes require a decoder by definition).
- Docs, docstrings, and test parametrizations streamlined in a follow-up refactor commit.

See `src/autocast/configs/eval/README.md` for the full mode table and auto-dispatch rules.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `pyright` clean
- [x] `pytest tests/scripts/test_eval_encoder_processor_decoder.py` -- 60 passed, including new coverage for
  - `auto` dispatch across the (processor_only, batch_type, ae_ckpt) matrix
  - `encode_once` path resolution and `_resolve_eval_path` matrix
  - `_validate_latent_space_metrics_flag` rejection on auto/ambient/encode_once
  - `_require_decoder_unless_latent_metrics_opt_in` fail-fast vs. opt-in warning paths
  - `_maybe_swap_to_ambient_datamodule` swap for `encode_once`