### PR TITLE
Add 0.75 ensemble evaluation support and workflow enhancements

### DIFF
--- a/slurm_scripts/ablations/ensemble_size/README.md
+++ b/slurm_scripts/ablations/ensemble_size/README.md
@@ -53,6 +53,7 @@ batch) CRPS ablations on the other comparison datasets.
 | `submit_ensemble_timing.sh` | 5-epoch timing for the three active `eff_bs1024` runs (`gray_scott`, `gpe_laser_only_wake`, `advection_diffusion`) → `timing.ckpt` per run |
 | `submit_ensemble_large.sh`  | 24h production runs for the same three active runs, using cached or timing-derived cosine schedules |
 | `eval/submit_eval_crps_ambient.sh` | ambient eval for the current `m=16` CRPS run set (CNS `fixed_bs32` pilot plus all available `eff_bs1024` runs), with conservative `eval.batch_size=4` and explicit `eval.n_members=10` to match the comparison-study eval regime |
+| `eval_0p75/submit_eval_crps_ambient.sh` | ambient eval for the same run set, but against each run's third `quarter-*.ckpt` (the 75% schedule checkpoint), with outputs isolated under `eval_0p75/` |
 
 ## Extending the sweep
 
@@ -68,13 +69,21 @@ each submit script, so extending `eff_bs1024` without broadening
 
 ## Eval placement
 
-Ensemble-size eval now lives under `slurm_scripts/ablations/ensemble_size/eval/`
+Ensemble-size eval now lives under `slurm_scripts/ablations/ensemble_size/`
 rather than `slurm_scripts/comparison/eval/`. The reason is organizational:
 the run set is still partly ablation-only (`fixed_bs32`) even though the
 `eff_bs1024` subset may later graduate into the main comparison baseline.
 
-If that promotion happens, move the promoted run dirs into a comparison-level
-eval script and leave only the genuinely ablation-only runs here.
+We keep two sibling eval directories here:
+
+- `eval/` for the standard final-checkpoint evals.
+- `eval_0p75/` for the third quarter-checkpoint (`75%`) evals, so those
+  partial-schedule outputs do not mix with the canonical final-checkpoint
+  metrics and videos.
+
+If the `eff_bs1024` subset is later promoted, move the promoted run dirs into a
+comparison-level eval script and leave only the genuinely ablation-only runs
+here.
 
 ## Scheduling
 

--- a/slurm_scripts/ablations/ensemble_size/eval_0p75/submit_eval_crps_ambient.sh
+++ b/slurm_scripts/ablations/ensemble_size/eval_0p75/submit_eval_crps_ambient.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -euo pipefail
+# Ambient eval submitter for the 75%-schedule checkpoints from the current
+# CRPS ensemble-size runs.
+#
+# This mirrors ../eval/submit_eval_crps_ambient.sh but keeps outputs under a
+# sibling eval_0p75/ folder so partial-schedule metrics, rollout videos, and
+# SLURM logs do not mix with the standard final-checkpoint evals.
+#
+# The large-run training scripts save checkpoints at 25/50/75/100% of the
+# cosine schedule via quarter-*.ckpt filenames. Rather than hard-coding epoch
+# numbers per dataset, we sort the available quarter checkpoints and pick the
+# third one (the 0.75 checkpoint) for each run.
+#
+# Batch size: keep 4/GPU as the same conservative first pass used by the
+# standard ambient ensemble-size eval script.
+
+EVAL_BATCH_SIZE=4
+EVAL_N_MEMBERS=10
+TIMEOUT_MIN=240
+EVAL_SUBDIR="eval_0p75"
+RUN_DRY_STATES=("true" "false")
+EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
+
+RUN_DIRS=(
+    # CNS pilot runs retained alongside the compute-matched sweep.
+    "outputs/2026-04-20/ensemble_size/crps_cns64_vit_azula_large_0db40e1_5e157a5"  # ensemble_m16_fixed_bs32
+    # Compute-matched eff_bs1024 runs across comparison datasets.
+    "outputs/2026-04-20/ensemble_size/crps_cns64_vit_azula_large_0db40e1_dcd79e4"
+    "outputs/2026-04-21/ensemble_size/crps_gs64_vit_azula_large_ac1bb06_639963f"
+    "outputs/2026-04-21/ensemble_size/crps_gpe64_vit_azula_large_ac1bb06_638585e"
+    "outputs/2026-04-21/ensemble_size/crps_ad64_vit_azula_large_ac1bb06_ef6368d"
+)
+
+resolve_three_quarter_checkpoint() {
+    local run_dir="$1"
+    local -a quarter_ckpts=()
+
+    mapfile -t quarter_ckpts < <(
+        find "${run_dir}" -maxdepth 1 -type f -name 'quarter-*.ckpt' | sort
+    )
+
+    if (( ${#quarter_ckpts[@]} < 3 )); then
+        return 1
+    fi
+
+    printf '%s\n' "${quarter_ckpts[2]}"
+}
+
+for run_dir in "${RUN_DIRS[@]}"; do
+    if [[ ! -f "${run_dir}/resolved_config.yaml" ]]; then
+        echo "Skipping ${run_dir}: resolved_config.yaml missing" >&2
+        continue
+    fi
+
+    if ! eval_ckpt="$(resolve_three_quarter_checkpoint "${run_dir}")"; then
+        echo "Skipping ${run_dir}: fewer than three quarter-*.ckpt files found" >&2
+        continue
+    fi
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        dry_run_arg=()
+        run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting ensemble-size CRPS ambient eval (0.75 checkpoint)"
+        echo "  mode: ${run_label}"
+        echo "  run_dir: ${run_dir}"
+        echo "  eval.checkpoint: ${eval_ckpt}"
+        echo "  output_subdir: ${EVAL_SUBDIR}"
+        echo "  eval.batch_size: ${EVAL_BATCH_SIZE}"
+        echo "  eval.n_members: ${EVAL_N_MEMBERS}"
+        echo "  eval.metrics: ${EVAL_METRICS}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir}" \
+            --output-subdir "${EVAL_SUBDIR}" \
+            eval.checkpoint="${eval_ckpt}" \
+            eval.csv_path="${run_dir}/${EVAL_SUBDIR}/evaluation_metrics.csv" \
+            eval.video_dir="${run_dir}/${EVAL_SUBDIR}/videos" \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}"
+    done
+done

--- a/slurm_scripts/ablations/ensemble_size/eval_0p75/submit_eval_crps_ambient.sh
+++ b/slurm_scripts/ablations/ensemble_size/eval_0p75/submit_eval_crps_ambient.sh
@@ -25,7 +25,7 @@ EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,ps
 
 RUN_DIRS=(
     # CNS pilot runs retained alongside the compute-matched sweep.
-    "outputs/2026-04-20/ensemble_size/crps_cns64_vit_azula_large_0db40e1_5e157a5"  # ensemble_m16_fixed_bs32
+    # "outputs/2026-04-20/ensemble_size/crps_cns64_vit_azula_large_0db40e1_5e157a5"  # ensemble_m16_fixed_bs32
     # Compute-matched eff_bs1024 runs across comparison datasets.
     "outputs/2026-04-20/ensemble_size/crps_cns64_vit_azula_large_0db40e1_dcd79e4"
     "outputs/2026-04-21/ensemble_size/crps_gs64_vit_azula_large_ac1bb06_639963f"
@@ -38,7 +38,7 @@ resolve_three_quarter_checkpoint() {
     local -a quarter_ckpts=()
 
     mapfile -t quarter_ckpts < <(
-        find "${run_dir}" -maxdepth 1 -type f -name 'quarter-*.ckpt' | sort
+        find "${run_dir}" -type f -path '*/checkpoints/quarter-*.ckpt' | sort
     )
 
     if (( ${#quarter_ckpts[@]} < 3 )); then

--- a/slurm_scripts/ablations/ensemble_size/eval_0p75/submit_eval_crps_ambient.sh
+++ b/slurm_scripts/ablations/ensemble_size/eval_0p75/submit_eval_crps_ambient.sh
@@ -13,6 +13,12 @@ set -euo pipefail
 # numbers per dataset, we sort the available quarter checkpoints and pick the
 # third one (the 0.75 checkpoint) for each run.
 #
+# Force eval.mode=ambient here. These quarter checkpoints can look
+# processor-only to the early eval.mode=auto dispatcher because stateless
+# encoders/decoders (PermuteConcat / ChannelsLast) contribute no
+# encoder_decoder.* weights, even though the full raw-space ambient path is the
+# correct evaluation route for these runs.
+#
 # Batch size: keep 4/GPU as the same conservative first pass used by the
 # standard ambient ensemble-size eval script.
 
@@ -49,15 +55,18 @@ resolve_three_quarter_checkpoint() {
 }
 
 for run_dir in "${RUN_DIRS[@]}"; do
-    if [[ ! -f "${run_dir}/resolved_config.yaml" ]]; then
+    run_dir_abs="$(realpath "${run_dir}")"
+    if [[ ! -f "${run_dir_abs}/resolved_config.yaml" ]]; then
         echo "Skipping ${run_dir}: resolved_config.yaml missing" >&2
         continue
     fi
 
-    if ! eval_ckpt="$(resolve_three_quarter_checkpoint "${run_dir}")"; then
+    if ! eval_ckpt="$(resolve_three_quarter_checkpoint "${run_dir_abs}")"; then
         echo "Skipping ${run_dir}: fewer than three quarter-*.ckpt files found" >&2
         continue
     fi
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR}"
 
     for run_dry in "${RUN_DRY_STATES[@]}"; do
         dry_run_arg=()
@@ -69,19 +78,21 @@ for run_dir in "${RUN_DIRS[@]}"; do
 
         echo "Submitting ensemble-size CRPS ambient eval (0.75 checkpoint)"
         echo "  mode: ${run_label}"
-        echo "  run_dir: ${run_dir}"
-        echo "  eval.checkpoint: ${eval_ckpt}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  eval.mode: ambient"
         echo "  output_subdir: ${EVAL_SUBDIR}"
         echo "  eval.batch_size: ${EVAL_BATCH_SIZE}"
         echo "  eval.n_members: ${EVAL_N_MEMBERS}"
         echo "  eval.metrics: ${EVAL_METRICS}"
 
         uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
-            --workdir "${run_dir}" \
+            --workdir "${run_dir_abs}" \
             --output-subdir "${EVAL_SUBDIR}" \
-            eval.checkpoint="${eval_ckpt}" \
-            eval.csv_path="${run_dir}/${EVAL_SUBDIR}/evaluation_metrics.csv" \
-            eval.video_dir="${run_dir}/${EVAL_SUBDIR}/videos" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            eval.mode=ambient \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
             eval.metrics="${EVAL_METRICS}" \
             eval.batch_size="${EVAL_BATCH_SIZE}" \
             eval.n_members="${EVAL_N_MEMBERS}" \

--- a/src/autocast/scripts/workflow/cli.py
+++ b/src/autocast/scripts/workflow/cli.py
@@ -96,6 +96,14 @@ def build_parser() -> argparse.ArgumentParser:
     # -- eval --------------------------------------------------------------
     eval_parser = subparsers.add_parser("eval")
     eval_parser.add_argument("--workdir", required=True)
+    eval_parser.add_argument(
+        "--output-subdir",
+        default="eval",
+        help=(
+            "Evaluation output subdirectory under --workdir "
+            "(default: eval)."
+        ),
+    )
     _add_common_args(eval_parser)
 
     # -- benchmark ---------------------------------------------------------
@@ -302,6 +310,7 @@ def main() -> None:
             dataset=dataset,
             work_dir=args.workdir,
             overrides=combined_overrides,
+            output_subdir=args.output_subdir,
             runtime_typechecking=args.runtime_typechecking,
             dry_run=args.dry_run,
         )

--- a/src/autocast/scripts/workflow/commands.py
+++ b/src/autocast/scripts/workflow/commands.py
@@ -508,10 +508,11 @@ def build_eval_overrides(
     work_dir: str,
     overrides: list[str],
     using_resolved_config: bool = False,
+    output_subdir: str = "eval",
 ) -> tuple[Path, list[str]]:
     """Build evaluation overrides from CLI arguments."""
     base_work_dir = Path(work_dir).expanduser().resolve()
-    eval_dir = (base_work_dir / "eval").resolve()
+    eval_dir = (base_work_dir / output_subdir).resolve()
 
     command_overrides = [
         *build_common_launch_overrides(mode=mode, work_dir=eval_dir),
@@ -590,6 +591,7 @@ def eval_command(
     dataset: str | None,
     work_dir: str,
     overrides: list[str],
+    output_subdir: str = "eval",
     runtime_typechecking: bool = False,
     dry_run: bool = False,
 ) -> None:
@@ -609,6 +611,7 @@ def eval_command(
         work_dir=work_dir,
         overrides=effective_overrides,
         using_resolved_config=using_resolved_config,
+        output_subdir=output_subdir,
     )
 
     run_module(

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -707,6 +707,33 @@ def test_eval_command_quotes_inferred_checkpoint_with_equals(monkeypatch, tmp_pa
     assert f'eval.checkpoint="{ckpt.resolve()}"' in overrides
 
 
+def test_eval_command_uses_custom_output_subdir(monkeypatch, tmp_path):
+    (tmp_path / "resolved_config.yaml").write_text("x: 1\n", encoding="utf-8")
+    (tmp_path / "encoder_processor_decoder.ckpt").touch()
+    captured: dict[str, object] = {}
+
+    def _fake_run_module(_module, overrides, dry_run=False, mode="local", **_kwargs):
+        captured["overrides"] = overrides
+        del dry_run, mode, _kwargs  # accept run_module's keyword args
+
+    monkeypatch.setattr(
+        "autocast.scripts.workflow.commands.run_module", _fake_run_module
+    )
+
+    eval_command(
+        mode="local",
+        dataset="reaction_diffusion",
+        work_dir=str(tmp_path),
+        overrides=[],
+        output_subdir="eval_0p75",
+        dry_run=True,
+    )
+
+    overrides = captured["overrides"]
+    assert isinstance(overrides, list)
+    assert f"hydra.run.dir={(tmp_path / 'eval_0p75').resolve()}" in overrides
+
+
 def test_benchmark_command_quotes_inferred_checkpoint_with_equals(
     monkeypatch, tmp_path
 ):
@@ -1057,6 +1084,7 @@ def test_build_parser_eval_basic(parser: argparse.ArgumentParser):
     args = parser.parse_args(["eval", "--workdir", "/tmp/w"])
     assert args.command == "eval"
     assert args.workdir == "/tmp/w"
+    assert args.output_subdir == "eval"
 
 
 def test_build_parser_benchmark_basic(parser: argparse.ArgumentParser):
@@ -1352,6 +1380,41 @@ def test_main_eval_does_not_infer_dataset_from_workdir(monkeypatch, tmp_path):
 
     assert captured["dataset"] is None
     assert captured["work_dir"] == str(tmp_path)
+    assert captured["output_subdir"] == "eval"
+
+
+def test_main_eval_forwards_output_subdir(monkeypatch, tmp_path):
+    (tmp_path / "resolved_config.yaml").write_text(
+        "datamodule:\n  data_path: /tmp/datasets/reaction_diffusion\n",
+        encoding="utf-8",
+    )
+
+    captured = {}
+
+    def _fake_eval_command(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "autocast.scripts.workflow.cli.eval_command",
+        _fake_eval_command,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "autocast",
+            "eval",
+            "--workdir",
+            str(tmp_path),
+            "--output-subdir",
+            "eval_0p75",
+            "--dry-run",
+        ],
+    )
+
+    workflow_cli.main()
+
+    assert captured["output_subdir"] == "eval_0p75"
 
 
 def test_main_benchmark_does_not_infer_dataset_from_workdir(monkeypatch, tmp_path):


### PR DESCRIPTION
This pull request adds support for specifying a custom evaluation output subdirectory in the workflow, which allows evaluation results to be organized under different folders (e.g., for partial-schedule checkpoints). The main changes include updating the CLI, command logic, and tests to handle the new `--output-subdir` argument, and adding a new SLURM script for evaluating 75%-schedule checkpoints.

**Evaluation output directory customization:**

* Added a `--output-subdir` argument (default: `"eval"`) to the `eval` CLI command, allowing users to specify a custom subdirectory for evaluation outputs. [[1]](diffhunk://#diff-5e1cff7c1709f200cf151791b359b22aea1ad52ec4ee69398fb8e2a1d3d5c631R99-R106) [[2]](diffhunk://#diff-5e1cff7c1709f200cf151791b359b22aea1ad52ec4ee69398fb8e2a1d3d5c631R313)
* Updated `build_eval_overrides` and `eval_command` in `commands.py` to use the specified `output_subdir` instead of hardcoding `"eval"`. [[1]](diffhunk://#diff-36b8d7f3ef0f474d79cbcaeec2b4a92f90f2b3129d276caa18cd4f87a462e59bR511-R515) [[2]](diffhunk://#diff-36b8d7f3ef0f474d79cbcaeec2b4a92f90f2b3129d276caa18cd4f87a462e59bR594) [[3]](diffhunk://#diff-36b8d7f3ef0f474d79cbcaeec2b4a92f90f2b3129d276caa18cd4f87a462e59bR614)
* Added and updated tests to verify that the custom output subdirectory is honored throughout the CLI and command layers. [[1]](diffhunk://#diff-a10bfb038ed9f9436127d62a1da8a90ec842a1295d2fecfc8247422bfd6364c4R710-R736) [[2]](diffhunk://#diff-a10bfb038ed9f9436127d62a1da8a90ec842a1295d2fecfc8247422bfd6364c4R1087) [[3]](diffhunk://#diff-a10bfb038ed9f9436127d62a1da8a90ec842a1295d2fecfc8247422bfd6364c4R1383-R1417)

**New evaluation script for partial checkpoints:**

* Added `slurm_scripts/ablations/ensemble_size/eval_0p75/submit_eval_crps_ambient.sh`, which evaluates the 75%-schedule (third quarter) checkpoints and outputs results to an isolated `eval_0p75/` directory.
* Updated the documentation in `README.md` to explain the new script and the organization of evaluation outputs for ensemble-size ablation runs. [[1]](diffhunk://#diff-407e39980ec0a9abd514dc9c0ad3bf13c30d9b0e02206cc6d0896f663e7b5e88R56) [[2]](diffhunk://#diff-407e39980ec0a9abd514dc9c0ad3bf13c30d9b0e02206cc6d0896f663e7b5e88L71-R86)