### PR TITLE
Fix ruff lint issues

### DIFF
--- a/src/autocast/scripts/workflow/cli.py
+++ b/src/autocast/scripts/workflow/cli.py
@@ -99,10 +99,7 @@ def build_parser() -> argparse.ArgumentParser:
     eval_parser.add_argument(
         "--output-subdir",
         default="eval",
-        help=(
-            "Evaluation output subdirectory under --workdir "
-            "(default: eval)."
-        ),
+        help=("Evaluation output subdirectory under --workdir (default: eval)."),
     )
     _add_common_args(eval_parser)
 


### PR DESCRIPTION
This pull request makes a minor formatting change to the help text for the `--output-subdir` argument in the `build_parser` function. The change does not affect functionality and simply condenses the help string to a single line.