### PR TITLE
Add ViT MAE pretrain ablation

### DIFF
--- a/local_hydra/local_experiment/ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble.yaml
+++ b/local_hydra/local_experiment/ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble.yaml
@@ -1,0 +1,54 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: conditioned_navier_stokes
+  - override /encoder@model.encoder: permute_concat
+  - override /decoder@model.decoder: channels_last
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: ablation_vit_mae_pretrain_conditioned_navier_stokes
+
+datamodule:
+  use_normalization: true
+  # Match the CRPS ViT effective per-GPU batch:
+  # baseline CRPS uses batch_size=32 x n_members=8 = 256 examples.
+  batch_size: 256
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  train_in_latent_space: false
+  # n_members=1 keeps setup on deterministic EncoderProcessorDecoder.
+  n_members: 1
+  encoder:
+    with_constants: true
+  processor:
+    hidden_dim: 568
+    num_heads: 8
+    n_layers: 12
+    n_noise_channels: 1024
+  loss_func:
+    _target_: torch.nn.L1Loss
+  train_metrics:
+    mae:
+      _target_: autocast.metrics.MAE
+    rmse:
+      _target_: autocast.metrics.RMSE
+  val_metrics:
+    mae:
+      _target_: autocast.metrics.MAE
+    rmse:
+      _target_: autocast.metrics.RMSE

--- a/slurm_scripts/ablations/README.md
+++ b/slurm_scripts/ablations/README.md
@@ -24,6 +24,7 @@ small edit.
 | fm_vs_diffusion | comparison | CNS | 1 | stub |
 | arch_unet_fno_vit | comparison | CNS | 2 | stub |
 | model_size | sweep | CNS | 2 active (+2 staged) | in progress |
+| vit_mae_pretrain | pretrain | CNS | 1 | staged |
 | cached_latent_crps | comparison | CNS | 1 (done, 2026-04-20) | stub |
 | cond_global_vs_permute | comparison | CNS | 1 (done for CRPS-ViT, 2026-04-18) | stub |
 | eval_only/ode_steps | eval-only | FM runs | 0 | stub |

--- a/slurm_scripts/ablations/vit_mae_pretrain/README.md
+++ b/slurm_scripts/ablations/vit_mae_pretrain/README.md
@@ -1,0 +1,63 @@
+# ViT MAE pretraining
+
+Deterministic MAE pretraining run for the CNS ambient ViT baseline. The model
+keeps the CRPS ViT architecture from
+`local_hydra/local_experiment/epd/conditioned_navier_stokes/crps_vit_azula_large.yaml`
+but trains without the ensemble path:
+
+- `model.n_members=1`, which instantiates `EncoderProcessorDecoder` instead of
+  `EncoderProcessorDecoderEnsemble`.
+- `model.loss_func=torch.nn.L1Loss`, so `train_loss` and `val_loss` are MAE in
+  normalized space.
+- deterministic `MAE` and `RMSE` metrics replace ensemble CRPS metrics.
+- `datamodule.batch_size=256` preserves the CRPS baseline's effective per-GPU
+  batch size (`32 x 8 = 256`) now that there is no ensemble expansion.
+
+**Status:** staged - run timing first, then launch the 24h production script.
+
+## Files
+
+| file | purpose |
+|---|---|
+| `local_hydra/local_experiment/ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble.yaml` | CNS deterministic MAE preset |
+| `submit_vit_mae_pretrain_timing.sh` | 5-epoch timing run -> `timing.ckpt` |
+| `submit_vit_mae_pretrain_large.sh` | 24h production run, keeping and W&B-logging all progress checkpoints |
+
+## Workflow
+
+1. Submit timing:
+
+   ```bash
+   bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_pretrain_timing.sh
+   ```
+
+2. After the timing job finishes, collect the schedule:
+
+   ```bash
+   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
+   ```
+
+3. Paste the emitted `trainer.max_epochs` value into
+   `COSINE_EPOCHS_BY_DATASET` in `submit_vit_mae_pretrain_large.sh`, or leave it
+   blank and let the script derive it from the newest matching timing checkpoint.
+
+4. Submit the 24h pretraining run:
+
+   ```bash
+   bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_pretrain_large.sh
+   ```
+
+The production script intentionally runs dry-run first and then submits the real
+job, following the other ablation submitters.
+
+## Checkpoints and CRPS fine-tuning
+
+The 24h script saves local progress checkpoints every ~5% of optimizer-step
+progress with `save_top_k=-1`, keeps `last.ckpt`, and sets
+`logging.wandb.log_model=all` so W&B logs every checkpoint artifact emitted by
+the checkpoint callbacks.
+
+For the follow-up shortened CRPS fine-tune, start from one of these checkpoints
+with `resume_weights_only=true` rather than full-state resume. That loads the
+deterministic MAE weights into the CRPS ensemble model while starting a fresh
+optimizer, scheduler, and time budget.

--- a/slurm_scripts/ablations/vit_mae_pretrain/README.md
+++ b/slurm_scripts/ablations/vit_mae_pretrain/README.md
@@ -20,8 +20,10 @@ but trains without the ensemble path:
 | file | purpose |
 |---|---|
 | `local_hydra/local_experiment/ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble.yaml` | CNS deterministic MAE preset |
-| `submit_vit_mae_pretrain_timing.sh` | 5-epoch timing run -> `timing.ckpt` |
-| `submit_vit_mae_pretrain_large.sh` | 24h production run, keeping and W&B-logging all progress checkpoints |
+| `submit_vit_mae_pretrain_timing.sh` | 5-epoch MAE timing run -> `timing.ckpt` |
+| `submit_vit_mae_pretrain_large.sh` | 24h MAE production run, keeping and W&B-logging all progress checkpoints |
+| `submit_vit_mae_to_crps_timing.sh` | 5-epoch timing for MAE-initialized CRPS fine-tuning with `n_members=16` |
+| `submit_vit_mae_to_crps_large.sh` | short MAE-initialized CRPS fine-tune, defaulting to a 4h budget |
 
 ## Workflow
 
@@ -57,7 +59,22 @@ progress with `save_top_k=-1`, keeps `last.ckpt`, and sets
 `logging.wandb.log_model=all` so W&B logs every checkpoint artifact emitted by
 the checkpoint callbacks.
 
-For the follow-up shortened CRPS fine-tune, start from one of these checkpoints
-with `resume_weights_only=true` rather than full-state resume. That loads the
-deterministic MAE weights into the CRPS ensemble model while starting a fresh
-optimizer, scheduler, and time budget.
+For the follow-up shortened CRPS fine-tune, use the `vit_mae_to_crps` scripts
+and point `MAE_CHECKPOINT` at one of the MAE checkpoints:
+
+```bash
+MAE_CHECKPOINT=/path/to/mae/encoder_processor_decoder.ckpt \
+  bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
+
+MAE_CHECKPOINT=/path/to/mae/encoder_processor_decoder.ckpt \
+  bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
+```
+
+The CRPS fine-tune uses `n_members=16` with `datamodule.batch_size=16`, keeping
+the effective global batch at `16 x 16 x 4 GPUs = 1024`. It also uses
+`resume_weights_only=true` rather than full-state resume, so the deterministic
+MAE weights initialize the CRPS ensemble model while the optimizer, scheduler,
+and time budget start fresh.
+
+The default CRPS fine-tune budget is 4h. Override it for both timing and large
+runs with, for example, `CRPS_BUDGET_HOURS=6`.

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_pretrain_large.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_pretrain_large.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+# 24h deterministic ViT MAE pretraining on CNS.
+#
+# Populate COSINE_EPOCHS_BY_DATASET after running
+# submit_vit_mae_pretrain_timing.sh and extracting timing.ckpt with:
+#   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
+# If left blank, the script falls back to the newest matching timing.ckpt
+# under outputs/*/timing_vit_mae_pretrain/.
+
+declare -A EXPERIMENTS=(
+    ["conditioned_navier_stokes"]="ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble"
+)
+
+declare -A COSINE_EPOCHS_BY_DATASET=(
+    # ["conditioned_navier_stokes"]=...
+)
+
+BUDGET_MAX_TIME="00:23:59:00"
+TIMEOUT_MIN=1439
+RUN_DRY_STATES=("true" "false")
+RUN_GROUP="$(date +%Y-%m-%d)/vit_mae_pretrain"
+
+find_timing_checkpoint() {
+    local run_id="$1"
+
+    if [[ ! -d outputs ]]; then
+        return 0
+    fi
+
+    find outputs -path "*/timing_vit_mae_pretrain/${run_id}/timing.ckpt" | sort | tail -n 1
+}
+
+derive_cosine_epochs_from_timing() {
+    local timing_ckpt="$1"
+    local result
+
+    result="$(
+        uv run autocast time-epochs --from-checkpoint "${timing_ckpt}" -b 24
+    )"
+
+    sed -n 's/.*trainer.max_epochs=\([0-9][0-9]*\).*/\1/p' <<< "${result}" | tail -n 1
+}
+
+resolve_cosine_epochs() {
+    local datamodule="$1"
+    local cached="${COSINE_EPOCHS_BY_DATASET[$datamodule]:-}"
+
+    if [[ -n "${cached}" ]]; then
+        printf '%s\n' "${cached}"
+        return 0
+    fi
+
+    local run_id="vit_mae_pretrain_${datamodule}"
+    local timing_ckpt
+    timing_ckpt="$(find_timing_checkpoint "${run_id}")"
+
+    if [[ -z "${timing_ckpt}" ]]; then
+        return 1
+    fi
+
+    derive_cosine_epochs_from_timing "${timing_ckpt}"
+}
+
+for datamodule in "${!EXPERIMENTS[@]}"; do
+    experiment="${EXPERIMENTS[$datamodule]}"
+    if ! cosine_epochs="$(resolve_cosine_epochs "${datamodule}")"; then
+        echo "Skipping ${datamodule}: no timing-derived cosine_epochs available" >&2
+        continue
+    fi
+    if [[ -z "${cosine_epochs}" ]]; then
+        echo "Skipping ${datamodule}: could not parse trainer.max_epochs from timing output" >&2
+        continue
+    fi
+
+    wandb_name="vit_mae_pretrain_no_ensemble"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        dry_run_arg=()
+        run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting ViT MAE pretraining"
+        echo "  mode: ${run_label}"
+        echo "  datamodule: ${datamodule}"
+        echo "  local_experiment: ${experiment}"
+        echo "  cosine_epochs: ${cosine_epochs}"
+        echo "  wandb.name: ${wandb_name}"
+
+        uv run autocast epd --mode slurm "${dry_run_arg[@]}" \
+            --run-group "${RUN_GROUP}" \
+            datamodule="${datamodule}" \
+            local_experiment="${experiment}" \
+            logging.wandb.enabled=true \
+            logging.wandb.name="${wandb_name}" \
+            logging.wandb.log_model=all \
+            optimizer.cosine_epochs="${cosine_epochs}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+            trainer.max_time="${BUDGET_MAX_TIME}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_train_steps_fraction=0.05 \
+            trainer.callbacks.0.every_n_epochs=0 \
+            trainer.callbacks.0.save_top_k=-1 \
+            trainer.callbacks.0.filename=\"snapshot-{progress_token}-{epoch:04d}-{step:08d}\"
+    done
+done

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_pretrain_timing.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_pretrain_timing.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+# Timing run for deterministic ViT MAE pretraining on CNS.
+#
+# This starts from the CRPS ViT ambient architecture but disables the ensemble
+# path (n_members=1) and trains with torch.nn.L1Loss. Run this first, then
+# derive the 24h cosine schedule from timing.ckpt:
+#   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24
+
+declare -A EXPERIMENTS=(
+    ["conditioned_navier_stokes"]="ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble"
+)
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing_vit_mae_pretrain"
+
+for datamodule in "${!EXPERIMENTS[@]}"; do
+    experiment="${EXPERIMENTS[$datamodule]}"
+    run_id="vit_mae_pretrain_${datamodule}"
+
+    echo "Submitting ViT MAE pretrain timing run"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  run_id: ${run_id}"
+    echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+    echo "  budget: ${BUDGET_HOURS}h"
+    echo "  run_group: ${RUN_GROUP}"
+    echo ""
+
+    uv run autocast time-epochs --kind epd --mode slurm \
+        --run-group "${RUN_GROUP}" \
+        --run-id "${run_id}" \
+        -n "${NUM_TIMING_EPOCHS}" \
+        -b "${BUDGET_HOURS}" \
+        datamodule="${datamodule}" \
+        local_experiment="${experiment}"
+
+    echo ""
+    echo "---"
+    echo ""
+done
+
+echo "All ViT MAE pretrain timing jobs submitted."
+echo ""
+echo "Once SLURM jobs complete, collect all results with:"
+echo "  for f in outputs/${RUN_GROUP}/vit_mae_pretrain_*/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+set -euo pipefail
+# Short MAE-initialized CRPS fine-tuning run on CNS.
+#
+# Usage:
+#   MAE_CHECKPOINT=/path/to/mae/encoder_processor_decoder.ckpt \
+#     bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
+#
+# Run submit_vit_mae_to_crps_timing.sh first. If COSINE_EPOCHS_BY_DATASET is
+# left blank, this script derives max_epochs from the newest matching timing.ckpt.
+
+MAE_CHECKPOINT="${MAE_CHECKPOINT:-${1:-}}"
+if [[ -z "${MAE_CHECKPOINT}" ]]; then
+    echo "FATAL: set MAE_CHECKPOINT or pass the MAE checkpoint path as argv[1]" >&2
+    exit 1
+fi
+
+if [[ ! -f "${MAE_CHECKPOINT}" ]]; then
+    echo "FATAL: MAE_CHECKPOINT does not exist: ${MAE_CHECKPOINT}" >&2
+    exit 1
+fi
+
+declare -A EXPERIMENTS=(
+    ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large"
+)
+
+declare -A COSINE_EPOCHS_BY_DATASET=(
+    # ["conditioned_navier_stokes"]=...
+)
+
+CRPS_BUDGET_HOURS="${CRPS_BUDGET_HOURS:-4}"
+if ! [[ "${CRPS_BUDGET_HOURS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "FATAL: CRPS_BUDGET_HOURS must be a positive integer number of hours" >&2
+    exit 1
+fi
+
+BUDGET_MAX_TIME="$(printf "00:%02d:59:00" "$((CRPS_BUDGET_HOURS - 1))")"
+TIMEOUT_MIN=$((CRPS_BUDGET_HOURS * 60 - 1))
+RUN_DRY_STATES=("true" "false")
+RUN_GROUP="$(date +%Y-%m-%d)/vit_mae_to_crps"
+N_MEMBERS=16
+BS_PER_GPU=16
+
+find_timing_checkpoint() {
+    local run_id="$1"
+
+    if [[ ! -d outputs ]]; then
+        return 0
+    fi
+
+    find outputs -path "*/timing_vit_mae_to_crps/${run_id}/timing.ckpt" | sort | tail -n 1
+}
+
+derive_cosine_epochs_from_timing() {
+    local timing_ckpt="$1"
+    local result
+
+    result="$(
+        uv run autocast time-epochs \
+            --from-checkpoint "${timing_ckpt}" \
+            -b "${CRPS_BUDGET_HOURS}" \
+            -m 0.02
+    )"
+
+    sed -n 's/.*trainer.max_epochs=\([0-9][0-9]*\).*/\1/p' <<< "${result}" | tail -n 1
+}
+
+resolve_cosine_epochs() {
+    local datamodule="$1"
+    local cached="${COSINE_EPOCHS_BY_DATASET[$datamodule]:-}"
+
+    if [[ -n "${cached}" ]]; then
+        printf '%s\n' "${cached}"
+        return 0
+    fi
+
+    local run_id="vit_mae_to_crps_${datamodule}_m${N_MEMBERS}"
+    local timing_ckpt
+    timing_ckpt="$(find_timing_checkpoint "${run_id}")"
+
+    if [[ -z "${timing_ckpt}" ]]; then
+        return 1
+    fi
+
+    derive_cosine_epochs_from_timing "${timing_ckpt}"
+}
+
+for datamodule in "${!EXPERIMENTS[@]}"; do
+    experiment="${EXPERIMENTS[$datamodule]}"
+    if ! cosine_epochs="$(resolve_cosine_epochs "${datamodule}")"; then
+        echo "Skipping ${datamodule}: no timing-derived cosine_epochs available" >&2
+        continue
+    fi
+    if [[ -z "${cosine_epochs}" ]]; then
+        echo "Skipping ${datamodule}: could not parse trainer.max_epochs from timing output" >&2
+        continue
+    fi
+
+    wandb_name="vit_mae_to_crps_m${N_MEMBERS}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        dry_run_arg=()
+        run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting MAE-initialized CRPS fine-tuning"
+        echo "  mode: ${run_label}"
+        echo "  datamodule: ${datamodule}"
+        echo "  local_experiment: ${experiment}"
+        echo "  mae checkpoint: ${MAE_CHECKPOINT}"
+        echo "  n_members: ${N_MEMBERS}"
+        echo "  bs_per_gpu: ${BS_PER_GPU}"
+        echo "  budget: ${CRPS_BUDGET_HOURS}h"
+        echo "  cosine_epochs: ${cosine_epochs}"
+        echo "  wandb.name: ${wandb_name}"
+
+        uv run autocast epd --mode slurm "${dry_run_arg[@]}" \
+            --run-group "${RUN_GROUP}" \
+            datamodule="${datamodule}" \
+            local_experiment="${experiment}" \
+            model.n_members="${N_MEMBERS}" \
+            datamodule.batch_size="${BS_PER_GPU}" \
+            +resume_from_checkpoint="${MAE_CHECKPOINT}" \
+            +resume_weights_only=true \
+            logging.wandb.enabled=true \
+            logging.wandb.name="${wandb_name}" \
+            logging.wandb.log_model=all \
+            optimizer.cosine_epochs="${cosine_epochs}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+            trainer.max_time="${BUDGET_MAX_TIME}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_train_steps_fraction=0.05 \
+            trainer.callbacks.0.every_n_epochs=0 \
+            trainer.callbacks.0.save_top_k=-1 \
+            trainer.callbacks.0.filename=\"snapshot-{progress_token}-{epoch:04d}-{step:08d}\"
+    done
+done

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+# Timing run for MAE-initialized CRPS fine-tuning on CNS.
+#
+# Usage:
+#   MAE_CHECKPOINT=/path/to/mae/encoder_processor_decoder.ckpt \
+#     bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
+#
+# This fine-tune uses CRPS with n_members=16 and batch_size=16/GPU, keeping
+# the effective global batch at 16 x 16 x 4 GPUs = 1024.
+
+MAE_CHECKPOINT="${MAE_CHECKPOINT:-${1:-}}"
+if [[ -z "${MAE_CHECKPOINT}" ]]; then
+    echo "FATAL: set MAE_CHECKPOINT or pass the MAE checkpoint path as argv[1]" >&2
+    exit 1
+fi
+
+if [[ ! -f "${MAE_CHECKPOINT}" ]]; then
+    echo "FATAL: MAE_CHECKPOINT does not exist: ${MAE_CHECKPOINT}" >&2
+    exit 1
+fi
+
+declare -A EXPERIMENTS=(
+    ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large"
+)
+
+CRPS_BUDGET_HOURS="${CRPS_BUDGET_HOURS:-4}"
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing_vit_mae_to_crps"
+N_MEMBERS=16
+BS_PER_GPU=16
+
+for datamodule in "${!EXPERIMENTS[@]}"; do
+    experiment="${EXPERIMENTS[$datamodule]}"
+    run_id="vit_mae_to_crps_${datamodule}_m${N_MEMBERS}"
+
+    echo "Submitting MAE-initialized CRPS timing run"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  mae checkpoint: ${MAE_CHECKPOINT}"
+    echo "  n_members: ${N_MEMBERS}"
+    echo "  bs_per_gpu: ${BS_PER_GPU}"
+    echo "  run_id: ${run_id}"
+    echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+    echo "  budget: ${CRPS_BUDGET_HOURS}h"
+    echo "  run_group: ${RUN_GROUP}"
+    echo ""
+
+    uv run autocast time-epochs --kind epd --mode slurm \
+        --run-group "${RUN_GROUP}" \
+        --run-id "${run_id}" \
+        -n "${NUM_TIMING_EPOCHS}" \
+        -b "${CRPS_BUDGET_HOURS}" \
+        datamodule="${datamodule}" \
+        local_experiment="${experiment}" \
+        model.n_members="${N_MEMBERS}" \
+        datamodule.batch_size="${BS_PER_GPU}" \
+        +resume_from_checkpoint="${MAE_CHECKPOINT}" \
+        +resume_weights_only=true
+
+    echo ""
+    echo "---"
+    echo ""
+done
+
+echo "All MAE-initialized CRPS timing jobs submitted."
+echo ""
+echo "Once SLURM jobs complete, collect all results with:"
+echo "  for f in outputs/${RUN_GROUP}/vit_mae_to_crps_*/retrieve.sh; do bash \"\$f\"; done"


### PR DESCRIPTION
## Summary
- add CNS deterministic ViT MAE/no-ensemble pretrain preset
- add timing and 24h MAE Slurm submitters with all progress checkpoints retained and W&B checkpoint artifact logging
- add MAE-to-CRPS timing and short fine-tune submitters using n_members=16 and batch_size=16
- document workflow for using MAE checkpoints to seed later CRPS fine-tuning

## Validation
- bash -n slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_pretrain_timing.sh
- bash -n slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_pretrain_large.sh
- bash -n slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
- bash -n slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
- uv run autocast epd --mode local --dry-run datamodule=conditioned_navier_stokes local_experiment=ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble logging.wandb.enabled=false trainer.max_epochs=1
- uv run python -m autocast.scripts.train.encoder_processor_decoder --cfg job datamodule=conditioned_navier_stokes local_experiment=ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble logging.wandb.enabled=true logging.wandb.log_model=all +trainer.max_epochs=1
- uv run autocast epd --mode local --dry-run datamodule=conditioned_navier_stokes local_experiment=epd/conditioned_navier_stokes/crps_vit_azula_large model.n_members=16 datamodule.batch_size=16 +resume_from_checkpoint=/tmp/fake_mae.ckpt +resume_weights_only=true logging.wandb.enabled=true logging.wandb.log_model=all +trainer.max_epochs=1
- uv run python -m autocast.scripts.train.encoder_processor_decoder --cfg job datamodule=conditioned_navier_stokes local_experiment=epd/conditioned_navier_stokes/crps_vit_azula_large model.n_members=16 datamodule.batch_size=16 +resume_from_checkpoint=/tmp/fake_mae.ckpt +resume_weights_only=true logging.wandb.enabled=true logging.wandb.log_model=all +trainer.max_epochs=1