### PR TITLE
Window best checkpoints for coverage/winkler

### DIFF
--- a/slurm_scripts/ablations/ensemble_size/submit_ensemble_large.sh
+++ b/slurm_scripts/ablations/ensemble_size/submit_ensemble_large.sh
@@ -120,7 +120,7 @@ resolve_cosine_epochs() {
 declare -A DATASETS=(
     ["gray_scott"]="epd/gray_scott/crps_vit_azula_large"
     ["gpe_laser_only_wake"]="epd/gpe_laser_wake_only/crps_vit_azula_large"
-    # ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large"
+    ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large"
     ["advection_diffusion"]="epd/advection_diffusion/crps_vit_azula_large"
 )
 
@@ -128,6 +128,7 @@ declare -A REGIMES_BY_DATASET=(
     ["gray_scott"]="eff_bs1024"
     ["gpe_laser_only_wake"]="eff_bs1024"
     # ["conditioned_navier_stokes"]="fixed_bs32 eff_bs1024"
+    ["conditioned_navier_stokes"]="eff_bs1024"
     ["advection_diffusion"]="eff_bs1024"
 )
 

--- a/src/autocast/callbacks/checkpoint.py
+++ b/src/autocast/callbacks/checkpoint.py
@@ -19,6 +19,8 @@ class ProgressModelCheckpoint(ModelCheckpoint):
       estimated number of optimizer steps in the run.
     - ``start_after_fraction`` delays monitored top-k checkpointing until a
       chosen fraction of training has completed.
+    - ``stop_after_fraction`` stops monitored top-k checkpointing once a chosen
+      fraction of training has completed.
 
     ``save_last`` continues to behave exactly as in ``ModelCheckpoint``.
     """
@@ -27,6 +29,7 @@ class ProgressModelCheckpoint(ModelCheckpoint):
         self,
         *,
         start_after_fraction: float = 0.0,
+        stop_after_fraction: float | None = None,
         every_n_train_steps_fraction: float | None = None,
         monitor_optional: bool = False,
         **kwargs: Any,
@@ -40,6 +43,20 @@ class ProgressModelCheckpoint(ModelCheckpoint):
         if not 0.0 <= start_after_fraction <= 1.0:
             raise ValueError(
                 f"start_after_fraction must be in [0, 1], got {start_after_fraction}."
+            )
+        if stop_after_fraction is not None and not 0.0 <= stop_after_fraction <= 1.0:
+            raise ValueError(
+                f"stop_after_fraction must be in [0, 1], got {stop_after_fraction}."
+            )
+        if (
+            stop_after_fraction is not None
+            and stop_after_fraction > 0.0
+            and stop_after_fraction < start_after_fraction
+        ):
+            raise ValueError(
+                "stop_after_fraction must be >= start_after_fraction when set, "
+                f"got start_after_fraction={start_after_fraction}, "
+                f"stop_after_fraction={stop_after_fraction}."
             )
         if every_n_train_steps_fraction is not None and not (
             0.0 < every_n_train_steps_fraction <= 1.0
@@ -69,6 +86,7 @@ class ProgressModelCheckpoint(ModelCheckpoint):
                 raise ValueError(msg)
 
         self.start_after_fraction = start_after_fraction
+        self.stop_after_fraction = stop_after_fraction
         self.every_n_train_steps_fraction = every_n_train_steps_fraction
         self.monitor_optional = monitor_optional
         self._resolved_fractional_steps = False
@@ -165,9 +183,15 @@ class ProgressModelCheckpoint(ModelCheckpoint):
         return f"{progress_hundredths // 100}p{progress_hundredths % 100:02d}"
 
     def _monitor_ready(self, trainer: L.Trainer) -> bool:
-        if self.monitor is None or self.start_after_fraction <= 0.0:
+        if self.monitor is None:
             return True
-        return self._training_progress_fraction(trainer) >= self.start_after_fraction
+
+        progress = self._training_progress_fraction(trainer)
+        if self.start_after_fraction > 0.0 and progress < self.start_after_fraction:
+            return False
+        return not (
+            self.stop_after_fraction is not None and progress > self.stop_after_fraction
+        )
 
     def _save_topk_checkpoint(
         self, trainer: L.Trainer, monitor_candidates: dict[str, Any]

--- a/src/autocast/callbacks/metrics.py
+++ b/src/autocast/callbacks/metrics.py
@@ -240,7 +240,15 @@ class ValidationMetricPlotCallback(Callback):
                         payload[key] = wandb_image
                 if not payload:
                     payload[key] = fig
-                experiment.log(payload, step=step)
+                if self._is_wandb_experiment(experiment):
+                    # Passing step= forces wandb's internal _step to jump to
+                    # trainer.global_step, which is orders of magnitude ahead of
+                    # the auto-incremented _step used by Lightning's WandbLogger.
+                    # That collapses the default "Step" X-axis for every other
+                    # metric into stepped plateaus. Let wandb auto-increment.
+                    experiment.log(payload)
+                else:
+                    experiment.log(payload, step=step)
 
     @staticmethod
     def _is_wandb_experiment(experiment: Any) -> bool:

--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -31,9 +31,41 @@ callbacks:
     save_last: false  # rolling callback above owns last.ckpt
     filename: "best-val-{epoch:04d}-{val_loss:.4f}"
     auto_insert_metric_name: false
+  # Optional coverage checkpoint for early phase (<= 0.25). Stops updating after
+  # the burn-in cutoff.
+  - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
+    monitor: val_multicoverage
+    monitor_optional: true
+    stop_after_fraction: 0.25
+    mode: min
+    save_top_k: 1
+    save_last: false
+    filename: "best-multicov-pre0p25-{epoch:04d}-{val_multicoverage:.4f}"
+    auto_insert_metric_name: false
+  # Optional interval-score checkpoint for early phase (<= 0.25). Stops updating
+  # after the burn-in cutoff.
+  - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
+    monitor: val_multiwinkler
+    monitor_optional: true
+    stop_after_fraction: 0.25
+    mode: min
+    save_top_k: 1
+    save_last: false
+    filename: "best-multiwinkler-pre0p25-{epoch:04d}-{val_multiwinkler:.4f}"
+    auto_insert_metric_name: false
   # Optional coverage-oriented checkpoint. This stays dormant unless the model
   # logs `val_multicoverage`, and only starts tracking once training is half done
   # to avoid anchoring on the noisy early phase.
+  - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
+    monitor: val_multicoverage
+    monitor_optional: true
+    start_after_fraction: 0.25
+    mode: min
+    save_top_k: 1
+    save_last: false
+    filename: "best-multicov-from0p25-{epoch:04d}-{val_multicoverage:.4f}"
+    auto_insert_metric_name: false
+  # Optional coverage checkpoint for later phase (>= 0.50).
   - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
     monitor: val_multicoverage
     monitor_optional: true
@@ -41,7 +73,17 @@ callbacks:
     mode: min
     save_top_k: 1
     save_last: false
-    filename: "best-multicov-{epoch:04d}-{val_multicoverage:.4f}"
+    filename: "best-multicov-from0p50-{epoch:04d}-{val_multicoverage:.4f}"
+    auto_insert_metric_name: false
+  # Optional coverage checkpoint for very-late phase (>= 0.75).
+  - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
+    monitor: val_multicoverage
+    monitor_optional: true
+    start_after_fraction: 0.75
+    mode: min
+    save_top_k: 1
+    save_last: false
+    filename: "best-multicov-from0p75-{epoch:04d}-{val_multicoverage:.4f}"
     auto_insert_metric_name: false
   # Optional interval-score checkpoint. MultiWinkler rewards sharper intervals
   # but penalizes misses across a grid of central coverage levels, so it is a
@@ -49,11 +91,31 @@ callbacks:
   - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
     monitor: val_multiwinkler
     monitor_optional: true
+    start_after_fraction: 0.25
+    mode: min
+    save_top_k: 1
+    save_last: false
+    filename: "best-multiwinkler-from0p25-{epoch:04d}-{val_multiwinkler:.4f}"
+    auto_insert_metric_name: false
+  # Optional interval-score checkpoint for later phase (>= 0.50).
+  - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
+    monitor: val_multiwinkler
+    monitor_optional: true
     start_after_fraction: 0.5
     mode: min
     save_top_k: 1
     save_last: false
-    filename: "best-multiwinkler-{epoch:04d}-{val_multiwinkler:.4f}"
+    filename: "best-multiwinkler-from0p50-{epoch:04d}-{val_multiwinkler:.4f}"
+    auto_insert_metric_name: false
+  # Optional interval-score checkpoint for very-late phase (>= 0.75).
+  - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
+    monitor: val_multiwinkler
+    monitor_optional: true
+    start_after_fraction: 0.75
+    mode: min
+    save_top_k: 1
+    save_last: false
+    filename: "best-multiwinkler-from0p75-{epoch:04d}-{val_multiwinkler:.4f}"
     auto_insert_metric_name: false
   # Plot scalar validation metric histories and custom metric diagnostics
   # such as the MultiCoverage reliability curve at each validation end.

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -502,6 +502,48 @@ def test_validation_metric_plot_callback_saves_custom_metric_plot(tmp_path: Path
     ).exists()
 
 
+def test_validation_metric_plot_callback_wandb_log_omits_step(tmp_path: Path):
+    callback = ValidationMetricPlotCallback(
+        save_local=False,
+        log_to_logger=True,
+        plot_metric_objects=False,
+    )
+
+    class FakeWandbRun:
+        project = "p"
+        entity = "e"
+
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        def log(self, payload, step=None):
+            self.calls.append({"payload": payload, "step": step})
+
+    run = FakeWandbRun()
+    logger = SimpleNamespace(experiment=run)
+    trainer = SimpleNamespace(
+        callback_metrics={"val_loss": torch.tensor(1.5)},
+        default_root_dir=tmp_path,
+        global_step=1189,
+        is_global_zero=True,
+        sanity_checking=False,
+        loggers=[logger],
+    )
+    pl_module = SimpleNamespace(val_metrics=None)
+
+    callback.on_validation_end(
+        cast(L.Trainer, trainer), cast(L.LightningModule, pl_module)
+    )
+
+    assert run.calls, "expected at least one wandb.log call"
+    for call in run.calls:
+        assert call["step"] is None, (
+            "wandb.log must not receive an explicit step= argument; "
+            "passing trainer.global_step forces wandb's internal _step forward "
+            "and breaks the default X-axis for all other metrics."
+        )
+
+
 def test_default_trainer_config_tracks_coverage_winkler_and_plots(config_dir: str):
     trainer_cfg = OmegaConf.load(Path(config_dir) / "trainer" / "default.yaml")
     callbacks = list(trainer_cfg.callbacks)


### PR DESCRIPTION
This pull request introduces improvements to checkpointing flexibility and logging behavior, particularly for metric-based checkpoints during training. The main changes include adding an option to stop saving top-k checkpoints after a certain training fraction, updating the default trainer configuration to use this new option for more granular checkpointing, and fixing an issue with explicit step logging in wandb. Additionally, a previously commented-out dataset regime is now enabled.

**Checkpointing enhancements:**

* Added a new `stop_after_fraction` parameter to the `ProgressModelCheckpoint` callback, allowing users to specify when top-k checkpointing should stop based on training progress. This includes input validation and updated logic to respect the new parameter. [[1]](diffhunk://#diff-144f12423cfe3da41d529f0ea87e83ef991d7a06f2ab0109bebf3deaac6bbc42R22-R23) [[2]](diffhunk://#diff-144f12423cfe3da41d529f0ea87e83ef991d7a06f2ab0109bebf3deaac6bbc42R32) [[3]](diffhunk://#diff-144f12423cfe3da41d529f0ea87e83ef991d7a06f2ab0109bebf3deaac6bbc42R47-R60) [[4]](diffhunk://#diff-144f12423cfe3da41d529f0ea87e83ef991d7a06f2ab0109bebf3deaac6bbc42R89) [[5]](diffhunk://#diff-144f12423cfe3da41d529f0ea87e83ef991d7a06f2ab0109bebf3deaac6bbc42L168-R194)
* Updated `default.yaml` trainer configuration to add early-phase checkpoints (ending at 0.25 training fraction) and late-phase checkpoints (starting at 0.25, 0.5, and 0.75 fractions) for both `val_multicoverage` and `val_multiwinkler` metrics, utilizing the new `stop_after_fraction` and `start_after_fraction` options for finer checkpoint control.

**Logging and metrics:**

* Modified the `ValidationMetricPlotCallback` to avoid passing the `step` argument to `wandb.log`, preventing issues with the X-axis in wandb plots. This is now tested with a new unit test to ensure correct behavior. [[1]](diffhunk://#diff-41555060d34759ec5314557ec8752be246c74b8f90fa40a78bfdd0de1dcf3a21R243-R250) [[2]](diffhunk://#diff-58bd482e850320831d84e66aa32948bbed9ab77b8be233e7717b1426690eab24R505-R546)

**Dataset configuration:**

* Enabled the `conditioned_navier_stokes` dataset and its associated regime in the ensemble submission script, which was previously commented out.## Summary
- Add `stop_after_fraction` to `ProgressModelCheckpoint` to support bounded best-checkpoint windows.
- Save windowed best checkpoints for `val_multicoverage` and `val_multiwinkler` across early (<=0.25) and late phases (>=0.25/0.50/0.75), with clearer filenames.
- Avoid passing explicit `step=` to `wandb.log` for validation metric plots to prevent WandB step-axis distortion.

## Test plan
- [x] `pytest -q`