### PR TITLE
Add CNS AE compression ablations

### DIFF
--- a/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_c2.yaml
+++ b/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_c2.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - /local_experiment/ae/conditioned_navier_stokes/ae_dc_large
+  - _self_
+
+experiment_name: ablation_ae_compression_dc_large_c2_conditioned_navier_stokes
+
+# Latent-channel sweep on the main-study AE (3-level, widths [128,256,512]):
+# latent channels reduced 8 -> 2 with all other config preserved. Param
+# count is unchanged to within ~0.1% (only the final encoder/initial
+# decoder projections scale with C), so the ~49M budget is preserved and
+# the latent-channel axis is isolated. Latent geometry: 16x16x2 (24x
+# channel-volume compression for CNS at 64x64x3 ambient).
+model:
+  encoder:
+    out_channels: 2
+  decoder:
+    in_channels: 2

--- a/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8.yaml
+++ b/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+defaults:
+  - /local_experiment/ae/conditioned_navier_stokes/ae_dc_large
+  - _self_
+
+experiment_name: ablation_ae_compression_dc_large_f8_conditioned_navier_stokes
+
+# 4-level encoder/decoder: 64 -> 32 -> 16 -> 8 spatial.
+# Widths scaled down (64,128,256,512) so total params stay ~constant vs the
+# 3-level baseline (128,256,512). Latent channels held at 8 to isolate
+# spatial compression as the only delta vs the main-study AE.
+model:
+  encoder:
+    hid_channels: [64, 128, 256, 512]
+    hid_blocks: [3, 3, 3, 3]
+  decoder:
+    hid_channels: [512, 256, 128, 64]
+    hid_blocks: [3, 3, 3, 3]

--- a/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8.yaml
+++ b/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8.yaml
@@ -1,5 +1,6 @@
 # @package _global_
 defaults:
+  - /distributed: ddp_4gpu_slurm
   - /local_experiment/ae/conditioned_navier_stokes/ae_dc_large
   - _self_
 

--- a/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_100m.yaml
+++ b/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_100m.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - /local_experiment/ae/conditioned_navier_stokes/ae_dc_large
+  - _self_
+
+experiment_name: ablation_ae_compression_dc_large_f8_100m_conditioned_navier_stokes
+
+# Capacity sweep on top of the f8 ablation: widths sized to land at ~100M
+# total params (encoder + decoder), keeping the strict 1:2:4:8 ratio.
+# Tests whether the f8 en/decoder is under-provisioned at 24x compression.
+model:
+  encoder:
+    hid_channels: [90, 180, 360, 720]
+    hid_blocks: [3, 3, 3, 3]
+  decoder:
+    hid_channels: [720, 360, 180, 90]
+    hid_blocks: [3, 3, 3, 3]

--- a/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_150m.yaml
+++ b/local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_150m.yaml
@@ -1,0 +1,17 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - /local_experiment/ae/conditioned_navier_stokes/ae_dc_large
+  - _self_
+
+experiment_name: ablation_ae_compression_dc_large_f8_150m_conditioned_navier_stokes
+
+# Capacity sweep on top of the f8 ablation: widths sized to land at ~150M
+# total params (153M, +2% of target), keeping the strict 1:2:4:8 ratio.
+model:
+  encoder:
+    hid_channels: [112, 224, 448, 896]
+    hid_blocks: [3, 3, 3, 3]
+  decoder:
+    hid_channels: [896, 448, 224, 112]
+    hid_blocks: [3, 3, 3, 3]

--- a/local_hydra/local_experiment/cache_latents/conditioned_navier_stokes/cache_latents_f8.yaml
+++ b/local_hydra/local_experiment/cache_latents/conditioned_navier_stokes/cache_latents_f8.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+defaults:
+  - /local_experiment/cache_latents/conditioned_navier_stokes/cache_latents
+  - _self_
+
+experiment_name: cache_latents_conditioned_navier_stokes_f8
+
+# Must match the f8 AE training config so encoder/decoder architectures align
+# with the checkpoint weights during cache_latents setup.
+model:
+  encoder:
+    hid_channels: [64, 128, 256, 512]
+    hid_blocks: [3, 3, 3, 3]
+  decoder:
+    hid_channels: [512, 256, 128, 64]
+    hid_blocks: [3, 3, 3, 3]

--- a/local_hydra/local_experiment/cache_latents/conditioned_navier_stokes/cache_latents_f8.yaml
+++ b/local_hydra/local_experiment/cache_latents/conditioned_navier_stokes/cache_latents_f8.yaml
@@ -6,7 +6,12 @@ defaults:
 experiment_name: cache_latents_conditioned_navier_stokes_f8
 
 # Must match the f8 AE training config so encoder/decoder architectures align
-# with the checkpoint weights during cache_latents setup.
+# with the checkpoint weights during cache_latents setup. The validator in
+# validate_cached_latents_against_ae.sh parses this file directly (does not
+# follow Hydra defaults), so use_normalization must be declared here.
+datamodule:
+  use_normalization: true
+
 model:
   encoder:
     hid_channels: [64, 128, 256, 512]

--- a/slurm_scripts/ablations/ae_compression/README.md
+++ b/slurm_scripts/ablations/ae_compression/README.md
@@ -1,0 +1,36 @@
+# AE compression ablation (CNS-only)
+
+CNS autoencoder trained at 8×8×8 latent (24× compression) for comparison
+with the main-study AE at 16×16×8 (4×). See
+`slurm_scripts/comparison/README.md` for the main-study design.
+
+## Configuration
+
+| | main study | this ablation |
+|---|---|---|
+| latent | 16×16×8 | 8×8×8 |
+| compression | 4× | 24× |
+| encoder `hid_channels` | `[128,256,512]` | `[64,128,256,512]` |
+| encoder `hid_blocks` | `[3,3,3]` | `[3,3,3,3]` |
+| latent channels | 8 | 8 |
+| trainable params | ~49M (24.5M enc + 24.5M dec) | ~50M (+2.1%) |
+| schedule | `COSINE_EPOCHS=512` | `COSINE_EPOCHS=512` |
+
+The DC encoder downsamples between adjacent levels, so N levels gives N-1
+downsamples (3 → 64 → 16; 4 → 64 → 8).
+
+## Files
+
+| file | purpose |
+|---|---|
+| `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8.yaml` | overrides on top of the baseline AE config |
+| `submit_ae_compression_large.sh` | 24h production run, `COSINE_EPOCHS=512` |
+| `submit_ae_compression_timing.sh` | 5-epoch timing run, fallback if 512 wall-clocks out |
+
+## Workflow
+
+1. `bash submit_ae_compression_large.sh`
+2. If the run hits the 24h wall: `bash submit_ae_compression_timing.sh`,
+   then extract a fitted value via
+   `uv run autocast time-epochs --from-checkpoint <timing_path>/timing.ckpt -b 24`
+   and re-run with that `COSINE_EPOCHS`.

--- a/slurm_scripts/ablations/ae_compression/README.md
+++ b/slurm_scripts/ablations/ae_compression/README.md
@@ -6,15 +6,28 @@ with the main-study AE at 16×16×8 (4×). See
 
 ## Configuration
 
-| | main study | this ablation |
-|---|---|---|
-| latent | 16×16×8 | 8×8×8 |
-| compression | 4× | 24× |
-| encoder `hid_channels` | `[128,256,512]` | `[64,128,256,512]` |
-| encoder `hid_blocks` | `[3,3,3]` | `[3,3,3,3]` |
-| latent channels | 8 | 8 |
-| trainable params | ~49M (24.5M enc + 24.5M dec) | ~50M (+2.1%) |
-| schedule | `COSINE_EPOCHS=512` | `COSINE_EPOCHS=512` |
+The base ablation matches the main-study AE param budget; the 100M and
+150M variants form a capacity sweep at fixed 24× compression to test
+whether the f8 en/decoder is under-provisioned at the harder bottleneck.
+
+| | main study | f8 base | f8 100M | f8 150M |
+|---|---|---|---|---|
+| latent | 16×16×8 | 8×8×8 | 8×8×8 | 8×8×8 |
+| compression | 4× | 24× | 24× | 24× |
+| encoder `hid_channels` | `[128,256,512]` | `[64,128,256,512]` | `[90,180,360,720]` | `[112,224,448,896]` |
+| encoder `hid_blocks` | `[3,3,3]` | `[3,3,3,3]` | `[3,3,3,3]` | `[3,3,3,3]` |
+| latent channels | 8 | 8 | 8 | 8 |
+| trainable params | ~49M | ~50M | ~99M (1.98×) | ~153M (3.06×) |
+| schedule | `COSINE_EPOCHS=512` | `COSINE_EPOCHS=512` | `COSINE_EPOCHS=256` | `COSINE_EPOCHS=256` |
+
+Widths follow a strict 1:2:4:8 ratio across all variants; the 100M and
+150M widths are sized to land at their target param counts. Both 100M and
+150M use the same `COSINE_EPOCHS=256` for an apples-to-apples comparison
+on a shared schedule. FLOPs/epoch scale ~linearly with params at fixed
+latent grid, so the 100M run (~14h linear) sits comfortably within the
+24h wall, while the 150M run (~21h linear) is expected to wall before
+the schedule fully completes — checkpoint callbacks preserve the best
+state.
 
 The DC encoder downsamples between adjacent levels, so N levels gives N-1
 downsamples (3 → 64 → 16; 4 → 64 → 8).
@@ -23,14 +36,19 @@ downsamples (3 → 64 → 16; 4 → 64 → 8).
 
 | file | purpose |
 |---|---|
-| `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8.yaml` | overrides on top of the baseline AE config |
-| `submit_ae_compression_large.sh` | 24h production run, `COSINE_EPOCHS=512` |
-| `submit_ae_compression_timing.sh` | 5-epoch timing run, fallback if 512 wall-clocks out |
+| `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8.yaml` | base ablation (50M, 4-level f8) |
+| `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_100m.yaml` | widths `[90,180,360,720]`, ~99M |
+| `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_150m.yaml` | widths `[112,224,448,896]`, ~153M |
+| `submit_ae_compression_large.sh` | base 50M run, `COSINE_EPOCHS=512` |
+| `submit_ae_compression_100m.sh` | 100M run, `COSINE_EPOCHS=256` |
+| `submit_ae_compression_150m.sh` | 150M run, `COSINE_EPOCHS=256` |
+| `submit_ae_compression_timing.sh` | 5-epoch timing run, fallback if a run wall-clocks out |
 
 ## Workflow
 
-1. `bash submit_ae_compression_large.sh`
-2. If the run hits the 24h wall: `bash submit_ae_compression_timing.sh`,
+1. `bash submit_ae_compression_large.sh` (base 50M)
+2. `bash submit_ae_compression_100m.sh` and `bash submit_ae_compression_150m.sh` (capacity sweep)
+3. If a run hits the 24h wall: `bash submit_ae_compression_timing.sh`,
    then extract a fitted value via
    `uv run autocast time-epochs --from-checkpoint <timing_path>/timing.ckpt -b 24`
    and re-run with that `COSINE_EPOCHS`.

--- a/slurm_scripts/ablations/ae_compression/README.md
+++ b/slurm_scripts/ablations/ae_compression/README.md
@@ -9,16 +9,18 @@ with the main-study AE at 16×16×8 (4×). See
 The base ablation matches the main-study AE param budget; the 100M and
 150M variants form a capacity sweep at fixed 24× compression to test
 whether the f8 en/decoder is under-provisioned at the harder bottleneck.
+The C=2 variant reuses the main-study widths but reduces latent channels
+to isolate the latent-channel axis at fixed param budget.
 
-| | main study | f8 base | f8 100M | f8 150M |
-|---|---|---|---|---|
-| latent | 16×16×8 | 8×8×8 | 8×8×8 | 8×8×8 |
-| compression | 4× | 24× | 24× | 24× |
-| encoder `hid_channels` | `[128,256,512]` | `[64,128,256,512]` | `[90,180,360,720]` | `[112,224,448,896]` |
-| encoder `hid_blocks` | `[3,3,3]` | `[3,3,3,3]` | `[3,3,3,3]` | `[3,3,3,3]` |
-| latent channels | 8 | 8 | 8 | 8 |
-| trainable params | ~49M | ~50M | ~99M (1.98×) | ~153M (3.06×) |
-| schedule | `COSINE_EPOCHS=512` | `COSINE_EPOCHS=512` | `COSINE_EPOCHS=256` | `COSINE_EPOCHS=256` |
+| | main study | f8 base | f8 100M | f8 150M | C=2 |
+|---|---|---|---|---|---|
+| latent | 16×16×8 | 8×8×8 | 8×8×8 | 8×8×8 | 16×16×2 |
+| compression | 4× | 24× | 24× | 24× | 24× |
+| encoder `hid_channels` | `[128,256,512]` | `[64,128,256,512]` | `[90,180,360,720]` | `[112,224,448,896]` | `[128,256,512]` |
+| encoder `hid_blocks` | `[3,3,3]` | `[3,3,3,3]` | `[3,3,3,3]` | `[3,3,3,3]` | `[3,3,3]` |
+| latent channels | 8 | 8 | 8 | 8 | 2 |
+| trainable params | ~49M | ~50M | ~99M (1.98×) | ~153M (3.06×) | ~49M |
+| schedule | `COSINE_EPOCHS=512` | `COSINE_EPOCHS=512` | `COSINE_EPOCHS=256` | `COSINE_EPOCHS=256` | `COSINE_EPOCHS=512` |
 
 Widths follow a strict 1:2:4:8 ratio across all variants; the 100M and
 150M widths are sized to land at their target param counts. Both 100M and
@@ -39,16 +41,37 @@ downsamples (3 → 64 → 16; 4 → 64 → 8).
 | `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8.yaml` | base ablation (50M, 4-level f8) |
 | `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_100m.yaml` | widths `[90,180,360,720]`, ~99M |
 | `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_150m.yaml` | widths `[112,224,448,896]`, ~153M |
+| `local_hydra/local_experiment/ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_c2.yaml` | main-study widths, latent channels = 2 (~49M, 24× compression, 16×16×2) |
 | `submit_ae_compression_large.sh` | base 50M run, `COSINE_EPOCHS=512` |
 | `submit_ae_compression_100m.sh` | 100M run, `COSINE_EPOCHS=256` |
 | `submit_ae_compression_150m.sh` | 150M run, `COSINE_EPOCHS=256` |
+| `submit_ae_compression_c2.sh` | C=2 run, `COSINE_EPOCHS=512` |
 | `submit_ae_compression_timing.sh` | 5-epoch timing run, fallback if a run wall-clocks out |
+| `submit_cache_latents_f8.sh` | cache f8 latents from `ae_cns64_de1b4b7_e1059d7` |
+| `submit_fm_f8_timing.sh` | 5-epoch FM-in-latent timing run on f8 latents |
+| `submit_fm_f8_large.sh` | 24h FM-in-latent run on f8 latents (placeholder `COSINE_EPOCHS`) |
 
 ## Workflow
 
 1. `bash submit_ae_compression_large.sh` (base 50M)
 2. `bash submit_ae_compression_100m.sh` and `bash submit_ae_compression_150m.sh` (capacity sweep)
-3. If a run hits the 24h wall: `bash submit_ae_compression_timing.sh`,
+3. `bash submit_ae_compression_c2.sh` (latent-channel sweep at fixed 50M)
+4. If a run hits the 24h wall: `bash submit_ae_compression_timing.sh`,
    then extract a fitted value via
    `uv run autocast time-epochs --from-checkpoint <timing_path>/timing.ckpt -b 24`
    and re-run with that `COSINE_EPOCHS`.
+
+### FM-in-latent follow-up (post-AE)
+
+Once `ae_cns64_de1b4b7_e1059d7` (base 50M f8) finishes:
+
+1. `bash submit_cache_latents_f8.sh` — caches latents into `<ae_run_dir>/cached_latents/`.
+2. `bash submit_fm_f8_timing.sh` — 5-epoch timing on the smaller 8×8 latent
+   (the main-study `COSINE_EPOCHS=3223` was timed on 16×16 latents and is
+   not directly transferable).
+3. Update `COSINE_EPOCHS` in `submit_fm_f8_large.sh` from the timing
+   output, then `bash submit_fm_f8_large.sh`.
+
+Reuses `processor/conditioned_navier_stokes/fm_vit_large.yaml` unchanged
+— the `vit` backbone with `patch_size=1` adapts to the smaller spatial
+grid automatically.

--- a/slurm_scripts/ablations/ae_compression/submit_ae_compression_100m.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_ae_compression_100m.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+# CNS f8 capacity sweep — ~100M params (99M, widths [90,180,360,720]).
+# 256 epochs to stay within the 24h wall: 99M ~= 1.98x FLOPs/epoch vs the
+# 50M run (which used ~14h at 512 epochs), so 256 epochs ~= 14h linear,
+# allowing for 1.3x empirical slowdown still leaves comfortable margin.
+COSINE_EPOCHS=256
+
+BUDGET_MAX_TIME="01:00:00:00"
+TIMEOUT_MIN=1439
+RUN_DRY_STATES=("true" "false")
+
+datamodule="conditioned_navier_stokes"
+experiment="ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_100m"
+
+for run_dry in "${RUN_DRY_STATES[@]}"; do
+    dry_run_arg=()
+    run_label="slurm"
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+        run_label="slurm --dry-run"
+    fi
+
+    echo "Submitting AE compression 100M run"
+    echo "  mode: ${run_label}"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  cosine_epochs: ${COSINE_EPOCHS}"
+
+    uv run autocast ae --mode slurm "${dry_run_arg[@]}" \
+        datamodule="${datamodule}" \
+        local_experiment="${experiment}" \
+        logging.wandb.enabled=true \
+        +optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+        hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+        trainer.max_time="${BUDGET_MAX_TIME}" \
+        +trainer.max_epochs="${COSINE_EPOCHS}"
+done

--- a/slurm_scripts/ablations/ae_compression/submit_ae_compression_150m.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_ae_compression_150m.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+# CNS f8 capacity sweep — ~150M params (153M, widths [112,224,448,896]).
+# 256 epochs matches the 100M run for an apples-to-apples comparison: 153M
+# ~= 3.06x FLOPs/epoch vs the 50M run (~14h at 512 epochs) -> 256 epochs
+# ~= 21h linear. May wall-out before full schedule completion under any
+# empirical slowdown — checkpoint callbacks preserve the best state.
+COSINE_EPOCHS=256
+
+BUDGET_MAX_TIME="01:00:00:00"
+TIMEOUT_MIN=1439
+RUN_DRY_STATES=("true" "false")
+
+datamodule="conditioned_navier_stokes"
+experiment="ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8_150m"
+
+for run_dry in "${RUN_DRY_STATES[@]}"; do
+    dry_run_arg=()
+    run_label="slurm"
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+        run_label="slurm --dry-run"
+    fi
+
+    echo "Submitting AE compression 150M run"
+    echo "  mode: ${run_label}"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  cosine_epochs: ${COSINE_EPOCHS}"
+
+    uv run autocast ae --mode slurm "${dry_run_arg[@]}" \
+        datamodule="${datamodule}" \
+        local_experiment="${experiment}" \
+        logging.wandb.enabled=true \
+        +optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+        hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+        trainer.max_time="${BUDGET_MAX_TIME}" \
+        +trainer.max_epochs="${COSINE_EPOCHS}"
+done

--- a/slurm_scripts/ablations/ae_compression/submit_ae_compression_c2.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_ae_compression_c2.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+# CNS latent-channel sweep on the main-study AE — ~49M params, C=2.
+# Same widths and FLOPs/epoch as the main-study AE, so COSINE_EPOCHS=512
+# matches submit_ae_compression_large.sh (and the main-study schedule)
+# on equal-schedule footing.
+COSINE_EPOCHS=512
+
+BUDGET_MAX_TIME="01:00:00:00"
+TIMEOUT_MIN=1439
+RUN_DRY_STATES=("true" "false")
+
+datamodule="conditioned_navier_stokes"
+experiment="ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_c2"
+
+for run_dry in "${RUN_DRY_STATES[@]}"; do
+    dry_run_arg=()
+    run_label="slurm"
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+        run_label="slurm --dry-run"
+    fi
+
+    echo "Submitting AE compression C=2 run"
+    echo "  mode: ${run_label}"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  cosine_epochs: ${COSINE_EPOCHS}"
+
+    uv run autocast ae --mode slurm "${dry_run_arg[@]}" \
+        datamodule="${datamodule}" \
+        local_experiment="${experiment}" \
+        logging.wandb.enabled=true \
+        +optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+        hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+        trainer.max_time="${BUDGET_MAX_TIME}" \
+        +trainer.max_epochs="${COSINE_EPOCHS}"
+done

--- a/slurm_scripts/ablations/ae_compression/submit_ae_compression_large.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_ae_compression_large.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euo pipefail
+# CNS-only AE compression ablation — 24h production run.
+# Uses COSINE_EPOCHS=512 to match the main-study AE schedule
+# (slurm_scripts/comparison/ae/submit_ae_large.sh), so AE comparisons are
+# on equal-schedule footing. CNS at 91 s/ep used ~58% of its 24h budget at
+# 512 epochs in the baseline; the 4-level AE adds modest compute (one extra
+# shallow level, narrower widths) and should remain comfortably within 24h.
+#
+# If the run wall-clocks out, fall back to submit_ae_compression_timing.sh
+# to derive a safe per-budget value.
+COSINE_EPOCHS=512
+
+BUDGET_MAX_TIME="01:00:00:00"
+TIMEOUT_MIN=1439
+RUN_DRY_STATES=("true" "false")
+
+datamodule="conditioned_navier_stokes"
+experiment="ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8"
+
+for run_dry in "${RUN_DRY_STATES[@]}"; do
+    dry_run_arg=()
+    run_label="slurm"
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+        run_label="slurm --dry-run"
+    fi
+
+    echo "Submitting AE compression production run"
+    echo "  mode: ${run_label}"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  cosine_epochs: ${COSINE_EPOCHS}"
+
+    uv run autocast ae --mode slurm "${dry_run_arg[@]}" \
+        datamodule="${datamodule}" \
+        local_experiment="${experiment}" \
+        logging.wandb.enabled=true \
+        +optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+        hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+        trainer.max_time="${BUDGET_MAX_TIME}" \
+        +trainer.max_epochs="${COSINE_EPOCHS}"
+done

--- a/slurm_scripts/ablations/ae_compression/submit_ae_compression_timing.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_ae_compression_timing.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+# CNS-only AE compression ablation — timing run.
+# Trains the 4-level (64,128,256,512) encoder/decoder on CNS for 5 epochs
+# to fit a 24h cosine schedule via `autocast time-epochs`.
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/ae_compression_timing"
+
+datamodule="conditioned_navier_stokes"
+experiment="ablations/ae_compression/conditioned_navier_stokes/ae_dc_large_f8"
+
+echo "Submitting AE compression timing run"
+echo "  datamodule: ${datamodule}"
+echo "  local_experiment: ${experiment}"
+echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+echo "  budget: ${BUDGET_HOURS}h"
+echo "  run_group: ${RUN_GROUP}"
+
+uv run autocast time-epochs --kind ae --mode slurm \
+    --run-group "${RUN_GROUP}" \
+    --run-id "ae_b16_${datamodule}_f8" \
+    -n "${NUM_TIMING_EPOCHS}" \
+    -b "${BUDGET_HOURS}" \
+    local_experiment="${experiment}"
+
+echo ""
+echo "Once SLURM job completes, retrieve with:"
+echo "  bash outputs/${RUN_GROUP}/ae_b16_${datamodule}_f8/retrieve.sh"
+echo "Then extract cosine_epochs:"
+echo "  uv run autocast time-epochs --from-checkpoint outputs/${RUN_GROUP}/ae_b16_${datamodule}_f8/timing.ckpt -b ${BUDGET_HOURS}"

--- a/slurm_scripts/ablations/ae_compression/submit_cache_latents_f8.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_cache_latents_f8.sh
@@ -8,13 +8,12 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # but targets the single ae_dc_large_f8 run rather than the 4-dataset
 # main-study AEs.
 #
-# The cache_latents experiment yaml supplies the encoder/decoder shape via
-# the dc_large overrides — those load defaults that the AE checkpoint then
-# overrides at load time, so the same yaml works for both 3-level and
-# 4-level AEs without modification.
+# The cache_latents experiment yaml must instantiate the same encoder/decoder
+# architecture as the AE checkpoint; Lightning loads weights into the existing
+# module shape and does not reconstruct a wider/deeper DC stack from the ckpt.
 
 DATAMODULE="conditioned_navier_stokes"
-EXPERIMENT="cache_latents/conditioned_navier_stokes/cache_latents"
+EXPERIMENT="cache_latents/conditioned_navier_stokes/cache_latents_f8"
 AE_RUN_DIR="$HOME/autocast/outputs/2026-04-26/ae_cns64_de1b4b7_e1059d7"
 
 ckpt="${AE_RUN_DIR}/autoencoder.ckpt"

--- a/slurm_scripts/ablations/ae_compression/submit_cache_latents_f8.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_cache_latents_f8.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../../comparison/cached_latents/validate_cached_latents_against_ae.sh"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+# CNS-only AE-compression ablation: cache latents from the f8 (8x8x8) AE.
+# Mirrors slurm_scripts/comparison/cached_latents/submit_cache_latents.sh
+# but targets the single ae_dc_large_f8 run rather than the 4-dataset
+# main-study AEs.
+#
+# The cache_latents experiment yaml supplies the encoder/decoder shape via
+# the dc_large overrides — those load defaults that the AE checkpoint then
+# overrides at load time, so the same yaml works for both 3-level and
+# 4-level AEs without modification.
+
+DATAMODULE="conditioned_navier_stokes"
+EXPERIMENT="cache_latents/conditioned_navier_stokes/cache_latents"
+AE_RUN_DIR="$HOME/autocast/outputs/2026-04-26/ae_cns64_de1b4b7_e1059d7"
+
+ckpt="${AE_RUN_DIR}/autoencoder.ckpt"
+if [[ ! -f "$ckpt" ]]; then
+    ckpt="$(ls -t "${AE_RUN_DIR}"/autocast/*/checkpoints/latest-*.ckpt 2>/dev/null | head -n 1 || true)"
+    if [[ -z "$ckpt" || ! -f "$ckpt" ]]; then
+        echo "No autoencoder.ckpt or latest-*.ckpt under ${AE_RUN_DIR}" >&2
+        exit 1
+    fi
+    echo "Using temp checkpoint (AE still training?): ${ckpt}" >&2
+fi
+
+cache_workdir="${AE_RUN_DIR}/cached_latents"
+if ! validate_cache_experiment_against_ae "${AE_RUN_DIR}" "${EXPERIMENT}" "${REPO_ROOT}"; then
+    echo "Cache-latents experiment config mismatch vs AE training config" >&2
+    exit 1
+fi
+
+if [[ -d "$cache_workdir" ]]; then
+    echo "Warning: cache workdir already exists, will overwrite: $cache_workdir" >&2
+fi
+
+echo "Submitting f8 latent cache job"
+echo "  datamodule: ${DATAMODULE}"
+echo "  local_experiment: ${EXPERIMENT}"
+echo "  autoencoder run: ${AE_RUN_DIR}"
+echo "  cache workdir: ${cache_workdir}"
+
+uv run autocast cache-latents --mode slurm \
+    --workdir "${cache_workdir}" \
+    --output-dir "${cache_workdir}" \
+    autoencoder_checkpoint="${ckpt}" \
+    local_experiment="${EXPERIMENT}" \
+    hydra.launcher.timeout_min=120

--- a/slurm_scripts/ablations/ae_compression/submit_fm_f8_large.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_fm_f8_large.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../../comparison/cached_latents/validate_cached_latents_against_ae.sh"
+# CNS-only AE-compression ablation: 24h FM-in-latent run on the f8 (8x8x8)
+# cached latents.
+# Mirrors slurm_scripts/comparison/cached_latents/submit_fm_large.sh but
+# targets the single ae_dc_large_f8 run.
+#
+# Replace COSINE_EPOCHS once timing is available from:
+#   submit_fm_f8_timing.sh
+
+DATAMODULE="conditioned_navier_stokes"
+EXPERIMENT="processor/conditioned_navier_stokes/fm_vit_large"
+AE_RUN_DIR="$HOME/autocast/outputs/2026-04-26/ae_cns64_de1b4b7_e1059d7"
+COSINE_EPOCHS=3223  # placeholder: 16x16 main-study value; re-fit from f8 timing
+
+BUDGET_MAX_TIME="00:23:59:00"
+TIMEOUT_MIN=1439
+RUN_DRY_STATES=("true" "false")
+
+cache_dir="${AE_RUN_DIR}/cached_latents"
+
+if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
+    echo "Cache missing train/valid/test under ${cache_dir}" >&2
+    exit 1
+fi
+if ! validate_cached_latents_against_ae "${AE_RUN_DIR}"; then
+    echo "Cached-latents config mismatch vs AE training config" >&2
+    exit 1
+fi
+
+for run_dry in "${RUN_DRY_STATES[@]}"; do
+    dry_run_arg=()
+    run_label="slurm"
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+        run_label="slurm --dry-run"
+    fi
+
+    echo "Submitting f8 FM-in-latent training"
+    echo "  mode: ${run_label}"
+    echo "  datamodule: ${DATAMODULE}"
+    echo "  local_experiment: ${EXPERIMENT}"
+    echo "  cache dir: ${cache_dir}"
+    echo "  cosine_epochs: ${COSINE_EPOCHS}"
+
+    uv run autocast processor --mode slurm "${dry_run_arg[@]}" \
+        local_experiment="${EXPERIMENT}" \
+        datamodule.data_path="${cache_dir}" \
+        logging.wandb.enabled=true \
+        optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+        hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+        trainer.max_time="${BUDGET_MAX_TIME}" \
+        +trainer.max_epochs="${COSINE_EPOCHS}" \
+        trainer.callbacks.0.every_n_train_steps_fraction=0.05 \
+        +trainer.callbacks.0.every_n_epochs=0 \
+        trainer.callbacks.0.save_top_k=-1 \
+        trainer.callbacks.0.filename=\"snapshot-{progress_token}-{epoch:04d}-{step:08d}\"
+done

--- a/slurm_scripts/ablations/ae_compression/submit_fm_f8_timing.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_fm_f8_timing.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../../comparison/cached_latents/validate_cached_latents_against_ae.sh"
+# CNS-only AE-compression ablation: 5-epoch FM-in-latent timing run on the
+# f8 (8x8x8) cached latents.
+# Re-times because the main-study cosine_epochs=3223 was derived on the
+# 16x16x8 latent — the 8x8x8 latent has 4x fewer tokens per sample so the
+# per-epoch wall is meaningfully different.
+# Reuses processor/conditioned_navier_stokes/fm_vit_large.yaml (vit
+# backbone, patch_size=1) — the smaller spatial grid is handled
+# automatically by the ViT.
+
+EXPERIMENT="processor/conditioned_navier_stokes/fm_vit_large"
+AE_RUN_DIR="$HOME/autocast/outputs/2026-04-26/ae_cns64_de1b4b7_e1059d7"
+DATAMODULE="conditioned_navier_stokes"
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing"
+
+cache_dir="${AE_RUN_DIR}/cached_latents"
+
+if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
+    echo "Cache missing train/valid/test under ${cache_dir}" >&2
+    exit 1
+fi
+if ! validate_cached_latents_against_ae "${AE_RUN_DIR}"; then
+    echo "Cached-latents config mismatch vs AE training config" >&2
+    exit 1
+fi
+
+echo "Submitting f8 FM-in-latent timing run"
+echo "  datamodule: ${DATAMODULE}"
+echo "  local_experiment: ${EXPERIMENT}"
+echo "  cache dir: ${cache_dir}"
+echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+echo "  budget: ${BUDGET_HOURS}h"
+echo "  run_group: ${RUN_GROUP}"
+echo ""
+
+uv run autocast time-epochs --kind processor --mode slurm \
+    --run-group "${RUN_GROUP}" \
+    --run-id "fm_f8_b256_${DATAMODULE}" \
+    -n "${NUM_TIMING_EPOCHS}" \
+    -b "${BUDGET_HOURS}" \
+    local_experiment="${EXPERIMENT}" \
+    datamodule.data_path="${cache_dir}"
+
+echo ""
+echo "Once SLURM job completes, collect with:"
+echo "  bash outputs/${RUN_GROUP}/fm_f8_b256_${DATAMODULE}/retrieve.sh"
+echo "Then derive COSINE_EPOCHS via:"
+echo "  uv run autocast time-epochs --from-checkpoint outputs/${RUN_GROUP}/fm_f8_b256_${DATAMODULE}/timing.ckpt -b 24"

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -85,58 +85,84 @@ def _extract_local_experiment_name(overrides: list[str]) -> str | None:
     return None
 
 
+def _resolve_local_experiment_parent(item: object) -> Path | None:
+    # Map a defaults-list entry of the form
+    # ``- /local_experiment/<rel/path>`` to its YAML file, so we can
+    # follow the inheritance chain when looking up ``/distributed``.
+    if isinstance(item, str) and item.startswith("/local_experiment/"):
+        rel = item[len("/local_experiment/") :]
+        return Path.cwd() / "local_hydra" / "local_experiment" / f"{rel}.yaml"
+    return None
+
+
+def _extract_distributed_preset_name(
+    cfg: dict, seen: set[Path] | None = None
+) -> str | None:
+    if seen is None:
+        seen = set()
+    defaults = cfg.get("defaults")
+    if not isinstance(defaults, list):
+        return None
+    for item in defaults:
+        if not isinstance(item, dict):
+            continue
+        val = item.get("/distributed") or item.get("distributed")
+        if isinstance(val, str) and val:
+            return val
+    for item in defaults:
+        parent_path = _resolve_local_experiment_parent(item)
+        if parent_path is None or parent_path in seen or not parent_path.exists():
+            continue
+        seen.add(parent_path)
+        parent_raw = OmegaConf.to_container(OmegaConf.load(parent_path), resolve=False)
+        if not isinstance(parent_raw, dict):
+            continue
+        result = _extract_distributed_preset_name(parent_raw, seen)
+        if result:
+            return result
+    return None
+
+
+def _load_distributed_cfg(name: str) -> dict:
+    cfg_root = Path(__file__).resolve().parents[2] / "configs"
+    path = cfg_root / "distributed" / f"{name}.yaml"
+    if not path.exists():
+        return {}
+    loaded = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _load_launcher_from_file(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    # Do not resolve the whole experiment config here; it may contain
+    # interpolations that are valid only during full Hydra composition
+    # (e.g. model.processor.n_steps_input -> datamodule.n_steps_input).
+    # We only need the hydra.launcher subtree for submission defaults.
+    raw = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
+    if not isinstance(raw, dict):
+        return {}
+    distributed = _extract_distributed_preset_name(raw)
+    if distributed:
+        merged = OmegaConf.merge(_load_distributed_cfg(distributed), raw)
+        cfg = OmegaConf.to_container(merged, resolve=False)
+    else:
+        cfg = raw
+    if not isinstance(cfg, dict):
+        return {}
+    hydra_cfg = cfg.get("hydra")
+    if not isinstance(hydra_cfg, dict):
+        return {}
+    launcher_cfg = hydra_cfg.get("launcher")
+    return launcher_cfg if isinstance(launcher_cfg, dict) else {}
+
+
 def _load_preset_launcher_cfg(overrides: list[str]) -> dict:
     """Load ``hydra.launcher`` mapping from selected experiment preset.
 
     Supports both ``local_experiment=<name>`` and ``experiment=<name>``.
     ``local_experiment`` has precedence if both are provided.
     """
-
-    def _extract_distributed_preset_name(cfg: dict) -> str | None:
-        defaults = cfg.get("defaults")
-        if not isinstance(defaults, list):
-            return None
-        for item in defaults:
-            if not isinstance(item, dict):
-                continue
-            val = item.get("/distributed") or item.get("distributed")
-            if isinstance(val, str) and val:
-                return val
-        return None
-
-    def _load_distributed_cfg(name: str) -> dict:
-        cfg_root = Path(__file__).resolve().parents[2] / "configs"
-        path = cfg_root / "distributed" / f"{name}.yaml"
-        if not path.exists():
-            return {}
-        loaded = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
-        return loaded if isinstance(loaded, dict) else {}
-
-    def _load_launcher_from_file(path: Path) -> dict:
-        if not path.exists():
-            return {}
-        # Do not resolve the whole experiment config here; it may contain
-        # interpolations that are valid only during full Hydra composition
-        # (e.g. model.processor.n_steps_input -> datamodule.n_steps_input).
-        # We only need the hydra.launcher subtree for submission defaults.
-        raw = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
-        if not isinstance(raw, dict):
-            return {}
-        distributed = _extract_distributed_preset_name(raw)
-        merged = (
-            OmegaConf.merge(_load_distributed_cfg(distributed), raw)
-            if distributed
-            else raw
-        )
-        cfg = OmegaConf.to_container(merged, resolve=False)
-        if not isinstance(cfg, dict):
-            return {}
-        hydra_cfg = cfg.get("hydra")
-        if not isinstance(hydra_cfg, dict):
-            return {}
-        launcher_cfg = hydra_cfg.get("launcher")
-        return launcher_cfg if isinstance(launcher_cfg, dict) else {}
-
     local_experiment = _extract_local_experiment_name(overrides)
     if local_experiment:
         local_cfg_path = (

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -216,6 +216,43 @@ def test_load_preset_launcher_cfg_ignores_unrelated_interpolation(
     assert launcher_cfg.get("timeout_min") == 120
 
 
+def test_load_preset_launcher_cfg_walks_local_experiment_parent_chain(
+    tmp_path: Path, monkeypatch
+):
+    # Child references a parent local_experiment that declares /distributed:
+    # — the loader must walk the chain so SLURM allocates the right resources.
+    local_root = tmp_path / "local_hydra" / "local_experiment"
+    parent_cfg = local_root / "parent.yaml"
+    parent_cfg.parent.mkdir(parents=True, exist_ok=True)
+    parent_cfg.write_text(
+        "\n".join(
+            [
+                "defaults:",
+                "  - /distributed: ddp_4gpu_slurm",
+                "  - _self_",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    child_cfg = local_root / "child.yaml"
+    child_cfg.write_text(
+        "\n".join(
+            [
+                "defaults:",
+                "  - /local_experiment/parent",
+                "  - _self_",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    launcher_cfg = _load_preset_launcher_cfg(["local_experiment=child"])
+
+    assert launcher_cfg.get("gpus_per_node") == 4
+    assert launcher_cfg.get("tasks_per_node") == 4
+
+
 # ---------------------------------------------------------------------------
 # naming
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add conditioned Navier-Stokes AE compression ablation configs for C=2 and F8 variants
- add Slurm scripts and README coverage for AE compression, cache-latent, FM, and timing runs
- update workflow Slurm handling and validator normalization coverage

## Tests
- uv run pytest tests/scripts/test_workflow.py