### PR TITLE
Add planned ablation run scripts

### DIFF
--- a/local_hydra/local_experiment/processor/advection_diffusion/diffusion_vit_large.yaml
+++ b/local_hydra/local_experiment/processor/advection_diffusion/diffusion_vit_large.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: cached_latents
+  - override /processor@model.processor: diffusion_vit
+  - override /backbone@model.processor.backbone: vit
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: processor_diffusion_vit_large_advection_diffusion
+
+datamodule:
+  batch_size: 256
+  # data_path supplied at runtime (points at <ae_run_dir>/cached_latents)
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 1e-4
+  warmup: 0
+
+model:
+  processor:
+    denoiser_type: karras
+    sampler: euler
+    sampler_steps: 50
+    backbone:
+      hid_channels: 704
+      hid_blocks: 12
+      attention_heads: 8
+  val_metrics: []

--- a/local_hydra/local_experiment/processor/conditioned_navier_stokes/diffusion_vit_large.yaml
+++ b/local_hydra/local_experiment/processor/conditioned_navier_stokes/diffusion_vit_large.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: cached_latents
+  - override /processor@model.processor: diffusion_vit
+  - override /backbone@model.processor.backbone: vit
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: processor_diffusion_vit_large_conditioned_navier_stokes
+
+datamodule:
+  batch_size: 256
+  # data_path supplied at runtime (points at <ae_run_dir>/cached_latents)
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 1e-4
+  warmup: 0
+
+model:
+  processor:
+    denoiser_type: karras
+    sampler: euler
+    sampler_steps: 50
+    backbone:
+      hid_channels: 704
+      hid_blocks: 12
+      attention_heads: 8
+  val_metrics: []

--- a/local_hydra/local_experiment/processor/gpe_laser_wake_only/diffusion_vit_large.yaml
+++ b/local_hydra/local_experiment/processor/gpe_laser_wake_only/diffusion_vit_large.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: cached_latents
+  - override /processor@model.processor: diffusion_vit
+  - override /backbone@model.processor.backbone: vit
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: processor_diffusion_vit_large_gpe_laser_only_wake
+
+datamodule:
+  batch_size: 256
+  # data_path supplied at runtime (points at <ae_run_dir>/cached_latents)
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 1e-4
+  warmup: 0
+
+model:
+  processor:
+    denoiser_type: karras
+    sampler: euler
+    sampler_steps: 50
+    backbone:
+      hid_channels: 704
+      hid_blocks: 12
+      attention_heads: 8
+  val_metrics: []

--- a/local_hydra/local_experiment/processor/gray_scott/diffusion_vit_large.yaml
+++ b/local_hydra/local_experiment/processor/gray_scott/diffusion_vit_large.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: cached_latents
+  - override /processor@model.processor: diffusion_vit
+  - override /backbone@model.processor.backbone: vit
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: processor_diffusion_vit_large_gray_scott
+
+datamodule:
+  batch_size: 256
+  # data_path supplied at runtime (points at <ae_run_dir>/cached_latents)
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 1e-4
+  warmup: 0
+
+model:
+  processor:
+    denoiser_type: karras
+    sampler: euler
+    sampler_steps: 50
+    backbone:
+      hid_channels: 704
+      hid_blocks: 12
+      attention_heads: 8
+  val_metrics: []

--- a/slurm_scripts/ablations/README.md
+++ b/slurm_scripts/ablations/README.md
@@ -20,7 +20,7 @@ small edit.
 | ensemble_size (m=16, fixed bs=32) | sweep | CNS | 1 | ready |
 | ensemble_size (m=16, fixed global eff. bs=1024) | sweep | GS / GPE / CNS / AD | 4 | timing ready |
 | planned_01 batch | mixed | CNS | 8 | timing scripted |
-| planned_02 batch | mixed | GS / GPE / AD | 4 | timing scripted |
+| planned_02 batch | mixed | GS / GPE / AD | 6 | timing + production scripted |
 | noise_channels | sweep | CNS | 1 | config + planned |
 | crps_variants (AlphaFair / Fair / CRPS) | comparison | CNS | 2 new (+baseline) | config + planned |
 | fm_vs_diffusion | comparison | CNS | 1 | config + planned |
@@ -60,9 +60,11 @@ eval scripts have those dates wired in.
 
 ## Planned Batch 02
 
-The follow-up batch lives in `submit_planned_02_timing.sh` and
-`submit_planned_02_large.sh` so planned batches can keep extending without
-repurposing earlier scripts. It covers:
+The follow-up batch lives in `submit_planned_02_timing.sh`,
+`submit_planned_02_large.sh`,
+`submit_planned_02_m4_followup_timing.sh`, and
+`submit_planned_02_m4_followup_large.sh` so planned batches can keep
+extending without repurposing earlier scripts. It covers:
 
 | planned run | study folder | implementation |
 |---|---|---|
@@ -70,6 +72,12 @@ repurposing earlier scripts. It covers:
 | GPE m=8 latent CRPS | `cached_latent_crps` | `processor/gpe_laser_wake_only/crps_vit_azula_large` with cached GPE latents |
 | AD m=8 latent CRPS | `cached_latent_crps` | `processor/advection_diffusion/crps_vit_azula_large` with cached AD latents |
 | GS m=4 ViT | `ensemble_size` | canonical GS CRPS ViT plus `n_members=4`, `batch_size=64` |
+| GPE m=4 ViT | `ensemble_size` | canonical GPE CRPS ViT plus `n_members=4`, `batch_size=64` |
+| AD m=4 ViT | `ensemble_size` | canonical AD CRPS ViT plus `n_members=4`, `batch_size=64` |
+
+The m=4 GPE/AD follow-up follows the same timing-then-production pattern:
+`submit_planned_02_m4_followup_timing.sh` first, then
+`submit_planned_02_m4_followup_large.sh` after retrieving timing outputs.
 
 ## Design notes
 

--- a/slurm_scripts/ablations/README.md
+++ b/slurm_scripts/ablations/README.md
@@ -19,7 +19,7 @@ small edit.
 |---|---|---|---|---|
 | ensemble_size (m=16, fixed bs=32) | sweep | CNS | 1 | ready |
 | ensemble_size (m=16, fixed global eff. bs=1024) | sweep | GS / GPE / CNS / AD | 4 | timing ready |
-| planned_cns batch | mixed | CNS | 8 | timing scripted |
+| planned_01 batch | mixed | CNS | 8 | timing scripted |
 | noise_channels | sweep | CNS | 1 | config + planned |
 | crps_variants (AlphaFair / Fair / CRPS) | comparison | CNS | 2 new (+baseline) | config + planned |
 | fm_vs_diffusion | comparison | CNS | 1 | config + planned |
@@ -36,10 +36,10 @@ small edit.
 ablation — no new training required, but they should be eval'd through
 the same pipeline.
 
-## Planned CNS batch
+## Planned Batch 01
 
 The current planned CNS batch is centralized in
-`submit_planned_cns_timing.sh` and `submit_planned_cns_large.sh` so the
+`submit_planned_01_timing.sh` and `submit_planned_01_large.sh` so the
 cross-ablation run list can be submitted consistently after timing. It covers:
 
 | planned run | study folder | implementation |

--- a/slurm_scripts/ablations/README.md
+++ b/slurm_scripts/ablations/README.md
@@ -20,6 +20,7 @@ small edit.
 | ensemble_size (m=16, fixed bs=32) | sweep | CNS | 1 | ready |
 | ensemble_size (m=16, fixed global eff. bs=1024) | sweep | GS / GPE / CNS / AD | 4 | timing ready |
 | planned_01 batch | mixed | CNS | 8 | timing scripted |
+| planned_02 batch | mixed | GS / GPE / AD | 4 | timing scripted |
 | noise_channels | sweep | CNS | 1 | config + planned |
 | crps_variants (AlphaFair / Fair / CRPS) | comparison | CNS | 2 new (+baseline) | config + planned |
 | fm_vs_diffusion | comparison | CNS | 1 | config + planned |
@@ -57,6 +58,19 @@ Use the 2026-04-24 CRPS ambient runs for current CRPS comparison numbers and
 the 2026-04-20 `diff_*` cached-latent runs as the FM/diff basis. The comparison
 eval scripts have those dates wired in.
 
+## Planned Batch 02
+
+The follow-up batch lives in `submit_planned_02_timing.sh` and
+`submit_planned_02_large.sh` so planned batches can keep extending without
+repurposing earlier scripts. It covers:
+
+| planned run | study folder | implementation |
+|---|---|---|
+| GS m=8 latent CRPS | `cached_latent_crps` | `processor/gray_scott/crps_vit_azula_large` with cached GS latents |
+| GPE m=8 latent CRPS | `cached_latent_crps` | `processor/gpe_laser_wake_only/crps_vit_azula_large` with cached GPE latents |
+| AD m=8 latent CRPS | `cached_latent_crps` | `processor/advection_diffusion/crps_vit_azula_large` with cached AD latents |
+| GS m=4 ViT | `ensemble_size` | canonical GS CRPS ViT plus `n_members=4`, `batch_size=64` |
+
 ## Design notes
 
 - **Flexible by construction.** Each ablation is a self-contained
@@ -81,7 +95,8 @@ eval scripts have those dates wired in.
 1. `submit_*_timing.sh` — 5-epoch timing runs, producing `timing.ckpt`.
 2. Extract per-combo `cosine_epochs` via
    `uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24`
-   and paste into `submit_*_large.sh` (matches `comparison/` flow).
+   and paste into `submit_*_large.sh`, or use a large script that derives
+   them from matching timing checkpoints.
 3. `submit_*_large.sh` — 24h production runs, dry-run first.
 4. Eval from the script local to the study:
    `slurm_scripts/comparison/eval/` for the canonical comparison suite, and

--- a/slurm_scripts/ablations/crps_variants/README.md
+++ b/slurm_scripts/ablations/crps_variants/README.md
@@ -34,5 +34,5 @@ CNS only for now. The planned batch adds the two non-baseline loss variants:
 ## Implementation sketch
 
 The cross-cutting submitter is
-`slurm_scripts/ablations/submit_planned_cns_{timing,large}.sh`; it keeps the
+`slurm_scripts/ablations/submit_planned_01_{timing,large}.sh`; it keeps the
 loss-variant runs alongside the other planned CNS ablations.

--- a/slurm_scripts/ablations/ensemble_size/eval_best_multiwinkler_from0p25/submit_eval_crps_ambient.sh
+++ b/slurm_scripts/ablations/ensemble_size/eval_best_multiwinkler_from0p25/submit_eval_crps_ambient.sh
@@ -3,9 +3,12 @@
 set -euo pipefail
 # Ambient eval submitter for the 2026-04-24 CRPS ensemble-size runs.
 #
-# This variant selects the best multi-Winkler checkpoint after the 0.25
-# progress cutoff: best-multiwinkler-from0p25-*.ckpt. The standard ensemble
-# eval submitter under ../eval/ is left unchanged.
+# Picks the multi-Winkler checkpoint per run with a two-step resolver:
+#   1. <run>/autocast/<id>/checkpoints/best-multiwinkler.ckpt — a hand-picked
+#      symlink, used for runs where best-multiwinkler-pre0p25-*.ckpt beats the
+#      from-0.25 selection.
+#   2. otherwise, the latest best-multiwinkler-from0p25-*.ckpt as the default.
+# The standard ensemble eval submitter under ../eval/ is left unchanged.
 #
 # Force eval.mode=ambient. These stateless EPD checkpoints can look
 # processor-only to eval.mode=auto because PermuteConcat / ChannelsLast add no
@@ -34,6 +37,15 @@ resolve_multiwinkler_checkpoint() {
     local -a ckpts=()
 
     mapfile -t ckpts < <(
+        find "${run_dir}" -path '*/checkpoints/best-multiwinkler.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    mapfile -t ckpts < <(
         find "${run_dir}" -type f -path '*/checkpoints/best-multiwinkler-from0p25-*.ckpt' | sort
     )
 
@@ -53,7 +65,7 @@ for run_dir in "${RUN_DIRS[@]}"; do
     fi
 
     if ! eval_ckpt="$(resolve_multiwinkler_checkpoint "${run_dir_abs}")"; then
-        echo "Skipping ${run_dir}: best-multiwinkler-from0p25-*.ckpt missing" >&2
+        echo "Skipping ${run_dir}: no best-multiwinkler.ckpt symlink and no best-multiwinkler-from0p25-*.ckpt" >&2
         continue
     fi
     eval_ckpt_abs="$(realpath "${eval_ckpt}")"

--- a/slurm_scripts/ablations/submit_check_latent_crps_m16_gpe.sh
+++ b/slurm_scripts/ablations/submit_check_latent_crps_m16_gpe.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cached_latents_against_ae.sh"
+
+# Quick sanity check: GPE m=16 latent CRPS — does the loss drop?
+#
+# Not a timing run, not a production run. Short max_time, modest cosine
+# schedule so the LR still anneals, default callbacks, wandb on so the loss
+# trajectory is visible live. Expected outcome: train_loss / val_loss visibly
+# decrease within a handful of epochs.
+
+CHECK_MAX_TIME="00:02:00:00"
+TIMEOUT_MIN=125          # 2h05 — gives Lightning a few minutes to wrap up
+COSINE_EPOCHS=160        # Choose around half of 326 for m=8
+RUN_GROUP="$(date +%Y-%m-%d)/check_latent_crps_m16_gpe"
+
+AE_RUN_DIR="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f"
+CACHE_DIR="${AE_RUN_DIR}/cached_latents"
+LOCAL_EXPERIMENT="processor/gpe_laser_wake_only/crps_vit_azula_large"
+RUN_ID="latent_crps_m16_gpe_check"
+RUN_DRY_STATES=("true" "false")
+
+if [[ ! -d "${CACHE_DIR}/train" ]] || [[ ! -d "${CACHE_DIR}/valid" ]] || [[ ! -d "${CACHE_DIR}/test" ]]; then
+    echo "FATAL: cache missing train/valid/test under ${CACHE_DIR}" >&2
+    exit 1
+fi
+if ! validate_cached_latents_against_ae "${AE_RUN_DIR}"; then
+    echo "FATAL: cached-latents config mismatch vs AE training config" >&2
+    exit 1
+fi
+
+for run_dry in "${RUN_DRY_STATES[@]}"; do
+    dry_run_arg=()
+    run_label="slurm"
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+        run_label="slurm --dry-run"
+    fi
+
+    echo "Submitting GPE m=16 latent CRPS sanity check"
+    echo "  mode: ${run_label}"
+    echo "  run_id: ${RUN_ID}"
+    echo "  local_experiment: ${LOCAL_EXPERIMENT}"
+    echo "  cache_dir: ${CACHE_DIR}"
+    echo "  cosine_epochs: ${COSINE_EPOCHS}"
+    echo "  max_time: ${CHECK_MAX_TIME}"
+
+    uv run autocast processor --mode slurm "${dry_run_arg[@]}" \
+        --run-group "${RUN_GROUP}" \
+        local_experiment="${LOCAL_EXPERIMENT}" \
+        datamodule=cached_latents \
+        datamodule.data_path="${CACHE_DIR}" \
+        model.n_members=16 \
+        logging.wandb.enabled=true \
+        logging.wandb.name="${RUN_ID}" \
+        optimizer.cosine_epochs="${COSINE_EPOCHS}" \
+        hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+        trainer.max_time="${CHECK_MAX_TIME}" \
+        +trainer.max_epochs="${COSINE_EPOCHS}"
+done

--- a/slurm_scripts/ablations/submit_check_latent_crps_m16_gpe.sh
+++ b/slurm_scripts/ablations/submit_check_latent_crps_m16_gpe.sh
@@ -52,6 +52,7 @@ for run_dry in "${RUN_DRY_STATES[@]}"; do
         local_experiment="${LOCAL_EXPERIMENT}" \
         datamodule=cached_latents \
         datamodule.data_path="${CACHE_DIR}" \
+        datamodule.batch_size=16 \
         model.n_members=16 \
         logging.wandb.enabled=true \
         logging.wandb.name="${RUN_ID}" \

--- a/slurm_scripts/ablations/submit_eval_planned_01.sh
+++ b/slurm_scripts/ablations/submit_eval_planned_01.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+
+set -euo pipefail
+# Eval submitter for the 2026-04-25 planned_01 CNS ablation runs.
+#
+# Mirrors the RUNS structure of submit_planned_01_large.sh. Each row is
+# dispatched to one of three eval profiles:
+#
+#   crps_ambient      EPD CRPS run, eval.mode=ambient, best-multiwinkler ckpt
+#                     resolver (symlink-first, then best-multiwinkler-from0p25-*).
+#                     Output: <run>/eval_best_multiwinkler_from0p25/.
+#
+#   crps_latent       processor cached-latent CRPS run, eval.mode=auto -> encode_once
+#                     with the matching AE checkpoint, best-multiwinkler ckpt
+#                     resolver (same as crps_ambient).
+#                     Output: <run>/eval_best_multiwinkler_from0p25/.
+#
+#   diffusion_ambient EPD diffusion (identity encoder/decoder), eval.mode=ambient,
+#                     best-val ckpt resolver. Output: <run>/eval_ambient/.
+#
+# The two-step multi-Winkler resolver:
+#   1. <run>/autocast/<id>/checkpoints/best-multiwinkler.ckpt — a hand-picked
+#      symlink for runs where best-multiwinkler-pre0p25-*.ckpt beats the
+#      from-0.25 selection.
+#   2. otherwise, the latest best-multiwinkler-from0p25-*.ckpt as the default.
+
+EVAL_BATCH_SIZE_CRPS=8
+EVAL_BATCH_SIZE_DIFF=4
+EVAL_N_MEMBERS=10
+TIMEOUT_MIN_CRPS=240
+TIMEOUT_MIN_DIFF=360
+EVAL_SUBDIR_MW="eval_best_multiwinkler_from0p25"
+EVAL_SUBDIR_DIFF="eval_ambient"
+ROLLOUT_SNAPSHOT_TIMESTEPS="[0,4,12,30,99]"
+RUN_DRY_STATES=("true" "false")
+EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
+
+CNS_AE_CKPT="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8/autoencoder.ckpt"
+
+# run_id|profile|run_dir
+RUNS=(
+    "unet_m8_crps_cns|crps_ambient|outputs/2026-04-25/planned_cns/crps_cns64_unet_azula_large_9c98db0_65f8f71"
+    "diffusion_cns|diffusion_ambient|outputs/2026-04-25/planned_cns/diff_cns64_diffusion_vit_9c98db0_e9bc460"
+    "fair_crps_m8_cns|crps_ambient|outputs/2026-04-25/planned_cns/crps_cns64_vit_azula_large_9c98db0_d2a0496"
+    "plain_crps_m8_cns|crps_ambient|outputs/2026-04-25/planned_cns/crps_cns64_vit_azula_large_9c98db0_6a91c49"
+    "vit_noise256_m8_cns|crps_ambient|outputs/2026-04-25/planned_cns/crps_cns64_vit_azula_large_9c98db0_86e355d"
+    "vit_m4_cns|crps_ambient|outputs/2026-04-25/planned_cns/crps_cns64_vit_azula_large_9c98db0_957ff88"
+    "latent_crps_m8_cns|crps_latent|outputs/2026-04-25/planned_cns/crps_cns64_vit_azula_large_9c98db0_4b2a1a5"
+    "vit_global_cond_m8_cns|crps_ambient|outputs/2026-04-25/planned_cns/crps_cns64_vit_azula_large_9c98db0_2fa67c5"
+)
+
+resolve_multiwinkler_checkpoint() {
+    local run_dir="$1"
+    local -a ckpts=()
+
+    mapfile -t ckpts < <(
+        find "${run_dir}" -path '*/checkpoints/best-multiwinkler.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    mapfile -t ckpts < <(
+        find "${run_dir}" -type f -path '*/checkpoints/best-multiwinkler-from0p25-*.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    return 1
+}
+
+submit_crps_ambient() {
+    local run_id="$1" run_dir_abs="$2"
+    local eval_ckpt
+    if ! eval_ckpt="$(resolve_multiwinkler_checkpoint "${run_dir_abs}")"; then
+        echo "Skipping ${run_id}: no best-multiwinkler.ckpt symlink and no best-multiwinkler-from0p25-*.ckpt" >&2
+        return 0
+    fi
+    local eval_ckpt_abs eval_output_dir
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR_MW}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        local dry_run_arg=() run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting CRPS-ambient eval (best multi-Winkler)"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  eval.mode: ambient"
+        echo "  output_subdir: ${EVAL_SUBDIR_MW}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir_abs}" \
+            --output-subdir "${EVAL_SUBDIR_MW}" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            eval.mode=ambient \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
+            eval.save_rollout_snapshots=true \
+            eval.rollout_snapshot_dir="${eval_output_dir}/videos/snapshots" \
+            eval.rollout_snapshot_timesteps="${ROLLOUT_SNAPSHOT_TIMESTEPS}" \
+            eval.rollout_snapshot_format=png \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE_CRPS}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN_CRPS}"
+    done
+}
+
+submit_crps_latent() {
+    local run_id="$1" run_dir_abs="$2" ae_ckpt="$3"
+    if [[ ! -f "${ae_ckpt}" ]]; then
+        echo "Skipping ${run_id}: AE checkpoint missing at ${ae_ckpt}" >&2
+        return 0
+    fi
+    local ae_ckpt_abs
+    ae_ckpt_abs="$(realpath "${ae_ckpt}")"
+
+    local eval_ckpt
+    if ! eval_ckpt="$(resolve_multiwinkler_checkpoint "${run_dir_abs}")"; then
+        echo "Skipping ${run_id}: no best-multiwinkler.ckpt symlink and no best-multiwinkler-from0p25-*.ckpt" >&2
+        return 0
+    fi
+    local eval_ckpt_abs eval_output_dir
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR_MW}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        local dry_run_arg=() run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting CRPS cached-latent eval (best multi-Winkler)"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  autoencoder_checkpoint: ${ae_ckpt_abs}"
+        echo "  eval.mode: auto"
+        echo "  output_subdir: ${EVAL_SUBDIR_MW}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir_abs}" \
+            --output-subdir "${EVAL_SUBDIR_MW}" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            +autoencoder_checkpoint="${ae_ckpt_abs}" \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
+            eval.save_rollout_snapshots=true \
+            eval.rollout_snapshot_dir="${eval_output_dir}/videos/snapshots" \
+            eval.rollout_snapshot_timesteps="${ROLLOUT_SNAPSHOT_TIMESTEPS}" \
+            eval.rollout_snapshot_format=png \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE_CRPS}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN_CRPS}"
+    done
+}
+
+submit_diffusion_ambient() {
+    local run_id="$1" run_dir_abs="$2"
+    # Match the existing FM/diffusion eval pattern (submit_eval_fm_ambient.sh):
+    # use the saved final checkpoint symlink, eval.mode=ambient, batch_size=4,
+    # timeout=360. The diffusion run has identity encoder/decoder, so it is
+    # already ambient — no autoencoder_checkpoint.
+    local eval_ckpt="${run_dir_abs}/encoder_processor_decoder.ckpt"
+    if [[ ! -e "${eval_ckpt}" ]]; then
+        echo "Skipping ${run_id}: encoder_processor_decoder.ckpt missing" >&2
+        return 0
+    fi
+    local eval_ckpt_abs eval_output_dir
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR_DIFF}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        local dry_run_arg=() run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting diffusion-ambient eval"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  eval.mode: ambient"
+        echo "  output_subdir: ${EVAL_SUBDIR_DIFF}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir_abs}" \
+            --output-subdir "${EVAL_SUBDIR_DIFF}" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            eval.mode=ambient \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
+            eval.save_rollout_snapshots=true \
+            eval.rollout_snapshot_dir="${eval_output_dir}/videos/snapshots" \
+            eval.rollout_snapshot_timesteps="${ROLLOUT_SNAPSHOT_TIMESTEPS}" \
+            eval.rollout_snapshot_format=png \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE_DIFF}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN_DIFF}"
+    done
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS='|' read -r run_id profile run_dir <<< "${run_spec}"
+
+    if [[ ! -d "${run_dir}" ]]; then
+        echo "Skipping ${run_id}: run_dir missing at ${run_dir}" >&2
+        continue
+    fi
+    run_dir_abs="$(realpath "${run_dir}")"
+    if [[ ! -f "${run_dir_abs}/resolved_config.yaml" ]]; then
+        echo "Skipping ${run_id}: resolved_config.yaml missing under ${run_dir}" >&2
+        continue
+    fi
+
+    case "${profile}" in
+        crps_ambient)
+            submit_crps_ambient "${run_id}" "${run_dir_abs}"
+            ;;
+        crps_latent)
+            submit_crps_latent "${run_id}" "${run_dir_abs}" "${CNS_AE_CKPT}"
+            ;;
+        diffusion_ambient)
+            submit_diffusion_ambient "${run_id}" "${run_dir_abs}"
+            ;;
+        *)
+            echo "FATAL: unknown profile '${profile}' for ${run_id}" >&2
+            exit 1
+            ;;
+    esac
+done

--- a/slurm_scripts/ablations/submit_eval_planned_01.sh
+++ b/slurm_scripts/ablations/submit_eval_planned_01.sh
@@ -18,11 +18,14 @@ set -euo pipefail
 #   diffusion_ambient EPD diffusion (identity encoder/decoder), eval.mode=ambient,
 #                     best-val ckpt resolver. Output: <run>/eval_ambient/.
 #
-# The two-step multi-Winkler resolver:
+# The multi-Winkler resolver tries, in order:
 #   1. <run>/autocast/<id>/checkpoints/best-multiwinkler.ckpt — a hand-picked
 #      symlink for runs where best-multiwinkler-pre0p25-*.ckpt beats the
 #      from-0.25 selection.
-#   2. otherwise, the latest best-multiwinkler-from0p25-*.ckpt as the default.
+#   2. best-multiwinkler-overall-*.ckpt — the no-window overall-best ckpt added
+#      by the trainer default callbacks. Only present for runs trained after
+#      that callback was added.
+#   3. otherwise, the latest best-multiwinkler-from0p25-*.ckpt as the default.
 
 EVAL_BATCH_SIZE_CRPS=8
 EVAL_BATCH_SIZE_DIFF=4
@@ -55,6 +58,15 @@ resolve_multiwinkler_checkpoint() {
 
     mapfile -t ckpts < <(
         find "${run_dir}" -path '*/checkpoints/best-multiwinkler.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    mapfile -t ckpts < <(
+        find "${run_dir}" -type f -path '*/checkpoints/best-multiwinkler-overall-*.ckpt' | sort
     )
 
     if (( ${#ckpts[@]} >= 1 )); then

--- a/slurm_scripts/ablations/submit_eval_planned_02.sh
+++ b/slurm_scripts/ablations/submit_eval_planned_02.sh
@@ -16,11 +16,14 @@ set -euo pipefail
 #                  resolver (same as crps_ambient).
 #                  Output: <run>/eval_best_multiwinkler_from0p25/.
 #
-# The two-step multi-Winkler resolver:
+# The multi-Winkler resolver tries, in order:
 #   1. <run>/autocast/<id>/checkpoints/best-multiwinkler.ckpt — a hand-picked
 #      symlink for runs where best-multiwinkler-pre0p25-*.ckpt beats the
 #      from-0.25 selection.
-#   2. otherwise, the latest best-multiwinkler-from0p25-*.ckpt as the default.
+#   2. best-multiwinkler-overall-*.ckpt — the no-window overall-best ckpt added
+#      by the trainer default callbacks. Only present for runs trained after
+#      that callback was added.
+#   3. otherwise, the latest best-multiwinkler-from0p25-*.ckpt as the default.
 #
 # GPE (latent_crps_m8_gpe) is intentionally omitted: the m=8 run collapsed and
 # will be rerun with m=16 only — eval will move to that follow-up script.
@@ -55,6 +58,15 @@ resolve_multiwinkler_checkpoint() {
 
     mapfile -t ckpts < <(
         find "${run_dir}" -path '*/checkpoints/best-multiwinkler.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    mapfile -t ckpts < <(
+        find "${run_dir}" -type f -path '*/checkpoints/best-multiwinkler-overall-*.ckpt' | sort
     )
 
     if (( ${#ckpts[@]} >= 1 )); then

--- a/slurm_scripts/ablations/submit_eval_planned_02.sh
+++ b/slurm_scripts/ablations/submit_eval_planned_02.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+set -euo pipefail
+# Eval submitter for the 2026-04-26 planned_02 ablation runs, including the
+# m=4 follow-up (planned_02_m4_followup) under the same RUNS table.
+#
+# Mirrors submit_eval_planned_01.sh but spans GS and AD datamodules, so the
+# crps_latent profile resolves the AE checkpoint via AE_CKPTS_BY_DATAMODULE.
+#
+#   crps_ambient   EPD CRPS run, eval.mode=ambient, best-multiwinkler ckpt
+#                  resolver (symlink-first, then best-multiwinkler-from0p25-*).
+#                  Output: <run>/eval_best_multiwinkler_from0p25/.
+#
+#   crps_latent    processor cached-latent CRPS run, eval.mode=auto -> encode_once
+#                  with the matching AE checkpoint, best-multiwinkler ckpt
+#                  resolver (same as crps_ambient).
+#                  Output: <run>/eval_best_multiwinkler_from0p25/.
+#
+# The two-step multi-Winkler resolver:
+#   1. <run>/autocast/<id>/checkpoints/best-multiwinkler.ckpt — a hand-picked
+#      symlink for runs where best-multiwinkler-pre0p25-*.ckpt beats the
+#      from-0.25 selection.
+#   2. otherwise, the latest best-multiwinkler-from0p25-*.ckpt as the default.
+#
+# GPE (latent_crps_m8_gpe) is intentionally omitted: the m=8 run collapsed and
+# will be rerun with m=16 only — eval will move to that follow-up script.
+
+EVAL_BATCH_SIZE_CRPS=8
+EVAL_N_MEMBERS=10
+TIMEOUT_MIN_CRPS=240
+EVAL_SUBDIR_MW="eval_best_multiwinkler_from0p25"
+ROLLOUT_SNAPSHOT_TIMESTEPS="[0,4,12,30,99]"
+RUN_DRY_STATES=("true" "false")
+EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
+
+declare -A AE_CKPTS_BY_DATAMODULE=(
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e/autoencoder.ckpt"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300/autoencoder.ckpt"
+)
+
+# run_id|profile|datamodule|run_dir
+# datamodule slot is only consumed by crps_latent (AE lookup); crps_ambient
+# rows still carry it for symmetry.
+RUNS=(
+    "latent_crps_m8_gs|crps_latent|gray_scott|outputs/2026-04-26/planned_02/crps_gs64_vit_azula_large_3b47441_1c8e446"
+    "latent_crps_m8_ad|crps_latent|advection_diffusion|outputs/2026-04-26/planned_02/crps_ad64_vit_azula_large_3b47441_3ad3562"
+    "vit_m4_gs|crps_ambient|gray_scott|outputs/2026-04-26/planned_02/crps_gs64_vit_azula_large_3b47441_4944cce"
+    "vit_m4_ad|crps_ambient|advection_diffusion|outputs/2026-04-26/planned_02_m4_followup/crps_ad64_vit_azula_large_189c141_bbb0bc8"
+    "vit_m4_gpe|crps_ambient|gpe_laser_only_wake|outputs/2026-04-26/planned_02_m4_followup/crps_gpe64_vit_azula_large_189c141_ce8db86"
+)
+
+resolve_multiwinkler_checkpoint() {
+    local run_dir="$1"
+    local -a ckpts=()
+
+    mapfile -t ckpts < <(
+        find "${run_dir}" -path '*/checkpoints/best-multiwinkler.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    mapfile -t ckpts < <(
+        find "${run_dir}" -type f -path '*/checkpoints/best-multiwinkler-from0p25-*.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    return 1
+}
+
+submit_crps_ambient() {
+    local run_id="$1" run_dir_abs="$2"
+    local eval_ckpt
+    if ! eval_ckpt="$(resolve_multiwinkler_checkpoint "${run_dir_abs}")"; then
+        echo "Skipping ${run_id}: no best-multiwinkler.ckpt symlink and no best-multiwinkler-from0p25-*.ckpt" >&2
+        return 0
+    fi
+    local eval_ckpt_abs eval_output_dir
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR_MW}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        local dry_run_arg=() run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting CRPS-ambient eval (best multi-Winkler)"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  eval.mode: ambient"
+        echo "  output_subdir: ${EVAL_SUBDIR_MW}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir_abs}" \
+            --output-subdir "${EVAL_SUBDIR_MW}" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            eval.mode=ambient \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
+            eval.save_rollout_snapshots=true \
+            eval.rollout_snapshot_dir="${eval_output_dir}/videos/snapshots" \
+            eval.rollout_snapshot_timesteps="${ROLLOUT_SNAPSHOT_TIMESTEPS}" \
+            eval.rollout_snapshot_format=png \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE_CRPS}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN_CRPS}"
+    done
+}
+
+submit_crps_latent() {
+    local run_id="$1" run_dir_abs="$2" ae_ckpt="$3"
+    if [[ ! -f "${ae_ckpt}" ]]; then
+        echo "Skipping ${run_id}: AE checkpoint missing at ${ae_ckpt}" >&2
+        return 0
+    fi
+    local ae_ckpt_abs
+    ae_ckpt_abs="$(realpath "${ae_ckpt}")"
+
+    local eval_ckpt
+    if ! eval_ckpt="$(resolve_multiwinkler_checkpoint "${run_dir_abs}")"; then
+        echo "Skipping ${run_id}: no best-multiwinkler.ckpt symlink and no best-multiwinkler-from0p25-*.ckpt" >&2
+        return 0
+    fi
+    local eval_ckpt_abs eval_output_dir
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR_MW}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        local dry_run_arg=() run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting CRPS cached-latent eval (best multi-Winkler)"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  autoencoder_checkpoint: ${ae_ckpt_abs}"
+        echo "  eval.mode: auto"
+        echo "  output_subdir: ${EVAL_SUBDIR_MW}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir_abs}" \
+            --output-subdir "${EVAL_SUBDIR_MW}" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            +autoencoder_checkpoint="${ae_ckpt_abs}" \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
+            eval.save_rollout_snapshots=true \
+            eval.rollout_snapshot_dir="${eval_output_dir}/videos/snapshots" \
+            eval.rollout_snapshot_timesteps="${ROLLOUT_SNAPSHOT_TIMESTEPS}" \
+            eval.rollout_snapshot_format=png \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE_CRPS}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN_CRPS}"
+    done
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS='|' read -r run_id profile datamodule run_dir <<< "${run_spec}"
+
+    if [[ ! -d "${run_dir}" ]]; then
+        echo "Skipping ${run_id}: run_dir missing at ${run_dir}" >&2
+        continue
+    fi
+    run_dir_abs="$(realpath "${run_dir}")"
+    if [[ ! -f "${run_dir_abs}/resolved_config.yaml" ]]; then
+        echo "Skipping ${run_id}: resolved_config.yaml missing under ${run_dir}" >&2
+        continue
+    fi
+
+    case "${profile}" in
+        crps_ambient)
+            submit_crps_ambient "${run_id}" "${run_dir_abs}"
+            ;;
+        crps_latent)
+            ae_ckpt="${AE_CKPTS_BY_DATAMODULE[$datamodule]:-}"
+            if [[ -z "${ae_ckpt}" ]]; then
+                echo "Skipping ${run_id}: no AE checkpoint configured for datamodule ${datamodule}" >&2
+                continue
+            fi
+            submit_crps_latent "${run_id}" "${run_dir_abs}" "${ae_ckpt}"
+            ;;
+        *)
+            echo "FATAL: unknown profile '${profile}' for ${run_id}" >&2
+            exit 1
+            ;;
+    esac
+done

--- a/slurm_scripts/ablations/submit_eval_planned_03.sh
+++ b/slurm_scripts/ablations/submit_eval_planned_03.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+# Eval submitter for the latent-diffusion sweep in planned ablation batch 03.
+#
+# All four runs share one profile: processor-only diffusion on cached AE
+# latents, evaluated through eval.mode=auto -> encode_once with the matching
+# per-dataset AE checkpoint. Mirrors slurm_scripts/comparison/eval/
+# submit_eval_fm_latent.sh — the diffusion sampler (50 ODE steps) is the
+# dominant per-rollout cost so batch=4/timeout=360 carry over.
+#
+# Output goes to <run>/eval_latent/.
+
+EVAL_BATCH_SIZE=4
+EVAL_N_MEMBERS=10
+TIMEOUT_MIN=360
+EVAL_SUBDIR="eval_latent"
+ROLLOUT_SNAPSHOT_TIMESTEPS="[0,4,12,30,99]"
+RUN_DRY_STATES=("true" "false")
+EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
+
+declare -A AE_CKPT=(
+    ["conditioned_navier_stokes"]="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8/autoencoder.ckpt"
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e/autoencoder.ckpt"
+    ["gpe_laser_only_wake"]="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f/autoencoder.ckpt"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300/autoencoder.ckpt"
+)
+
+# run_id|datamodule|run_dir
+# Fill in run_dir paths once submit_planned_03_large.sh has produced runs.
+RUNS=(
+    "latent_diffusion_cns|conditioned_navier_stokes|outputs/REPLACE_ME/planned_03/diff_cns64_diffusion_vit_REPLACE_ME"
+    "latent_diffusion_gs|gray_scott|outputs/REPLACE_ME/planned_03/diff_gs64_diffusion_vit_REPLACE_ME"
+    "latent_diffusion_gpe|gpe_laser_only_wake|outputs/REPLACE_ME/planned_03/diff_gpe64_diffusion_vit_REPLACE_ME"
+    "latent_diffusion_ad|advection_diffusion|outputs/REPLACE_ME/planned_03/diff_ad64_diffusion_vit_REPLACE_ME"
+)
+
+submit_diffusion_latent() {
+    local run_id="$1" run_dir_abs="$2" ae_ckpt="$3"
+    if [[ ! -f "${ae_ckpt}" ]]; then
+        echo "Skipping ${run_id}: AE checkpoint missing at ${ae_ckpt}" >&2
+        return 0
+    fi
+    local ae_ckpt_abs
+    ae_ckpt_abs="$(realpath "${ae_ckpt}")"
+
+    local eval_ckpt="${run_dir_abs}/processor.ckpt"
+    if [[ ! -e "${eval_ckpt}" ]]; then
+        echo "Skipping ${run_id}: processor.ckpt missing" >&2
+        return 0
+    fi
+    local eval_ckpt_abs eval_output_dir
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        local dry_run_arg=() run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting diffusion cached-latent eval (mode=auto -> encode_once)"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  autoencoder_checkpoint: ${ae_ckpt_abs}"
+        echo "  eval.mode: auto"
+        echo "  output_subdir: ${EVAL_SUBDIR}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir_abs}" \
+            --output-subdir "${EVAL_SUBDIR}" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            +autoencoder_checkpoint="${ae_ckpt_abs}" \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
+            eval.save_rollout_snapshots=true \
+            eval.rollout_snapshot_dir="${eval_output_dir}/videos/snapshots" \
+            eval.rollout_snapshot_timesteps="${ROLLOUT_SNAPSHOT_TIMESTEPS}" \
+            eval.rollout_snapshot_format=png \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}"
+    done
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS='|' read -r run_id datamodule run_dir <<< "${run_spec}"
+
+    if [[ ! -d "${run_dir}" ]]; then
+        echo "Skipping ${run_id}: run_dir missing at ${run_dir}" >&2
+        continue
+    fi
+    run_dir_abs="$(realpath "${run_dir}")"
+    if [[ ! -f "${run_dir_abs}/resolved_config.yaml" ]]; then
+        echo "Skipping ${run_id}: resolved_config.yaml missing under ${run_dir}" >&2
+        continue
+    fi
+
+    ae_ckpt="${AE_CKPT[$datamodule]:-}"
+    if [[ -z "${ae_ckpt}" ]]; then
+        echo "Skipping ${run_id}: no AE checkpoint configured for ${datamodule}" >&2
+        continue
+    fi
+
+    submit_diffusion_latent "${run_id}" "${run_dir_abs}" "${ae_ckpt}"
+done

--- a/slurm_scripts/ablations/submit_planned_01_large.sh
+++ b/slurm_scripts/ablations/submit_planned_01_large.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cached_latents_against_ae.sh"
 
-# 24h production jobs for the planned CNS ablation batch.
+# 24h production jobs for planned ablation batch 01.
 #
-# Run submit_planned_cns_timing.sh first. This script resolves each
+# Run submit_planned_01_timing.sh first. This script resolves each
 # trainer.max_epochs from either COSINE_EPOCHS_BY_RUN or the latest matching
-# timing.ckpt under outputs/*/timing_planned_cns/<run_id>/timing.ckpt.
+# timing.ckpt under outputs/*/timing_planned_01/<run_id>/timing.ckpt. It also
+# checks the legacy timing_planned_cns path for already-collected batch-01
+# timing outputs.
 
 declare -A COSINE_EPOCHS_BY_RUN=(
     # Pinned from outputs/2026-04-25/timing_planned_cns/*/timing.ckpt at
@@ -26,7 +28,7 @@ declare -A COSINE_EPOCHS_BY_RUN=(
 BUDGET_MAX_TIME="00:23:59:00"
 TIMEOUT_MIN=1439
 SOURCE_DATASET="conditioned_navier_stokes"
-RUN_GROUP="$(date +%Y-%m-%d)/planned_cns"
+RUN_GROUP="$(date +%Y-%m-%d)/planned_01"
 RUN_DRY_STATES=("true" "false")
 AE_RUN_DIR="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8"
 CACHE_DIR="${AE_RUN_DIR}/cached_latents"
@@ -88,7 +90,10 @@ find_timing_checkpoint() {
         return 0
     fi
 
-    find outputs -path "*/timing_planned_cns/${run_id}/timing.ckpt" | sort | tail -n 1
+    find outputs \
+        \( -path "*/timing_planned_01/${run_id}/timing.ckpt" \
+        -o -path "*/timing_planned_cns/${run_id}/timing.ckpt" \) \
+        | sort | tail -n 1
 }
 
 derive_cosine_epochs_from_timing() {
@@ -145,7 +150,7 @@ for run_spec in "${RUNS[@]}"; do
             run_label="slurm --dry-run"
         fi
 
-        echo "Submitting planned CNS production run"
+        echo "Submitting planned batch 01 production run"
         echo "  mode: ${run_label}"
         echo "  run_id: ${run_id}"
         echo "  kind: ${kind}"

--- a/slurm_scripts/ablations/submit_planned_01_timing.sh
+++ b/slurm_scripts/ablations/submit_planned_01_timing.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cached_latents_against_ae.sh"
 
-# Timing jobs for the planned CNS ablation batch.
+# Timing jobs for planned ablation batch 01.
 #
 # This is intentionally CNS-only and cross-cuts the study-specific ablation
 # folders. Architecture-changing variants use local_experiment configs under
@@ -13,7 +13,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cac
 
 BUDGET_HOURS=24
 NUM_TIMING_EPOCHS=5
-RUN_GROUP="$(date +%Y-%m-%d)/timing_planned_cns"
+RUN_GROUP="$(date +%Y-%m-%d)/timing_planned_01"
 SOURCE_DATASET="conditioned_navier_stokes"
 AE_RUN_DIR="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8"
 CACHE_DIR="${AE_RUN_DIR}/cached_latents"
@@ -76,7 +76,7 @@ for run_spec in "${RUNS[@]}"; do
 
     mapfile -t overrides < <(run_overrides "${run_id}")
 
-    echo "Submitting planned CNS timing run"
+    echo "Submitting planned batch 01 timing run"
     echo "  run_id: ${run_id}"
     echo "  kind: ${kind}"
     echo "  source_dataset: ${SOURCE_DATASET}"
@@ -98,7 +98,7 @@ for run_spec in "${RUNS[@]}"; do
     echo ""
 done
 
-echo "All planned CNS timing jobs submitted."
+echo "All planned batch 01 timing jobs submitted."
 echo ""
 echo "Once SLURM jobs complete, collect all results with:"
 echo "  for f in outputs/${RUN_GROUP}/*/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/ablations/submit_planned_02_large.sh
+++ b/slurm_scripts/ablations/submit_planned_02_large.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cached_latents_against_ae.sh"
+
+# 24h production jobs for planned ablation batch 02.
+#
+# Run submit_planned_02_timing.sh first. This script resolves each
+# trainer.max_epochs from either COSINE_EPOCHS_BY_RUN or the latest matching
+# timing.ckpt under outputs/*/timing_planned_02/<run_id>/timing.ckpt.
+
+declare -A COSINE_EPOCHS_BY_RUN=(
+    # Optional pinned values, e.g. after timing:
+    # ["latent_crps_m8_gs"]=123
+)
+
+BUDGET_MAX_TIME="00:23:59:00"
+TIMEOUT_MIN=1439
+RUN_GROUP="$(date +%Y-%m-%d)/planned_02"
+RUN_DRY_STATES=("true" "false")
+
+declare -A AE_RUN_DIRS=(
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e"
+    ["gpe_laser_only_wake"]="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300"
+)
+
+# run_id|kind|datamodule|local_experiment
+RUNS=(
+    "latent_crps_m8_gs|processor|gray_scott|processor/gray_scott/crps_vit_azula_large"
+    "latent_crps_m8_gpe|processor|gpe_laser_only_wake|processor/gpe_laser_wake_only/crps_vit_azula_large"
+    "latent_crps_m8_ad|processor|advection_diffusion|processor/advection_diffusion/crps_vit_azula_large"
+    "vit_m4_gs|epd|gray_scott|epd/gray_scott/crps_vit_azula_large"
+)
+
+run_overrides() {
+    local run_id="$1"
+    local kind="$2"
+    local datamodule="$3"
+
+    case "${kind}" in
+        processor)
+            local ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
+            local cache_dir="${ae_run_dir}/cached_latents"
+            printf '%s\n' "datamodule=cached_latents" "datamodule.data_path=${cache_dir}"
+            ;;
+        epd)
+            case "${run_id}" in
+                vit_m4_gs)
+                    printf '%s\n' "datamodule=${datamodule}" "model.n_members=4" "datamodule.batch_size=64"
+                    ;;
+                *)
+                    printf '%s\n' "datamodule=${datamodule}"
+                    ;;
+            esac
+            ;;
+        *)
+            echo "FATAL: unknown kind '${kind}' for ${run_id}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+validate_run_inputs() {
+    local run_id="$1"
+    local kind="$2"
+    local datamodule="$3"
+
+    if [[ "${kind}" != "processor" ]]; then
+        return 0
+    fi
+
+    local ae_run_dir="${AE_RUN_DIRS[$datamodule]:-}"
+    if [[ -z "${ae_run_dir}" ]]; then
+        echo "Skipping ${run_id}: no AE run dir configured for ${datamodule}" >&2
+        return 1
+    fi
+
+    local cache_dir="${ae_run_dir}/cached_latents"
+    if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
+        echo "Skipping ${run_id}: cache missing train/valid/test under ${cache_dir}" >&2
+        return 1
+    fi
+    if ! validate_cached_latents_against_ae "${ae_run_dir}"; then
+        echo "Skipping ${run_id}: cached-latents config mismatch vs AE training config" >&2
+        return 1
+    fi
+}
+
+find_timing_checkpoint() {
+    local run_id="$1"
+
+    if [[ ! -d outputs ]]; then
+        return 0
+    fi
+
+    find outputs -path "*/timing_planned_02/${run_id}/timing.ckpt" | sort | tail -n 1
+}
+
+derive_cosine_epochs_from_timing() {
+    local timing_ckpt="$1"
+    local result
+
+    result="$(
+        uv run autocast time-epochs --from-checkpoint "${timing_ckpt}" -b 24 -m 0.02
+    )"
+
+    sed -n 's/.*trainer.max_epochs=\([0-9][0-9]*\).*/\1/p' <<< "${result}" | tail -n 1
+}
+
+resolve_cosine_epochs() {
+    local run_id="$1"
+    local cached="${COSINE_EPOCHS_BY_RUN[$run_id]:-}"
+
+    if [[ -n "${cached}" ]]; then
+        printf '%s\n' "${cached}"
+        return 0
+    fi
+
+    local timing_ckpt
+    timing_ckpt="$(find_timing_checkpoint "${run_id}")"
+    if [[ -z "${timing_ckpt}" ]]; then
+        return 1
+    fi
+
+    derive_cosine_epochs_from_timing "${timing_ckpt}"
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS="|" read -r run_id kind datamodule experiment <<< "${run_spec}"
+    if ! validate_run_inputs "${run_id}" "${kind}" "${datamodule}"; then
+        continue
+    fi
+
+    if ! cosine_epochs="$(resolve_cosine_epochs "${run_id}")"; then
+        echo "Skipping ${run_id}: no timing-derived cosine_epochs available" >&2
+        continue
+    fi
+    if [[ -z "${cosine_epochs}" ]]; then
+        echo "Skipping ${run_id}: could not parse trainer.max_epochs from timing output" >&2
+        continue
+    fi
+
+    mapfile -t overrides < <(run_overrides "${run_id}" "${kind}" "${datamodule}")
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        dry_run_arg=()
+        run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting planned batch 02 production run"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  kind: ${kind}"
+        echo "  datamodule: ${datamodule}"
+        echo "  local_experiment: ${experiment}"
+        echo "  cosine_epochs: ${cosine_epochs}"
+
+        uv run autocast "${kind}" --mode slurm "${dry_run_arg[@]}" \
+            --run-group "${RUN_GROUP}" \
+            local_experiment="${experiment}" \
+            "${overrides[@]}" \
+            logging.wandb.enabled=true \
+            logging.wandb.name="${run_id}" \
+            optimizer.cosine_epochs="${cosine_epochs}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+            trainer.max_time="${BUDGET_MAX_TIME}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_train_steps_fraction=0.05 \
+            +trainer.callbacks.0.every_n_epochs=0 \
+            trainer.callbacks.0.save_top_k=-1 \
+            trainer.callbacks.0.filename=\"snapshot-{progress_token}-{epoch:04d}-{step:08d}\"
+    done
+done

--- a/slurm_scripts/ablations/submit_planned_02_large.sh
+++ b/slurm_scripts/ablations/submit_planned_02_large.sh
@@ -11,8 +11,12 @@ source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cac
 # timing.ckpt under outputs/*/timing_planned_02/<run_id>/timing.ckpt.
 
 declare -A COSINE_EPOCHS_BY_RUN=(
-    # Optional pinned values, e.g. after timing:
-    # ["latent_crps_m8_gs"]=123
+    # Pinned from outputs/2026-04-26/timing_planned_02/*/retrieve.sh at
+    # 24h budget, 2% margin (uv run autocast time-epochs -b 24 -m 0.02).
+    ["latent_crps_m8_gs"]=273
+    ["latent_crps_m8_gpe"]=326
+    ["latent_crps_m8_ad"]=318
+    ["vit_m4_gs"]=706
 )
 
 BUDGET_MAX_TIME="00:23:59:00"

--- a/slurm_scripts/ablations/submit_planned_02_m4_followup_large.sh
+++ b/slurm_scripts/ablations/submit_planned_02_m4_followup_large.sh
@@ -9,8 +9,10 @@ set -euo pipefail
 # timing.ckpt under outputs/*/timing_planned_02_m4_followup/<run_id>/timing.ckpt.
 
 declare -A COSINE_EPOCHS_BY_RUN=(
-    # Optional pinned values from:
-    #   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24 -m 0.02
+    # Pinned from outputs/2026-04-26/timing_planned_02_m4_followup/*/retrieve.sh
+    # at 24h budget, 2% margin.
+    ["vit_m4_gpe"]=827
+    ["vit_m4_ad"]=846
 )
 
 BUDGET_MAX_TIME="00:23:59:00"

--- a/slurm_scripts/ablations/submit_planned_02_m4_followup_large.sh
+++ b/slurm_scripts/ablations/submit_planned_02_m4_followup_large.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# 24h production jobs for the planned batch 02 m=4 CRPS follow-up.
+#
+# Run submit_planned_02_m4_followup_timing.sh first. This script resolves each
+# trainer.max_epochs from either COSINE_EPOCHS_BY_RUN or the latest matching
+# timing.ckpt under outputs/*/timing_planned_02_m4_followup/<run_id>/timing.ckpt.
+
+declare -A COSINE_EPOCHS_BY_RUN=(
+    # Optional pinned values from:
+    #   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24 -m 0.02
+)
+
+BUDGET_MAX_TIME="00:23:59:00"
+TIMEOUT_MIN=1439
+RUN_GROUP="$(date +%Y-%m-%d)/planned_02_m4_followup"
+RUN_DRY_STATES=("true" "false")
+
+# run_id|datamodule|local_experiment
+RUNS=(
+    "vit_m4_gpe|gpe_laser_only_wake|epd/gpe_laser_wake_only/crps_vit_azula_large"
+    "vit_m4_ad|advection_diffusion|epd/advection_diffusion/crps_vit_azula_large"
+)
+
+run_overrides() {
+    local datamodule="$1"
+
+    printf '%s\n' \
+        "datamodule=${datamodule}" \
+        "model.n_members=4" \
+        "datamodule.batch_size=64"
+}
+
+find_timing_checkpoint() {
+    local run_id="$1"
+
+    if [[ ! -d outputs ]]; then
+        return 0
+    fi
+
+    find outputs/ -path "*/timing_planned_02_m4_followup/${run_id}/timing.ckpt" \
+        | sort | tail -n 1
+}
+
+derive_cosine_epochs_from_timing() {
+    local timing_ckpt="$1"
+    local result
+
+    result="$(
+        uv run autocast time-epochs --from-checkpoint "${timing_ckpt}" -b 24 -m 0.02
+    )"
+
+    sed -n 's/.*trainer.max_epochs=\([0-9][0-9]*\).*/\1/p' <<< "${result}" | tail -n 1
+}
+
+resolve_cosine_epochs() {
+    local run_id="$1"
+    local cached="${COSINE_EPOCHS_BY_RUN[$run_id]:-}"
+
+    if [[ -n "${cached}" ]]; then
+        printf '%s\n' "${cached}"
+        return 0
+    fi
+
+    local timing_ckpt
+    timing_ckpt="$(find_timing_checkpoint "${run_id}")"
+    if [[ -z "${timing_ckpt}" ]]; then
+        return 1
+    fi
+
+    derive_cosine_epochs_from_timing "${timing_ckpt}"
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS="|" read -r run_id datamodule experiment <<< "${run_spec}"
+
+    if ! cosine_epochs="$(resolve_cosine_epochs "${run_id}")"; then
+        echo "Skipping ${run_id}: no timing-derived cosine_epochs available" >&2
+        continue
+    fi
+    if [[ -z "${cosine_epochs}" ]]; then
+        echo "Skipping ${run_id}: could not parse trainer.max_epochs from timing output" >&2
+        continue
+    fi
+
+    mapfile -t overrides < <(run_overrides "${datamodule}")
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        dry_run_arg=()
+        run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting planned batch 02 m=4 follow-up production run"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  datamodule: ${datamodule}"
+        echo "  local_experiment: ${experiment}"
+        echo "  cosine_epochs: ${cosine_epochs}"
+
+        uv run autocast epd --mode slurm "${dry_run_arg[@]}" \
+            --run-group "${RUN_GROUP}" \
+            local_experiment="${experiment}" \
+            "${overrides[@]}" \
+            logging.wandb.enabled=true \
+            logging.wandb.name="${run_id}" \
+            optimizer.cosine_epochs="${cosine_epochs}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+            trainer.max_time="${BUDGET_MAX_TIME}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_train_steps_fraction=0.05 \
+            +trainer.callbacks.0.every_n_epochs=0 \
+            trainer.callbacks.0.save_top_k=-1 \
+            trainer.callbacks.0.filename=\"snapshot-{progress_token}-{epoch:04d}-{step:08d}\"
+    done
+done

--- a/slurm_scripts/ablations/submit_planned_02_m4_followup_timing.sh
+++ b/slurm_scripts/ablations/submit_planned_02_m4_followup_timing.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Timing jobs for the planned batch 02 m=4 CRPS follow-up.
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing_planned_02_m4_followup"
+
+# run_id|datamodule|local_experiment
+RUNS=(
+    "vit_m4_gpe|gpe_laser_only_wake|epd/gpe_laser_wake_only/crps_vit_azula_large"
+    "vit_m4_ad|advection_diffusion|epd/advection_diffusion/crps_vit_azula_large"
+)
+
+run_overrides() {
+    local datamodule="$1"
+
+    printf '%s\n' \
+        "datamodule=${datamodule}" \
+        "model.n_members=4" \
+        "datamodule.batch_size=64"
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS="|" read -r run_id datamodule experiment <<< "${run_spec}"
+    mapfile -t overrides < <(run_overrides "${datamodule}")
+
+    echo "Submitting planned batch 02 m=4 follow-up timing run"
+    echo "  run_id: ${run_id}"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+    echo "  budget: ${BUDGET_HOURS}h"
+    echo "  run_group: ${RUN_GROUP}"
+
+    uv run autocast time-epochs --kind epd --mode slurm \
+        --run-group "${RUN_GROUP}" \
+        --run-id "${run_id}" \
+        -n "${NUM_TIMING_EPOCHS}" \
+        -b "${BUDGET_HOURS}" \
+        local_experiment="${experiment}" \
+        "${overrides[@]}"
+
+    echo ""
+    echo "---"
+    echo ""
+done
+
+echo "All planned batch 02 m=4 follow-up timing jobs submitted."
+echo ""
+echo "Once SLURM jobs complete, collect all results with:"
+echo "  for f in outputs/${RUN_GROUP}/*/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/ablations/submit_planned_02_timing.sh
+++ b/slurm_scripts/ablations/submit_planned_02_timing.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cached_latents_against_ae.sh"
+
+# Timing jobs for planned ablation batch 02.
+#
+# This deliberately sits next to, rather than edits,
+# submit_planned_01_timing.sh so the first CNS batch can remain a distinct
+# submission set.
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing_planned_02"
+
+declare -A AE_RUN_DIRS=(
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e"
+    ["gpe_laser_only_wake"]="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300"
+)
+
+# run_id|kind|datamodule|local_experiment
+RUNS=(
+    "latent_crps_m8_gs|processor|gray_scott|processor/gray_scott/crps_vit_azula_large"
+    "latent_crps_m8_gpe|processor|gpe_laser_only_wake|processor/gpe_laser_wake_only/crps_vit_azula_large"
+    "latent_crps_m8_ad|processor|advection_diffusion|processor/advection_diffusion/crps_vit_azula_large"
+    "vit_m4_gs|epd|gray_scott|epd/gray_scott/crps_vit_azula_large"
+)
+
+run_overrides() {
+    local run_id="$1"
+    local kind="$2"
+    local datamodule="$3"
+
+    case "${kind}" in
+        processor)
+            local ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
+            local cache_dir="${ae_run_dir}/cached_latents"
+            printf '%s\n' "datamodule=cached_latents" "datamodule.data_path=${cache_dir}"
+            ;;
+        epd)
+            case "${run_id}" in
+                vit_m4_gs)
+                    printf '%s\n' "datamodule=${datamodule}" "model.n_members=4" "datamodule.batch_size=64"
+                    ;;
+                *)
+                    printf '%s\n' "datamodule=${datamodule}"
+                    ;;
+            esac
+            ;;
+        *)
+            echo "FATAL: unknown kind '${kind}' for ${run_id}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+validate_run_inputs() {
+    local run_id="$1"
+    local kind="$2"
+    local datamodule="$3"
+
+    if [[ "${kind}" != "processor" ]]; then
+        return 0
+    fi
+
+    local ae_run_dir="${AE_RUN_DIRS[$datamodule]:-}"
+    if [[ -z "${ae_run_dir}" ]]; then
+        echo "Skipping ${run_id}: no AE run dir configured for ${datamodule}" >&2
+        return 1
+    fi
+
+    local cache_dir="${ae_run_dir}/cached_latents"
+    if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
+        echo "Skipping ${run_id}: cache missing train/valid/test under ${cache_dir}" >&2
+        return 1
+    fi
+    if ! validate_cached_latents_against_ae "${ae_run_dir}"; then
+        echo "Skipping ${run_id}: cached-latents config mismatch vs AE training config" >&2
+        return 1
+    fi
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS="|" read -r run_id kind datamodule experiment <<< "${run_spec}"
+    if ! validate_run_inputs "${run_id}" "${kind}" "${datamodule}"; then
+        continue
+    fi
+
+    mapfile -t overrides < <(run_overrides "${run_id}" "${kind}" "${datamodule}")
+
+    echo "Submitting planned batch 02 timing run"
+    echo "  run_id: ${run_id}"
+    echo "  kind: ${kind}"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+    echo "  budget: ${BUDGET_HOURS}h"
+    echo "  run_group: ${RUN_GROUP}"
+
+    uv run autocast time-epochs --kind "${kind}" --mode slurm \
+        --run-group "${RUN_GROUP}" \
+        --run-id "${run_id}" \
+        -n "${NUM_TIMING_EPOCHS}" \
+        -b "${BUDGET_HOURS}" \
+        local_experiment="${experiment}" \
+        "${overrides[@]}"
+
+    echo ""
+    echo "---"
+    echo ""
+done
+
+echo "All planned batch 02 timing jobs submitted."
+echo ""
+echo "Once SLURM jobs complete, collect all results with:"
+echo "  for f in outputs/${RUN_GROUP}/*/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/ablations/submit_planned_03_large.sh
+++ b/slurm_scripts/ablations/submit_planned_03_large.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cached_latents_against_ae.sh"
+
+# 24h production jobs for planned ablation batch 03.
+#
+# Run submit_planned_03_timing.sh first. This script resolves each
+# trainer.max_epochs from either COSINE_EPOCHS_BY_RUN or the latest matching
+# timing.ckpt under outputs/*/timing_planned_03/<run_id>/timing.ckpt.
+
+declare -A COSINE_EPOCHS_BY_RUN=()
+# Pin once timing has been retrieved, e.g.
+#     ["latent_diffusion_cns"]=NNN
+# from `uv run autocast time-epochs -b 24 -m 0.02`. Until any entry is
+# pinned, resolve_cosine_epochs falls back to the latest matching
+# outputs/*/timing_planned_03/<run_id>/timing.ckpt.
+
+BUDGET_MAX_TIME="00:23:59:00"
+TIMEOUT_MIN=1439
+RUN_GROUP="$(date +%Y-%m-%d)/planned_03"
+RUN_DRY_STATES=("true" "false")
+
+declare -A AE_RUN_DIRS=(
+    ["conditioned_navier_stokes"]="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8"
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e"
+    ["gpe_laser_only_wake"]="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300"
+)
+
+# run_id|kind|datamodule|local_experiment
+RUNS=(
+    "latent_diffusion_cns|processor|conditioned_navier_stokes|processor/conditioned_navier_stokes/diffusion_vit_large"
+    "latent_diffusion_gs|processor|gray_scott|processor/gray_scott/diffusion_vit_large"
+    "latent_diffusion_gpe|processor|gpe_laser_only_wake|processor/gpe_laser_wake_only/diffusion_vit_large"
+    "latent_diffusion_ad|processor|advection_diffusion|processor/advection_diffusion/diffusion_vit_large"
+)
+
+run_overrides() {
+    local run_id="$1"
+    local kind="$2"
+    local datamodule="$3"
+
+    case "${kind}" in
+        processor)
+            local ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
+            local cache_dir="${ae_run_dir}/cached_latents"
+            printf '%s\n' "datamodule=cached_latents" "datamodule.data_path=${cache_dir}"
+            ;;
+        *)
+            echo "FATAL: unknown kind '${kind}' for ${run_id}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+validate_run_inputs() {
+    local run_id="$1"
+    local kind="$2"
+    local datamodule="$3"
+
+    if [[ "${kind}" != "processor" ]]; then
+        return 0
+    fi
+
+    local ae_run_dir="${AE_RUN_DIRS[$datamodule]:-}"
+    if [[ -z "${ae_run_dir}" ]]; then
+        echo "Skipping ${run_id}: no AE run dir configured for ${datamodule}" >&2
+        return 1
+    fi
+
+    local cache_dir="${ae_run_dir}/cached_latents"
+    if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
+        echo "Skipping ${run_id}: cache missing train/valid/test under ${cache_dir}" >&2
+        return 1
+    fi
+    if ! validate_cached_latents_against_ae "${ae_run_dir}"; then
+        echo "Skipping ${run_id}: cached-latents config mismatch vs AE training config" >&2
+        return 1
+    fi
+}
+
+find_timing_checkpoint() {
+    local run_id="$1"
+
+    if [[ ! -d outputs ]]; then
+        return 0
+    fi
+
+    find outputs -path "*/timing_planned_03/${run_id}/timing.ckpt" | sort | tail -n 1
+}
+
+derive_cosine_epochs_from_timing() {
+    local timing_ckpt="$1"
+    local result
+
+    result="$(
+        uv run autocast time-epochs --from-checkpoint "${timing_ckpt}" -b 24 -m 0.02
+    )"
+
+    sed -n 's/.*trainer.max_epochs=\([0-9][0-9]*\).*/\1/p' <<< "${result}" | tail -n 1
+}
+
+resolve_cosine_epochs() {
+    local run_id="$1"
+    local cached="${COSINE_EPOCHS_BY_RUN[$run_id]:-}"
+
+    if [[ -n "${cached}" ]]; then
+        printf '%s\n' "${cached}"
+        return 0
+    fi
+
+    local timing_ckpt
+    timing_ckpt="$(find_timing_checkpoint "${run_id}")"
+    if [[ -z "${timing_ckpt}" ]]; then
+        return 1
+    fi
+
+    derive_cosine_epochs_from_timing "${timing_ckpt}"
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS="|" read -r run_id kind datamodule experiment <<< "${run_spec}"
+    if ! validate_run_inputs "${run_id}" "${kind}" "${datamodule}"; then
+        continue
+    fi
+
+    if ! cosine_epochs="$(resolve_cosine_epochs "${run_id}")"; then
+        echo "Skipping ${run_id}: no timing-derived cosine_epochs available" >&2
+        continue
+    fi
+    if [[ -z "${cosine_epochs}" ]]; then
+        echo "Skipping ${run_id}: could not parse trainer.max_epochs from timing output" >&2
+        continue
+    fi
+
+    mapfile -t overrides < <(run_overrides "${run_id}" "${kind}" "${datamodule}")
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        dry_run_arg=()
+        run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting planned batch 03 production run"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  kind: ${kind}"
+        echo "  datamodule: ${datamodule}"
+        echo "  local_experiment: ${experiment}"
+        echo "  cosine_epochs: ${cosine_epochs}"
+
+        uv run autocast "${kind}" --mode slurm "${dry_run_arg[@]}" \
+            --run-group "${RUN_GROUP}" \
+            local_experiment="${experiment}" \
+            "${overrides[@]}" \
+            logging.wandb.enabled=true \
+            logging.wandb.name="${run_id}" \
+            optimizer.cosine_epochs="${cosine_epochs}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}" \
+            trainer.max_time="${BUDGET_MAX_TIME}" \
+            +trainer.max_epochs="${cosine_epochs}" \
+            trainer.callbacks.0.every_n_train_steps_fraction=0.05 \
+            +trainer.callbacks.0.every_n_epochs=0 \
+            trainer.callbacks.0.save_top_k=-1 \
+            trainer.callbacks.0.filename=\"snapshot-{progress_token}-{epoch:04d}-{step:08d}\"
+    done
+done

--- a/slurm_scripts/ablations/submit_planned_03_large.sh
+++ b/slurm_scripts/ablations/submit_planned_03_large.sh
@@ -10,12 +10,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cac
 # trainer.max_epochs from either COSINE_EPOCHS_BY_RUN or the latest matching
 # timing.ckpt under outputs/*/timing_planned_03/<run_id>/timing.ckpt.
 
-declare -A COSINE_EPOCHS_BY_RUN=()
-# Pin once timing has been retrieved, e.g.
-#     ["latent_diffusion_cns"]=NNN
-# from `uv run autocast time-epochs -b 24 -m 0.02`. Until any entry is
-# pinned, resolve_cosine_epochs falls back to the latest matching
-# outputs/*/timing_planned_03/<run_id>/timing.ckpt.
+declare -A COSINE_EPOCHS_BY_RUN=(
+    # Pinned from outputs/2026-04-27/timing_planned_03/*/retrieve.sh at
+    # 24h budget, 2% margin (uv run autocast time-epochs -b 24 -m 0.02).
+    ["latent_diffusion_cns"]=2639
+    ["latent_diffusion_gs"]=2249
+    ["latent_diffusion_gpe"]=2674
+    ["latent_diffusion_ad"]=2601
+)
 
 BUDGET_MAX_TIME="00:23:59:00"
 TIMEOUT_MIN=1439

--- a/slurm_scripts/ablations/submit_planned_03_timing.sh
+++ b/slurm_scripts/ablations/submit_planned_03_timing.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../comparison/cached_latents/validate_cached_latents_against_ae.sh"
+
+# Timing jobs for planned ablation batch 03.
+#
+# This batch is a single-axis sweep: latent-space diffusion (DiffusionProcessor
+# trained on cached AE latents) across all four datasets, mirroring the
+# FM-latent comparison in slurm_scripts/comparison/cached_latents/. It sits
+# next to planned_01 (CNS-only) and planned_02 (CRPS/EPD across datasets) so
+# each batch can stay a distinct submission set.
+
+BUDGET_HOURS=24
+NUM_TIMING_EPOCHS=5
+RUN_GROUP="$(date +%Y-%m-%d)/timing_planned_03"
+
+declare -A AE_RUN_DIRS=(
+    ["conditioned_navier_stokes"]="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8"
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e"
+    ["gpe_laser_only_wake"]="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300"
+)
+
+# run_id|kind|datamodule|local_experiment
+RUNS=(
+    "latent_diffusion_cns|processor|conditioned_navier_stokes|processor/conditioned_navier_stokes/diffusion_vit_large"
+    "latent_diffusion_gs|processor|gray_scott|processor/gray_scott/diffusion_vit_large"
+    "latent_diffusion_gpe|processor|gpe_laser_only_wake|processor/gpe_laser_wake_only/diffusion_vit_large"
+    "latent_diffusion_ad|processor|advection_diffusion|processor/advection_diffusion/diffusion_vit_large"
+)
+
+run_overrides() {
+    local run_id="$1"
+    local kind="$2"
+    local datamodule="$3"
+
+    case "${kind}" in
+        processor)
+            local ae_run_dir="${AE_RUN_DIRS[$datamodule]}"
+            local cache_dir="${ae_run_dir}/cached_latents"
+            printf '%s\n' "datamodule=cached_latents" "datamodule.data_path=${cache_dir}"
+            ;;
+        *)
+            echo "FATAL: unknown kind '${kind}' for ${run_id}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+validate_run_inputs() {
+    local run_id="$1"
+    local kind="$2"
+    local datamodule="$3"
+
+    if [[ "${kind}" != "processor" ]]; then
+        return 0
+    fi
+
+    local ae_run_dir="${AE_RUN_DIRS[$datamodule]:-}"
+    if [[ -z "${ae_run_dir}" ]]; then
+        echo "Skipping ${run_id}: no AE run dir configured for ${datamodule}" >&2
+        return 1
+    fi
+
+    local cache_dir="${ae_run_dir}/cached_latents"
+    if [[ ! -d "${cache_dir}/train" ]] || [[ ! -d "${cache_dir}/valid" ]] || [[ ! -d "${cache_dir}/test" ]]; then
+        echo "Skipping ${run_id}: cache missing train/valid/test under ${cache_dir}" >&2
+        return 1
+    fi
+    if ! validate_cached_latents_against_ae "${ae_run_dir}"; then
+        echo "Skipping ${run_id}: cached-latents config mismatch vs AE training config" >&2
+        return 1
+    fi
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS="|" read -r run_id kind datamodule experiment <<< "${run_spec}"
+    if ! validate_run_inputs "${run_id}" "${kind}" "${datamodule}"; then
+        continue
+    fi
+
+    mapfile -t overrides < <(run_overrides "${run_id}" "${kind}" "${datamodule}")
+
+    echo "Submitting planned batch 03 timing run"
+    echo "  run_id: ${run_id}"
+    echo "  kind: ${kind}"
+    echo "  datamodule: ${datamodule}"
+    echo "  local_experiment: ${experiment}"
+    echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
+    echo "  budget: ${BUDGET_HOURS}h"
+    echo "  run_group: ${RUN_GROUP}"
+
+    uv run autocast time-epochs --kind "${kind}" --mode slurm \
+        --run-group "${RUN_GROUP}" \
+        --run-id "${run_id}" \
+        -n "${NUM_TIMING_EPOCHS}" \
+        -b "${BUDGET_HOURS}" \
+        local_experiment="${experiment}" \
+        "${overrides[@]}"
+
+    echo ""
+    echo "---"
+    echo ""
+done
+
+echo "All planned batch 03 timing jobs submitted."
+echo ""
+echo "Once SLURM jobs complete, collect all results with:"
+echo "  for f in outputs/${RUN_GROUP}/*/retrieve.sh; do bash \"\$f\"; done"

--- a/slurm_scripts/ablations/vit_mae_pretrain/README.md
+++ b/slurm_scripts/ablations/vit_mae_pretrain/README.md
@@ -22,8 +22,8 @@ but trains without the ensemble path:
 | `local_hydra/local_experiment/ablations/vit_mae_pretrain/conditioned_navier_stokes/vit_azula_large_mae_no_ensemble.yaml` | CNS deterministic MAE preset |
 | `submit_vit_mae_pretrain_timing.sh` | 5-epoch MAE timing run -> `timing.ckpt` |
 | `submit_vit_mae_pretrain_large.sh` | 24h MAE production run, keeping and W&B-logging all progress checkpoints |
-| `submit_vit_mae_to_crps_timing.sh` | 5-epoch timing for MAE-initialized CRPS fine-tuning with `n_members=16` |
-| `submit_vit_mae_to_crps_large.sh` | short MAE-initialized CRPS fine-tune, defaulting to a 4h budget |
+| `submit_vit_mae_to_crps_timing.sh` | 5-epoch timing for MAE-initialized CRPS fine-tuning with `n_members=8` |
+| `submit_vit_mae_to_crps_large.sh` | short MAE-initialized CRPS fine-tune, defaulting to a 6h budget |
 
 ## Workflow
 
@@ -60,21 +60,34 @@ checkpoint artifact uploads stay disabled with `logging.wandb.log_model=false`
 so a transient W&B artifact/auth failure cannot kill the Slurm job.
 
 For the follow-up shortened CRPS fine-tune, use the `vit_mae_to_crps` scripts
-and point `MAE_CHECKPOINT` at one of the MAE checkpoints:
+with no checkpoint argument to auto-detect the best local production MAE
+`best-val-*.ckpt`. You can also point `MAE_CHECKPOINT` at a MAE run directory;
+the scripts resolve that directory to the best-validation checkpoint, which is
+preferred over the final or exported end checkpoint for fine-tuning. Passing an
+explicit checkpoint file still overrides auto-detection.
 
 ```bash
-MAE_CHECKPOINT=/path/to/mae/encoder_processor_decoder.ckpt \
-  bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
+bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
 
-MAE_CHECKPOINT=/path/to/mae/encoder_processor_decoder.ckpt \
-  bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
+bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
 ```
 
-The CRPS fine-tune uses `n_members=16` with `datamodule.batch_size=16`, keeping
-the effective global batch at `16 x 16 x 4 GPUs = 1024`. It also uses
+The CRPS fine-tune uses `n_members=8` with `datamodule.batch_size=32`, matching
+the baseline effective global batch at `32 x 8 x 4 GPUs = 1024`. It also uses
 `resume_weights_only=true` rather than full-state resume, so the deterministic
 MAE weights initialize the CRPS ensemble model while the optimizer, scheduler,
 and time budget start fresh.
 
-The default CRPS fine-tune budget is 4h. Override it for both timing and large
-runs with, for example, `CRPS_BUDGET_HOURS=6`.
+The default CRPS fine-tune budget is 6h. Override it for both timing and large
+runs with, for example, `CRPS_BUDGET_HOURS=4`. The default fine-tune learning
+rate is `1e-4`, below the scratch CRPS baseline's `2e-4` but high enough to
+adapt the stochastic conditioning path; override it with
+`CRPS_LEARNING_RATE=5e-5` for a more conservative run.
+
+This follows the probabilistic-retrofitting recipe from Diaconu et al.
+(`arXiv:2603.01949`): initialize from deterministic weights, switch to an
+ensemble CRPS objective, and shrink the data batch by the ensemble expansion so
+the effective batch stays comparable. Their paper uses modest training ensemble
+sizes, reduced learning rates for CRPS retrofitting, and reports diminishing
+returns from increasing the training ensemble size, so the baseline `m=8`
+setting is the intended fine-tune point here.

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
@@ -74,6 +74,8 @@ if [[ -z "${MAE_CHECKPOINT}" ]]; then
     exit 1
 fi
 
+MAE_CHECKPOINT="$(realpath "${MAE_CHECKPOINT}")"
+
 declare -A EXPERIMENTS=(
     ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large"
 )

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
@@ -81,7 +81,9 @@ declare -A EXPERIMENTS=(
 )
 
 declare -A COSINE_EPOCHS_BY_DATASET=(
-    # ["conditioned_navier_stokes"]=...
+    # Pinned from outputs/2026-04-27/timing_vit_mae_to_crps/*/retrieve.sh at
+    # 6h budget, 2% margin (uv run autocast time-epochs -b 6 -m 0.02).
+    ["conditioned_navier_stokes"]=114
 )
 
 CRPS_BUDGET_HOURS="${CRPS_BUDGET_HOURS:-6}"

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
@@ -4,20 +4,73 @@ set -euo pipefail
 # Short MAE-initialized CRPS fine-tuning run on CNS.
 #
 # Usage:
-#   MAE_CHECKPOINT=/path/to/mae/encoder_processor_decoder.ckpt \
+#   bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
+#   # or explicitly:
+#   MAE_CHECKPOINT=/path/to/mae/run_dir \
 #     bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_large.sh
 #
 # Run submit_vit_mae_to_crps_timing.sh first. If COSINE_EPOCHS_BY_DATASET is
 # left blank, this script derives max_epochs from the newest matching timing.ckpt.
 
-MAE_CHECKPOINT="${MAE_CHECKPOINT:-${1:-}}"
-if [[ -z "${MAE_CHECKPOINT}" ]]; then
-    echo "FATAL: set MAE_CHECKPOINT or pass the MAE checkpoint path as argv[1]" >&2
+MAE_SOURCE="${MAE_CHECKPOINT:-${MAE_RUN_DIR:-${1:-}}}"
+
+select_best_val_checkpoint() {
+    awk '
+        {
+            base = $0
+            sub(/^.*\//, "", base)
+            sub(/\.ckpt$/, "", base)
+            n = split(base, parts, "-")
+            val_loss = parts[n] + 0
+            if (!seen || val_loss < best_val_loss) {
+                seen = 1
+                best_val_loss = val_loss
+                best_path = $0
+            }
+        }
+        END {
+            if (seen) {
+                print best_path
+            }
+        }
+    '
+}
+
+resolve_mae_checkpoint() {
+    local source="$1"
+
+    if [[ -f "${source}" ]]; then
+        printf '%s\n' "${source}"
+        return 0
+    fi
+
+    if [[ ! -d "${source}" ]]; then
+        return 1
+    fi
+
+    find "${source}" -type f -name 'best-val-*.ckpt' | select_best_val_checkpoint
+}
+
+find_default_mae_checkpoint() {
+    if [[ ! -d outputs ]]; then
+        return 0
+    fi
+
+    find outputs/ \
+        -path '*/vit_mae_pretrain/*/autocast/*/checkpoints/best-val-*.ckpt' \
+        | select_best_val_checkpoint
+}
+
+if [[ -z "${MAE_SOURCE}" ]]; then
+    MAE_SOURCE="auto:outputs/*/vit_mae_pretrain/*/autocast/*/checkpoints/best-val-*.ckpt"
+    MAE_CHECKPOINT="$(find_default_mae_checkpoint)"
+elif ! MAE_CHECKPOINT="$(resolve_mae_checkpoint "${MAE_SOURCE}")"; then
+    echo "FATAL: MAE source does not exist: ${MAE_SOURCE}" >&2
     exit 1
 fi
 
-if [[ ! -f "${MAE_CHECKPOINT}" ]]; then
-    echo "FATAL: MAE_CHECKPOINT does not exist: ${MAE_CHECKPOINT}" >&2
+if [[ -z "${MAE_CHECKPOINT}" ]]; then
+    echo "FATAL: no best-val-*.ckpt found for MAE source: ${MAE_SOURCE}" >&2
     exit 1
 fi
 
@@ -29,7 +82,8 @@ declare -A COSINE_EPOCHS_BY_DATASET=(
     # ["conditioned_navier_stokes"]=...
 )
 
-CRPS_BUDGET_HOURS="${CRPS_BUDGET_HOURS:-4}"
+CRPS_BUDGET_HOURS="${CRPS_BUDGET_HOURS:-6}"
+CRPS_LEARNING_RATE="${CRPS_LEARNING_RATE:-1e-4}"
 if ! [[ "${CRPS_BUDGET_HOURS}" =~ ^[1-9][0-9]*$ ]]; then
     echo "FATAL: CRPS_BUDGET_HOURS must be a positive integer number of hours" >&2
     exit 1
@@ -39,8 +93,8 @@ BUDGET_MAX_TIME="$(printf "00:%02d:59:00" "$((CRPS_BUDGET_HOURS - 1))")"
 TIMEOUT_MIN=$((CRPS_BUDGET_HOURS * 60 - 1))
 RUN_DRY_STATES=("true" "false")
 RUN_GROUP="$(date +%Y-%m-%d)/vit_mae_to_crps"
-N_MEMBERS=16
-BS_PER_GPU=16
+N_MEMBERS=8
+BS_PER_GPU=32
 
 find_timing_checkpoint() {
     local run_id="$1"
@@ -49,7 +103,7 @@ find_timing_checkpoint() {
         return 0
     fi
 
-    find outputs -path "*/timing_vit_mae_to_crps/${run_id}/timing.ckpt" | sort | tail -n 1
+    find outputs/ -path "*/timing_vit_mae_to_crps/${run_id}/timing.ckpt" | sort | tail -n 1
 }
 
 derive_cosine_epochs_from_timing() {
@@ -111,9 +165,11 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
         echo "  mode: ${run_label}"
         echo "  datamodule: ${datamodule}"
         echo "  local_experiment: ${experiment}"
+        echo "  mae source: ${MAE_SOURCE}"
         echo "  mae checkpoint: ${MAE_CHECKPOINT}"
         echo "  n_members: ${N_MEMBERS}"
         echo "  bs_per_gpu: ${BS_PER_GPU}"
+        echo "  learning_rate: ${CRPS_LEARNING_RATE}"
         echo "  budget: ${CRPS_BUDGET_HOURS}h"
         echo "  cosine_epochs: ${cosine_epochs}"
         echo "  wandb.name: ${wandb_name}"
@@ -124,6 +180,7 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
             local_experiment="${experiment}" \
             model.n_members="${N_MEMBERS}" \
             datamodule.batch_size="${BS_PER_GPU}" \
+            optimizer.learning_rate="${CRPS_LEARNING_RATE}" \
             +resume_from_checkpoint="${MAE_CHECKPOINT}" \
             +resume_weights_only=true \
             logging.wandb.enabled=true \

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
@@ -75,6 +75,8 @@ if [[ -z "${MAE_CHECKPOINT}" ]]; then
     exit 1
 fi
 
+MAE_CHECKPOINT="$(realpath "${MAE_CHECKPOINT}")"
+
 declare -A EXPERIMENTS=(
     ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large"
 )

--- a/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
+++ b/slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
@@ -4,20 +4,74 @@ set -euo pipefail
 # Timing run for MAE-initialized CRPS fine-tuning on CNS.
 #
 # Usage:
-#   MAE_CHECKPOINT=/path/to/mae/encoder_processor_decoder.ckpt \
+#   bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
+#   # or explicitly:
+#   MAE_CHECKPOINT=/path/to/mae/run_dir \
 #     bash slurm_scripts/ablations/vit_mae_pretrain/submit_vit_mae_to_crps_timing.sh
 #
-# This fine-tune uses CRPS with n_members=16 and batch_size=16/GPU, keeping
-# the effective global batch at 16 x 16 x 4 GPUs = 1024.
+# This fine-tune uses CRPS with n_members=8 and batch_size=32/GPU, matching
+# the baseline effective global batch of 32 x 8 x 4 GPUs = 1024. The lower
+# learning rate is intentional for MAE-initialized fine-tuning.
 
-MAE_CHECKPOINT="${MAE_CHECKPOINT:-${1:-}}"
-if [[ -z "${MAE_CHECKPOINT}" ]]; then
-    echo "FATAL: set MAE_CHECKPOINT or pass the MAE checkpoint path as argv[1]" >&2
+MAE_SOURCE="${MAE_CHECKPOINT:-${MAE_RUN_DIR:-${1:-}}}"
+
+select_best_val_checkpoint() {
+    awk '
+        {
+            base = $0
+            sub(/^.*\//, "", base)
+            sub(/\.ckpt$/, "", base)
+            n = split(base, parts, "-")
+            val_loss = parts[n] + 0
+            if (!seen || val_loss < best_val_loss) {
+                seen = 1
+                best_val_loss = val_loss
+                best_path = $0
+            }
+        }
+        END {
+            if (seen) {
+                print best_path
+            }
+        }
+    '
+}
+
+resolve_mae_checkpoint() {
+    local source="$1"
+
+    if [[ -f "${source}" ]]; then
+        printf '%s\n' "${source}"
+        return 0
+    fi
+
+    if [[ ! -d "${source}" ]]; then
+        return 1
+    fi
+
+    find "${source}" -type f -name 'best-val-*.ckpt' | select_best_val_checkpoint
+}
+
+find_default_mae_checkpoint() {
+    if [[ ! -d outputs ]]; then
+        return 0
+    fi
+
+    find outputs/ \
+        -path '*/vit_mae_pretrain/*/autocast/*/checkpoints/best-val-*.ckpt' \
+        | select_best_val_checkpoint
+}
+
+if [[ -z "${MAE_SOURCE}" ]]; then
+    MAE_SOURCE="auto:outputs/*/vit_mae_pretrain/*/autocast/*/checkpoints/best-val-*.ckpt"
+    MAE_CHECKPOINT="$(find_default_mae_checkpoint)"
+elif ! MAE_CHECKPOINT="$(resolve_mae_checkpoint "${MAE_SOURCE}")"; then
+    echo "FATAL: MAE source does not exist: ${MAE_SOURCE}" >&2
     exit 1
 fi
 
-if [[ ! -f "${MAE_CHECKPOINT}" ]]; then
-    echo "FATAL: MAE_CHECKPOINT does not exist: ${MAE_CHECKPOINT}" >&2
+if [[ -z "${MAE_CHECKPOINT}" ]]; then
+    echo "FATAL: no best-val-*.ckpt found for MAE source: ${MAE_SOURCE}" >&2
     exit 1
 fi
 
@@ -25,11 +79,12 @@ declare -A EXPERIMENTS=(
     ["conditioned_navier_stokes"]="epd/conditioned_navier_stokes/crps_vit_azula_large"
 )
 
-CRPS_BUDGET_HOURS="${CRPS_BUDGET_HOURS:-4}"
+CRPS_BUDGET_HOURS="${CRPS_BUDGET_HOURS:-6}"
+CRPS_LEARNING_RATE="${CRPS_LEARNING_RATE:-1e-4}"
 NUM_TIMING_EPOCHS=5
 RUN_GROUP="$(date +%Y-%m-%d)/timing_vit_mae_to_crps"
-N_MEMBERS=16
-BS_PER_GPU=16
+N_MEMBERS=8
+BS_PER_GPU=32
 
 for datamodule in "${!EXPERIMENTS[@]}"; do
     experiment="${EXPERIMENTS[$datamodule]}"
@@ -38,9 +93,11 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
     echo "Submitting MAE-initialized CRPS timing run"
     echo "  datamodule: ${datamodule}"
     echo "  local_experiment: ${experiment}"
+    echo "  mae source: ${MAE_SOURCE}"
     echo "  mae checkpoint: ${MAE_CHECKPOINT}"
     echo "  n_members: ${N_MEMBERS}"
     echo "  bs_per_gpu: ${BS_PER_GPU}"
+    echo "  learning_rate: ${CRPS_LEARNING_RATE}"
     echo "  run_id: ${run_id}"
     echo "  timing epochs: ${NUM_TIMING_EPOCHS}"
     echo "  budget: ${CRPS_BUDGET_HOURS}h"
@@ -56,8 +113,10 @@ for datamodule in "${!EXPERIMENTS[@]}"; do
         local_experiment="${experiment}" \
         model.n_members="${N_MEMBERS}" \
         datamodule.batch_size="${BS_PER_GPU}" \
+        optimizer.learning_rate="${CRPS_LEARNING_RATE}" \
         +resume_from_checkpoint="${MAE_CHECKPOINT}" \
-        +resume_weights_only=true
+        +resume_weights_only=true \
+        logging.wandb.log_model=false
 
     echo ""
     echo "---"

--- a/slurm_scripts/comparison/README.md
+++ b/slurm_scripts/comparison/README.md
@@ -107,7 +107,7 @@ and isolate the encoder effect. The config already lives at
 ## Planned CNS ablation batch
 
 The cross-cutting CNS batch is scripted in
-`slurm_scripts/ablations/submit_planned_cns_{timing,large}.sh`. It keeps
+`slurm_scripts/ablations/submit_planned_01_{timing,large}.sh`. It keeps
 the main CRPS comparison anchored to the 2026-04-24 CRPS runs and the FM/diff
 reference anchored to the 2026-04-20 diff basis.
 

--- a/slurm_scripts/comparison/eval/submit_eval_crps_ambient_best_multiwinkler_from0p25.sh
+++ b/slurm_scripts/comparison/eval/submit_eval_crps_ambient_best_multiwinkler_from0p25.sh
@@ -3,9 +3,12 @@
 set -euo pipefail
 # Evaluate CRPS-in-ambient EPD runs trained on 2026-04-24.
 #
-# This variant selects the best multi-Winkler checkpoint after the 0.25
-# progress cutoff: best-multiwinkler-from0p25-*.ckpt. The default CRPS ambient
-# eval submitter is left unchanged.
+# Picks the multi-Winkler checkpoint per run with a two-step resolver:
+#   1. <run>/autocast/<id>/checkpoints/best-multiwinkler.ckpt — a hand-picked
+#      symlink, used for runs where best-multiwinkler-pre0p25-*.ckpt beats the
+#      from-0.25 selection.
+#   2. otherwise, the latest best-multiwinkler-from0p25-*.ckpt as the default.
+# The default CRPS ambient eval submitter is left unchanged.
 #
 # Force eval.mode=ambient. These stateless EPD checkpoints can look
 # processor-only to eval.mode=auto because PermuteConcat / ChannelsLast add no
@@ -31,6 +34,15 @@ resolve_multiwinkler_checkpoint() {
     local -a ckpts=()
 
     mapfile -t ckpts < <(
+        find "${run_dir}" -path '*/checkpoints/best-multiwinkler.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    mapfile -t ckpts < <(
         find "${run_dir}" -type f -path '*/checkpoints/best-multiwinkler-from0p25-*.ckpt' | sort
     )
 
@@ -50,7 +62,7 @@ for run_dir in "${RUN_DIRS[@]}"; do
     fi
 
     if ! eval_ckpt="$(resolve_multiwinkler_checkpoint "${run_dir_abs}")"; then
-        echo "Skipping ${run_dir}: best-multiwinkler-from0p25-*.ckpt missing" >&2
+        echo "Skipping ${run_dir}: no best-multiwinkler.ckpt symlink and no best-multiwinkler-from0p25-*.ckpt" >&2
         continue
     fi
     eval_ckpt_abs="$(realpath "${eval_ckpt}")"

--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -117,6 +117,20 @@ callbacks:
     save_last: false
     filename: "best-multiwinkler-from0p75-{epoch:04d}-{val_multiwinkler:.4f}"
     auto_insert_metric_name: false
+  # Overall-best interval-score checkpoint with no upper window. The windowed
+  # callbacks above can disagree on the global minimum (e.g. pre0p25 wins when
+  # multiwinkler peaks early), and 4-decimal filename rounding hides ties — so
+  # this one tracks the absolute best across the run for the eval resolver.
+  # A small start_after_fraction floor avoids latching onto noisy first epochs.
+  - _target_: autocast.callbacks.checkpoint.ProgressModelCheckpoint
+    monitor: val_multiwinkler
+    monitor_optional: true
+    start_after_fraction: 0.05
+    mode: min
+    save_top_k: 1
+    save_last: false
+    filename: "best-multiwinkler-overall-{epoch:04d}-{val_multiwinkler:.4f}"
+    auto_insert_metric_name: false
   # Plot scalar validation metric histories and custom metric diagnostics
   # such as the MultiCoverage reliability curve at each validation end.
   - _target_: autocast.callbacks.metrics.ValidationMetricPlotCallback


### PR DESCRIPTION
## Summary
- add planned batch 01/02/03 ablation submission and evaluation scripts, including timing and production variants
- add diffusion ViT processor configs for GS, GPE, AD, and conditioned Navier-Stokes runs
- update ViT MAE-to-CRPS fine-tuning scripts and docs for m=8 defaults, checkpoint discovery, and timing-derived epochs
- add an overall best multiwinkler checkpoint callback for evaluation resolution

## Tests
- uv run pytest tests/scripts/test_workflow.py