### PR TITLE
Normalize launcher config loading through OmegaConf

### DIFF
--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -143,11 +143,12 @@ def _load_launcher_from_file(path: Path) -> dict:
     if not isinstance(raw, dict):
         return {}
     distributed = _extract_distributed_preset_name(raw)
-    if distributed:
-        merged = OmegaConf.merge(_load_distributed_cfg(distributed), raw)
-        cfg = OmegaConf.to_container(merged, resolve=False)
-    else:
-        cfg = raw
+    merged = (
+        OmegaConf.merge(_load_distributed_cfg(distributed), OmegaConf.create(raw))
+        if distributed
+        else OmegaConf.create(raw)
+    )
+    cfg = OmegaConf.to_container(merged, resolve=False)
     if not isinstance(cfg, dict):
         return {}
     hydra_cfg = cfg.get("hydra")

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -189,11 +189,12 @@ def _load_launcher_from_file(path: Path) -> dict:
     if not isinstance(raw, dict):
         return {}
     distributed = _extract_distributed_preset_name(raw)
-    if distributed:
-        merged = OmegaConf.merge(_load_distributed_cfg(distributed), raw)
-        cfg = OmegaConf.to_container(merged, resolve=False)
-    else:
-        cfg = raw
+    merged = (
+        OmegaConf.merge(_load_distributed_cfg(distributed), OmegaConf.create(raw))
+        if distributed
+        else OmegaConf.create(raw)
+    )
+    cfg = OmegaConf.to_container(merged, resolve=False)
     if not isinstance(cfg, dict):
         return {}
     return _extract_launcher_cfg(cfg)


### PR DESCRIPTION
OmegaConf.merge requires both arguments to be OmegaConf objects. OmegaConf.to_container() returns a plain Python dict, so passing it directly as the second argument raises a TypeError at runtime when a distributed preset is configured.

Fix by wrapping raw with OmegaConf.create() before merging, and apply the same wrapping in the else branch for consistency.