### PR TITLE
feat: reuse cached tensors for rollout dataloaders to save memory

### DIFF
--- a/src/autocast/data/datamodule.py
+++ b/src/autocast/data/datamodule.py
@@ -288,7 +288,9 @@ class SpatioTemporalDataModule(LightningDataModule):
                     "data": self.test_dataset.data,
                     "constant_scalars": self.test_dataset.constant_scalars,
                     "constant_fields": self.test_dataset.constant_fields,
-                } if data is None else data["test"],
+                }
+                if data is None
+                else data["test"],
                 n_steps_input=n_steps_input,
                 n_steps_output=n_steps_output,
                 stride=stride,

--- a/src/autocast/data/datamodule.py
+++ b/src/autocast/data/datamodule.py
@@ -266,10 +266,11 @@ class SpatioTemporalDataModule(LightningDataModule):
         self.batch_size = batch_size
 
         if not self.autoencoder_mode:
-            # Reuse already-loaded tensors to avoid reading the dataset from disk twice.
+            # Reuse loaded tensors; the payload records if channel_idxs were applied
+            # so rollout datasets do not slice the data a second time.
             self.rollout_val_dataset = dataset_cls(
-                data_path=str(train_path) if train_path is not None else None,
-                data=data["valid"] if data is not None else None,
+                data_path=None,
+                data=self.train_dataset.to_preloaded_data(),
                 n_steps_input=n_steps_input,
                 n_steps_output=n_steps_output,
                 stride=stride,
@@ -284,13 +285,7 @@ class SpatioTemporalDataModule(LightningDataModule):
             )
             self.rollout_test_dataset = dataset_cls(
                 data_path=None,
-                data={
-                    "data": self.test_dataset.data,
-                    "constant_scalars": self.test_dataset.constant_scalars,
-                    "constant_fields": self.test_dataset.constant_fields,
-                }
-                if data is None
-                else data["test"],
+                data=self.test_dataset.to_preloaded_data(),
                 n_steps_input=n_steps_input,
                 n_steps_output=n_steps_output,
                 stride=stride,

--- a/src/autocast/data/datamodule.py
+++ b/src/autocast/data/datamodule.py
@@ -264,9 +264,14 @@ class SpatioTemporalDataModule(LightningDataModule):
         self.batch_size = batch_size
 
         if not self.autoencoder_mode:
+            # Reuse already-loaded tensors to avoid reading the dataset from disk twice.
             self.rollout_val_dataset = dataset_cls(
-                data_path=str(train_path) if train_path is not None else None,
-                data=data["train"] if data is not None else None,
+                data_path=None,
+                data={
+                    "data": self.train_dataset.data,
+                    "constant_scalars": self.train_dataset.constant_scalars,
+                    "constant_fields": self.train_dataset.constant_fields,
+                } if data is None else data["train"],
                 n_steps_input=n_steps_input,
                 n_steps_output=n_steps_output,
                 stride=stride,
@@ -280,8 +285,12 @@ class SpatioTemporalDataModule(LightningDataModule):
                 normalization_stats=normalization_stats,
             )
             self.rollout_test_dataset = dataset_cls(
-                data_path=str(test_path) if test_path is not None else None,
-                data=data["test"] if data is not None else None,
+                data_path=None,
+                data={
+                    "data": self.test_dataset.data,
+                    "constant_scalars": self.test_dataset.constant_scalars,
+                    "constant_fields": self.test_dataset.constant_fields,
+                } if data is None else data["test"],
                 n_steps_input=n_steps_input,
                 n_steps_output=n_steps_output,
                 stride=stride,

--- a/src/autocast/data/datamodule.py
+++ b/src/autocast/data/datamodule.py
@@ -266,6 +266,7 @@ class SpatioTemporalDataModule(LightningDataModule):
         self.batch_size = batch_size
 
         if not self.autoencoder_mode:
+            # Reuse already-loaded tensors to avoid reading the dataset from disk twice.
             self.rollout_val_dataset = dataset_cls(
                 data_path=str(train_path) if train_path is not None else None,
                 data=data["valid"] if data is not None else None,
@@ -282,8 +283,12 @@ class SpatioTemporalDataModule(LightningDataModule):
                 normalization_stats=normalization_stats,
             )
             self.rollout_test_dataset = dataset_cls(
-                data_path=str(test_path) if test_path is not None else None,
-                data=data["test"] if data is not None else None,
+                data_path=None,
+                data={
+                    "data": self.test_dataset.data,
+                    "constant_scalars": self.test_dataset.constant_scalars,
+                    "constant_fields": self.test_dataset.constant_fields,
+                } if data is None else data["test"],
                 n_steps_input=n_steps_input,
                 n_steps_output=n_steps_output,
                 stride=stride,

--- a/src/autocast/data/datamodule.py
+++ b/src/autocast/data/datamodule.py
@@ -271,7 +271,9 @@ class SpatioTemporalDataModule(LightningDataModule):
                     "data": self.train_dataset.data,
                     "constant_scalars": self.train_dataset.constant_scalars,
                     "constant_fields": self.train_dataset.constant_fields,
-                } if data is None else data["train"],
+                }
+                if data is None
+                else data["train"],
                 n_steps_input=n_steps_input,
                 n_steps_output=n_steps_output,
                 stride=stride,
@@ -290,7 +292,9 @@ class SpatioTemporalDataModule(LightningDataModule):
                     "data": self.test_dataset.data,
                     "constant_scalars": self.test_dataset.constant_scalars,
                     "constant_fields": self.test_dataset.constant_fields,
-                } if data is None else data["test"],
+                }
+                if data is None
+                else data["test"],
                 n_steps_input=n_steps_input,
                 n_steps_output=n_steps_output,
                 stride=stride,

--- a/src/autocast/data/dataset.py
+++ b/src/autocast/data/dataset.py
@@ -94,6 +94,7 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
         self.normalization_path = normalization_path
         self.normalization_stats = normalization_stats
         self.autoencoder_mode = autoencoder_mode
+        self._channel_idxs_applied = False
 
         if data_path is not None:
             self.read_data(data_path)
@@ -101,8 +102,9 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
         if data is not None:
             self.parse_data(data)
 
-        if channel_idxs is not None:
+        if channel_idxs is not None and not self._channel_idxs_applied:
             self.data = self.data[..., list(channel_idxs)]
+            self._channel_idxs_applied = True
 
         self.set_up_normalization()
 
@@ -216,6 +218,7 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             and f["constant_fields"] != {}
             else None
         )
+        self._channel_idxs_applied = bool(f.get("_channel_idxs_applied", False))
 
     def read_data(self, data_path: str):
         """Read data.
@@ -239,9 +242,19 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             )
             self.constant_scalars = data.get("constant_scalars", None)
             self.constant_fields = data.get("constant_fields", None)
+            self._channel_idxs_applied = bool(data.get("_channel_idxs_applied", False))
             return
         msg = "No data provided to parse."
         raise ValueError(msg)
+
+    def to_preloaded_data(self) -> dict[str, Any]:
+        """Return the in-memory payload accepted by ``data=`` without copying."""
+        return {
+            "data": self.data,
+            "constant_scalars": self.constant_scalars,
+            "constant_fields": self.constant_fields,
+            "_channel_idxs_applied": self._channel_idxs_applied,
+        }
 
     def __len__(self):  # noqa: D105
         return len(self.all_input_fields)

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -1,0 +1,25 @@
+import torch
+
+from autocast.data.datamodule import SpatioTemporalDataModule
+
+
+def test_file_backed_rollout_datasets_apply_channel_idxs_once(tmp_path):
+    payload = {"data": torch.randn(2, 6, 3, 4, 2)}
+    for split in ("train", "valid", "test"):
+        split_dir = tmp_path / split
+        split_dir.mkdir()
+        torch.save(payload, split_dir / "data.pt")
+
+    dm = SpatioTemporalDataModule(
+        data_path=str(tmp_path),
+        n_steps_input=2,
+        n_steps_output=2,
+        channel_idxs=(1,),
+        ftype="torch",
+    )
+
+    assert dm.train_dataset.data.shape[-1] == 1
+    assert dm.rollout_val_dataset.data.shape[-1] == 1
+    assert dm.rollout_test_dataset.data.shape[-1] == 1
+    assert dm.rollout_val_dataset.data is dm.train_dataset.data
+    assert dm.rollout_test_dataset.data is dm.test_dataset.data


### PR DESCRIPTION
I discovered this from an OOM error during training my ViT model. When data_path is provided, rollout_val_dataset and rollout_test_dataset previously reloaded the full dataset from disk, doubling peak memory usage. This change passes the already-loaded tensors directly from train_dataset / test_dataset, so no second disk read occurs. 