### PR TITLE
Add latent diffusion and AE 24x ablations

### DIFF
--- a/slurm_scripts/ablations/README.md
+++ b/slurm_scripts/ablations/README.md
@@ -30,7 +30,7 @@ small edit.
 | cached_latent_crps | comparison | CNS | 1 (basis: 2026-04-20) | eval ready |
 | cond_global_vs_permute | comparison | CNS | 1 planned rerun (+old 2026-04-18 point) | config ready |
 | eval_only/ode_steps | eval-only | GS / GPE / CNS / AD | 4 | ready |
-| eval_only/ema | eval-only | EMA ckpts | 0 | stub |
+| eval_only/ema | eval-only | GS / GPE / CNS / AD | 4 | ready |
 
 "Done" entries refer to runs already produced by
 `slurm_scripts/comparison/` that double as the CNS data point for this

--- a/slurm_scripts/ablations/README.md
+++ b/slurm_scripts/ablations/README.md
@@ -29,7 +29,7 @@ small edit.
 | vit_mae_pretrain | pretrain | CNS | 1 | staged |
 | cached_latent_crps | comparison | CNS | 1 (basis: 2026-04-20) | eval ready |
 | cond_global_vs_permute | comparison | CNS | 1 planned rerun (+old 2026-04-18 point) | config ready |
-| eval_only/ode_steps | eval-only | FM runs | 0 | stub |
+| eval_only/ode_steps | eval-only | GS / GPE / CNS / AD | 4 | ready |
 | eval_only/ema | eval-only | EMA ckpts | 0 | stub |
 
 "Done" entries refer to runs already produced by

--- a/slurm_scripts/ablations/ae_compression/README.md
+++ b/slurm_scripts/ablations/ae_compression/README.md
@@ -50,6 +50,7 @@ downsamples (3 → 64 → 16; 4 → 64 → 8).
 | `submit_cache_latents_f8.sh` | cache f8 latents from `ae_cns64_de1b4b7_e1059d7` |
 | `submit_fm_f8_timing.sh` | 5-epoch FM-in-latent timing run on f8 latents |
 | `submit_fm_f8_large.sh` | 24h FM-in-latent run on f8 latents (placeholder `COSINE_EPOCHS`) |
+| `submit_eval_fm_f8_encode_once.sh` | eval the f8 FM-in-latent run with raw-space encode-once metrics |
 
 ## Workflow
 
@@ -71,6 +72,8 @@ Once `ae_cns64_de1b4b7_e1059d7` (base 50M f8) finishes:
    not directly transferable).
 3. Update `COSINE_EPOCHS` in `submit_fm_f8_large.sh` from the timing
    output, then `bash submit_fm_f8_large.sh`.
+4. `bash submit_eval_fm_f8_encode_once.sh` — eval the trained f8 FM run
+   through `eval.mode=encode_once`, writing to `eval_encode_once/`.
 
 Reuses `processor/conditioned_navier_stokes/fm_vit_large.yaml` unchanged
 — the `vit` backbone with `patch_size=1` adapts to the smaller spatial

--- a/slurm_scripts/ablations/ae_compression/submit_eval_fm_f8_encode_once.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_eval_fm_f8_encode_once.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# CNS-only AE-compression eval: FM-in-latent run on f8 (8x8x8) cached latents.
+#
+# Eval uses encode_once so metrics stay in raw data space after decoding while
+# avoiding the ambient path's per-step decode->encode loop.
+#
+# Output goes to <run>/eval_encode_once/.
+
+RUN_ID="fm_f8_cns"
+RUN_DIR="outputs/2026-05-01/diff_cns64_flow_matching_vit_43cbdde_bb55197"
+AE_CKPT="$HOME/autocast/outputs/2026-04-26/ae_cns64_de1b4b7_e1059d7/autoencoder.ckpt"
+
+EVAL_BATCH_SIZE=4
+EVAL_N_MEMBERS=10
+TIMEOUT_MIN=360
+EVAL_SUBDIR="eval_encode_once"
+ROLLOUT_SNAPSHOT_TIMESTEPS="[0,4,12,30,99]"
+RUN_DRY_STATES=("true" "false")
+EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
+
+if [[ ! -d "${RUN_DIR}" ]]; then
+    echo "Missing run_dir at ${RUN_DIR}" >&2
+    exit 1
+fi
+run_dir_abs="$(realpath "${RUN_DIR}")"
+
+if [[ ! -f "${run_dir_abs}/resolved_config.yaml" ]]; then
+    echo "Missing resolved_config.yaml under ${RUN_DIR}" >&2
+    exit 1
+fi
+
+eval_ckpt="${run_dir_abs}/processor.ckpt"
+if [[ ! -f "${eval_ckpt}" ]]; then
+    echo "Missing processor.ckpt under ${RUN_DIR}" >&2
+    exit 1
+fi
+eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+
+if [[ ! -f "${AE_CKPT}" ]]; then
+    echo "Missing AE checkpoint at ${AE_CKPT}" >&2
+    exit 1
+fi
+ae_ckpt_abs="$(realpath "${AE_CKPT}")"
+
+eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR}"
+
+for run_dry in "${RUN_DRY_STATES[@]}"; do
+    dry_run_arg=()
+    run_label="slurm"
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+        run_label="slurm --dry-run"
+    fi
+
+    echo "Submitting f8 FM encode_once eval"
+    echo "  mode: ${run_label}"
+    echo "  run_id: ${RUN_ID}"
+    echo "  run_dir: ${run_dir_abs}"
+    echo "  eval.checkpoint: ${eval_ckpt_abs}"
+    echo "  autoencoder_checkpoint: ${ae_ckpt_abs}"
+    echo "  eval.mode: encode_once"
+    echo "  output_subdir: ${EVAL_SUBDIR}"
+
+    uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+        --workdir "${run_dir_abs}" \
+        --output-subdir "${EVAL_SUBDIR}" \
+        eval.checkpoint="${eval_ckpt_abs}" \
+        eval.mode=encode_once \
+        +autoencoder_checkpoint="${ae_ckpt_abs}" \
+        eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+        eval.video_dir="${eval_output_dir}/videos" \
+        eval.save_rollout_snapshots=true \
+        eval.rollout_snapshot_dir="${eval_output_dir}/videos/snapshots" \
+        eval.rollout_snapshot_timesteps="${ROLLOUT_SNAPSHOT_TIMESTEPS}" \
+        eval.rollout_snapshot_format=png \
+        eval.metrics="${EVAL_METRICS}" \
+        eval.batch_size="${EVAL_BATCH_SIZE}" \
+        eval.n_members="${EVAL_N_MEMBERS}" \
+        hydra.launcher.timeout_min="${TIMEOUT_MIN}"
+done

--- a/slurm_scripts/ablations/ae_compression/submit_fm_f8_large.sh
+++ b/slurm_scripts/ablations/ae_compression/submit_fm_f8_large.sh
@@ -6,14 +6,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../comparison/cached_latents/validate_
 # cached latents.
 # Mirrors slurm_scripts/comparison/cached_latents/submit_fm_large.sh but
 # targets the single ae_dc_large_f8 run.
-#
-# Replace COSINE_EPOCHS once timing is available from:
-#   submit_fm_f8_timing.sh
+# Derived from outputs/2026-04-28/timing/fm_f8_b256_conditioned_navier_stokes/
+# timing.ckpt via:
+#   uv run autocast time-epochs --from-checkpoint <path>/timing.ckpt -b 24 -m 0.02
 
 DATAMODULE="conditioned_navier_stokes"
 EXPERIMENT="processor/conditioned_navier_stokes/fm_vit_large"
 AE_RUN_DIR="$HOME/autocast/outputs/2026-04-26/ae_cns64_de1b4b7_e1059d7"
-COSINE_EPOCHS=3223  # placeholder: 16x16 main-study value; re-fit from f8 timing
+COSINE_EPOCHS=4379  # 19.33 s/epoch from the 5-epoch f8 timing run
 
 BUDGET_MAX_TIME="00:23:59:00"
 TIMEOUT_MIN=1439

--- a/slurm_scripts/ablations/eval_only/ema/README.md
+++ b/slurm_scripts/ablations/eval_only/ema/README.md
@@ -1,31 +1,34 @@
-# EMA ablation (eval-only)
+# EMA
 
-Eval-only ablation: evaluate an already-trained run using the EMA
-shadow weights vs the online weights, to measure the EMA contribution.
+Eval-only ablation: evaluate already-trained runs using the EMA shadow
+weights stored in each checkpoint, without retraining.
 
-**Status:** stub — no scripts yet.
+## Script
 
-## Source runs
+- `submit_eval_fm_encode_once_ema.sh`
 
-Any run trained with `EMACallback` (all main comparison runs under
-`outputs/2026-04-18/`). Both the live weights and the EMA shadow are
-saved inside the same `.ckpt` — the knob is which to load at eval.
+## Source Runs
+
+Main 2026-04-20 FM cached-latent runs:
+
+- `outputs/2026-04-20/diff_gs64_flow_matching_vit_09490da_7e9e331`
+- `outputs/2026-04-20/diff_gpe64_flow_matching_vit_09490da_47bf39a`
+- `outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3`
+- `outputs/2026-04-20/diff_ad64_flow_matching_vit_09490da_dae1382`
+
+All four `processor.ckpt` files have an `ema_state_dict` key.
 
 ## Knob
 
-Whatever the eval-side flag is for EMA loading. Candidates (need to
-verify against the eval script):
+- `+eval.use_ema=true`
+- `eval.mode=encode_once`, so metrics are computed in raw data space after
+  decoding while avoiding the ambient path's per-step decode/encode loop.
+- Baseline online-weight comparison evals use the same checkpoints without
+  `eval.use_ema`.
 
-- `eval.use_ema=true|false`
-- `model.load_ema=true|false`
-- callback-state override
+Outputs write to:
 
-Check `src/autocast/callbacks/ema.py` for the state dict layout, then
-grep eval code for how it's surfaced.
+- `eval_encode_once_ema/`
 
-## Implementation sketch
-
-Copy `slurm_scripts/comparison/eval/submit_eval_crps_ambient.sh`, set
-`eval.use_ema=false` (or equivalent), and write to a
-`eval_no_ema/evaluation_metrics.csv` output so the EMA-on numbers from
-the main eval pass aren't overwritten.
+The submitter also overrides `eval.csv_path` and `eval.video_dir` inside that
+subdir so EMA evals do not clobber online-weight evals.

--- a/slurm_scripts/ablations/eval_only/ema/submit_eval_fm_encode_once_ema.sh
+++ b/slurm_scripts/ablations/eval_only/ema/submit_eval_fm_encode_once_ema.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Eval-only EMA sweep for the main 2026-04-20 FM cached-latent runs.
+#
+# Each run is evaluated once with the EMA shadow weights stored in
+# processor.ckpt under ema_state_dict. Eval uses encode_once so metrics stay in
+# raw data space after decoding while avoiding per-step decode->encode.
+#
+# Output goes to <run>/eval_encode_once_ema/.
+
+EVAL_BATCH_SIZE=4
+EVAL_N_MEMBERS=10
+TIMEOUT_MIN=360
+EVAL_SUBDIR="eval_encode_once_ema"
+RUN_DRY_STATES=("true" "false")
+EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
+
+declare -A AE_CKPT=(
+    ["conditioned_navier_stokes"]="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8/autoencoder.ckpt"
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e/autoencoder.ckpt"
+    ["gpe_laser_only_wake"]="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f/autoencoder.ckpt"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300/autoencoder.ckpt"
+)
+
+# run_id|datamodule|run_dir
+RUNS=(
+    "fm_gs|gray_scott|outputs/2026-04-20/diff_gs64_flow_matching_vit_09490da_7e9e331"
+    "fm_gpe|gpe_laser_only_wake|outputs/2026-04-20/diff_gpe64_flow_matching_vit_09490da_47bf39a"
+    "fm_cns|conditioned_navier_stokes|outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3"
+    "fm_ad|advection_diffusion|outputs/2026-04-20/diff_ad64_flow_matching_vit_09490da_dae1382"
+)
+
+submit_eval() {
+    local run_id="$1" run_dir_abs="$2" ae_ckpt_abs="$3"
+    local eval_ckpt="${run_dir_abs}/processor.ckpt"
+    local eval_ckpt_abs eval_output_dir
+
+    if [[ ! -f "${eval_ckpt}" ]]; then
+        echo "Skipping ${run_id}: processor.ckpt missing" >&2
+        return 0
+    fi
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        local dry_run_arg=() run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting FM encode_once EMA eval"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  autoencoder_checkpoint: ${ae_ckpt_abs}"
+        echo "  eval.mode: encode_once"
+        echo "  eval.use_ema: true"
+        echo "  output_subdir: ${EVAL_SUBDIR}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir_abs}" \
+            --output-subdir "${EVAL_SUBDIR}" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            eval.mode=encode_once \
+            +eval.use_ema=true \
+            +autoencoder_checkpoint="${ae_ckpt_abs}" \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}"
+    done
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS="|" read -r run_id datamodule run_dir <<< "${run_spec}"
+
+    if [[ ! -d "${run_dir}" ]]; then
+        echo "Skipping ${run_id}: run_dir missing at ${run_dir}" >&2
+        continue
+    fi
+    run_dir_abs="$(realpath "${run_dir}")"
+    if [[ ! -f "${run_dir_abs}/resolved_config.yaml" ]]; then
+        echo "Skipping ${run_id}: resolved_config.yaml missing under ${run_dir}" >&2
+        continue
+    fi
+
+    ae_ckpt="${AE_CKPT[$datamodule]:-}"
+    if [[ -z "${ae_ckpt}" ]]; then
+        echo "Skipping ${run_id}: no AE checkpoint configured for ${datamodule}" >&2
+        continue
+    fi
+    if [[ ! -f "${ae_ckpt}" ]]; then
+        echo "Skipping ${run_id}: AE checkpoint missing at ${ae_ckpt}" >&2
+        continue
+    fi
+    ae_ckpt_abs="$(realpath "${ae_ckpt}")"
+
+    submit_eval "${run_id}" "${run_dir_abs}" "${ae_ckpt_abs}"
+done

--- a/slurm_scripts/ablations/eval_only/ode_steps/README.md
+++ b/slurm_scripts/ablations/eval_only/ode_steps/README.md
@@ -18,7 +18,7 @@ Main 2026-04-20 FM cached-latent runs:
 
 ## Sweep
 
-- `model.processor.flow_ode_steps={1,5,10,25}`
+- `model.processor.flow_ode_steps={1,5,10,25,100}`
 - Baseline training and canonical eval used `flow_ode_steps=50`.
 - `eval.mode=encode_once`, so metrics are computed in raw data space after
   decoding while avoiding the ambient path's per-step decode/encode loop.
@@ -29,6 +29,10 @@ Each step value writes to a separate output subdir:
 - `eval_encode_once_ode005/`
 - `eval_encode_once_ode010/`
 - `eval_encode_once_ode025/`
+- `eval_encode_once_ode100/`
 
 The submitter also overrides `eval.csv_path` and `eval.video_dir` inside each
 subdir so repeated workdir evals do not clobber each other.
+
+To queue only a subset, set `ODE_STEPS_OVERRIDE` as a space-separated list, e.g.
+`ODE_STEPS_OVERRIDE="100" bash submit_eval_fm_encode_once_ode_steps.sh`.

--- a/slurm_scripts/ablations/eval_only/ode_steps/README.md
+++ b/slurm_scripts/ablations/eval_only/ode_steps/README.md
@@ -1,32 +1,34 @@
-# ODE steps / solver (eval-only)
+# ODE Steps / Solver
 
-Eval-only ablation: re-evaluate an already-trained FM run with
-different `model.processor.flow_ode_steps` and/or a different ODE
-solver, without retraining.
+Eval-only ablation: re-evaluate already-trained FM runs with different
+`model.processor.flow_ode_steps`, without retraining.
 
-**Status:** stub — no scripts yet.
+## Script
 
-## Source runs
+- `submit_eval_fm_encode_once_ode_steps.sh`
 
-FM ambient and FM cached-latent runs under `outputs/2026-04-18/diff_*`.
+## Source Runs
 
-## Knob
+Main 2026-04-20 FM cached-latent runs:
 
-- `model.processor.flow_ode_steps` — e.g. `{10, 25, 50, 100}` (baseline
-  trained with 50).
-- Solver family if more than one is supported (check
-  `src/autocast/processors/flow_matching.py`).
+- `outputs/2026-04-20/diff_gs64_flow_matching_vit_09490da_7e9e331`
+- `outputs/2026-04-20/diff_gpe64_flow_matching_vit_09490da_47bf39a`
+- `outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3`
+- `outputs/2026-04-20/diff_ad64_flow_matching_vit_09490da_dae1382`
 
-## Implementation sketch
+## Sweep
 
-Copy `slurm_scripts/comparison/eval/submit_eval_fm_ambient.sh` and sweep
-an extra dimension (ODE steps) inside the run-dir loop. Each sweep step
-gets its own `eval/` subdir suffix (e.g. `eval/ode50`, `eval/ode25`) via
-a non-default `hydra.sweep.dir` override — need to verify how
-`autocast eval` names output dirs when the same workdir is reused.
+- `model.processor.flow_ode_steps={1,5,10,25}`
+- Baseline training and canonical eval used `flow_ode_steps=50`.
+- `eval.mode=encode_once`, so metrics are computed in raw data space after
+  decoding while avoiding the ambient path's per-step decode/encode loop.
 
-## Outstanding decisions
+Each step value writes to a separate output subdir:
 
-- Step values.
-- How to prevent the 4 eval runs from clobbering each other's
-  `evaluation_metrics.csv` (likely via a csv_path override per sweep).
+- `eval_encode_once_ode001/`
+- `eval_encode_once_ode005/`
+- `eval_encode_once_ode010/`
+- `eval_encode_once_ode025/`
+
+The submitter also overrides `eval.csv_path` and `eval.video_dir` inside each
+subdir so repeated workdir evals do not clobber each other.

--- a/slurm_scripts/ablations/eval_only/ode_steps/submit_eval_fm_encode_once_ode_steps.sh
+++ b/slurm_scripts/ablations/eval_only/ode_steps/submit_eval_fm_encode_once_ode_steps.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Eval-only ODE-step sweep for the main 2026-04-20 FM cached-latent runs.
+#
+# These checkpoints were trained with model.processor.flow_ode_steps=50. This
+# script reuses the final processor.ckpt for each dataset and changes only the
+# inference-time Euler integration step count. Eval uses encode_once so metrics
+# stay in raw data space after decoding while avoiding per-step decode->encode.
+#
+# Output goes to <run>/eval_encode_once_ode{steps:03d}/.
+
+EVAL_BATCH_SIZE=4
+EVAL_N_MEMBERS=10
+TIMEOUT_MIN=360
+ODE_STEPS=(1 5 10 25)
+RUN_DRY_STATES=("true" "false")
+EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
+
+declare -A AE_CKPT=(
+    ["conditioned_navier_stokes"]="$HOME/autocast/outputs/2026-04-17/ae_cns64_3a7999b_b9c29f8/autoencoder.ckpt"
+    ["gray_scott"]="$HOME/autocast/outputs/2026-04-17/ae_gs64_3a7999b_ed36b8e/autoencoder.ckpt"
+    ["gpe_laser_only_wake"]="$HOME/autocast/outputs/2026-04-17/ae_gpe64_3a7999b_31e1c9f/autoencoder.ckpt"
+    ["advection_diffusion"]="$HOME/autocast/outputs/2026-04-17/ae_ad64_3a7999b_1a1e300/autoencoder.ckpt"
+)
+
+# run_id|datamodule|run_dir
+RUNS=(
+    "fm_gs|gray_scott|outputs/2026-04-20/diff_gs64_flow_matching_vit_09490da_7e9e331"
+    "fm_gpe|gpe_laser_only_wake|outputs/2026-04-20/diff_gpe64_flow_matching_vit_09490da_47bf39a"
+    "fm_cns|conditioned_navier_stokes|outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3"
+    "fm_ad|advection_diffusion|outputs/2026-04-20/diff_ad64_flow_matching_vit_09490da_dae1382"
+)
+
+submit_eval() {
+    local run_id="$1" run_dir_abs="$2" ae_ckpt_abs="$3" ode_steps="$4"
+    local ode_label
+    printf -v ode_label "%03d" "${ode_steps}"
+    local eval_subdir="eval_encode_once_ode${ode_label}"
+    local eval_ckpt="${run_dir_abs}/processor.ckpt"
+    local eval_ckpt_abs eval_output_dir
+
+    if [[ ! -f "${eval_ckpt}" ]]; then
+        echo "Skipping ${run_id} ode${ode_steps}: processor.ckpt missing" >&2
+        return 0
+    fi
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${eval_subdir}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        local dry_run_arg=() run_label="slurm"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="slurm --dry-run"
+        fi
+
+        echo "Submitting FM encode_once ODE-step eval"
+        echo "  mode: ${run_label}"
+        echo "  run_id: ${run_id}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  autoencoder_checkpoint: ${ae_ckpt_abs}"
+        echo "  eval.mode: encode_once"
+        echo "  flow_ode_steps: ${ode_steps}"
+        echo "  output_subdir: ${eval_subdir}"
+
+        uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
+            --workdir "${run_dir_abs}" \
+            --output-subdir "${eval_subdir}" \
+            eval.checkpoint="${eval_ckpt_abs}" \
+            eval.mode=encode_once \
+            +autoencoder_checkpoint="${ae_ckpt_abs}" \
+            model.processor.flow_ode_steps="${ode_steps}" \
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
+            eval.video_dir="${eval_output_dir}/videos" \
+            eval.metrics="${EVAL_METRICS}" \
+            eval.batch_size="${EVAL_BATCH_SIZE}" \
+            eval.n_members="${EVAL_N_MEMBERS}" \
+            hydra.launcher.timeout_min="${TIMEOUT_MIN}"
+    done
+}
+
+for run_spec in "${RUNS[@]}"; do
+    IFS="|" read -r run_id datamodule run_dir <<< "${run_spec}"
+
+    if [[ ! -d "${run_dir}" ]]; then
+        echo "Skipping ${run_id}: run_dir missing at ${run_dir}" >&2
+        continue
+    fi
+    run_dir_abs="$(realpath "${run_dir}")"
+    if [[ ! -f "${run_dir_abs}/resolved_config.yaml" ]]; then
+        echo "Skipping ${run_id}: resolved_config.yaml missing under ${run_dir}" >&2
+        continue
+    fi
+
+    ae_ckpt="${AE_CKPT[$datamodule]:-}"
+    if [[ -z "${ae_ckpt}" ]]; then
+        echo "Skipping ${run_id}: no AE checkpoint configured for ${datamodule}" >&2
+        continue
+    fi
+    if [[ ! -f "${ae_ckpt}" ]]; then
+        echo "Skipping ${run_id}: AE checkpoint missing at ${ae_ckpt}" >&2
+        continue
+    fi
+    ae_ckpt_abs="$(realpath "${ae_ckpt}")"
+
+    for ode_steps in "${ODE_STEPS[@]}"; do
+        submit_eval "${run_id}" "${run_dir_abs}" "${ae_ckpt_abs}" "${ode_steps}"
+    done
+done

--- a/slurm_scripts/ablations/eval_only/ode_steps/submit_eval_fm_encode_once_ode_steps.sh
+++ b/slurm_scripts/ablations/eval_only/ode_steps/submit_eval_fm_encode_once_ode_steps.sh
@@ -14,7 +14,12 @@ set -euo pipefail
 EVAL_BATCH_SIZE=4
 EVAL_N_MEMBERS=10
 TIMEOUT_MIN=360
-ODE_STEPS=(1 5 10 25)
+ODE_STEPS_DEFAULT=(1 5 10 25 100)
+if [[ -n "${ODE_STEPS_OVERRIDE:-}" ]]; then
+    read -r -a ODE_STEPS <<< "${ODE_STEPS_OVERRIDE}"
+else
+    ODE_STEPS=("${ODE_STEPS_DEFAULT[@]}")
+fi
 RUN_DRY_STATES=("true" "false")
 EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
 

--- a/slurm_scripts/ablations/submit_eval_planned_03.sh
+++ b/slurm_scripts/ablations/submit_eval_planned_03.sh
@@ -27,9 +27,8 @@ declare -A AE_CKPT=(
 )
 
 # run_id|datamodule|run_dir
-# Fill in run_dir paths once submit_planned_03_large.sh has produced runs.
 RUNS=(
-    "latent_diffusion_cns|conditioned_navier_stokes|outputs/REPLACE_ME/planned_03/diff_cns64_diffusion_vit_REPLACE_ME"
+    "latent_diffusion_cns|conditioned_navier_stokes|outputs/2026-05-01/planned_03/diff_cns64_diffusion_vit_0c75022_80967c4"
     # "latent_diffusion_gs|gray_scott|outputs/REPLACE_ME/planned_03/diff_gs64_diffusion_vit_REPLACE_ME"
     # "latent_diffusion_gpe|gpe_laser_only_wake|outputs/REPLACE_ME/planned_03/diff_gpe64_diffusion_vit_REPLACE_ME"
     # "latent_diffusion_ad|advection_diffusion|outputs/REPLACE_ME/planned_03/diff_ad64_diffusion_vit_REPLACE_ME"

--- a/slurm_scripts/ablations/submit_eval_planned_03.sh
+++ b/slurm_scripts/ablations/submit_eval_planned_03.sh
@@ -3,18 +3,19 @@
 set -euo pipefail
 # Eval submitter for the latent-diffusion sweep in planned ablation batch 03.
 #
-# All four runs share one profile: processor-only diffusion on cached AE
-# latents, evaluated through eval.mode=auto -> encode_once with the matching
-# per-dataset AE checkpoint. Mirrors slurm_scripts/comparison/eval/
-# submit_eval_fm_latent.sh — the diffusion sampler (50 ODE steps) is the
-# dominant per-rollout cost so batch=4/timeout=360 carry over.
+# All four runs share one profile: processor-only diffusion trained on cached
+# AE latents, evaluated through eval.mode=encode_once with the matching
+# per-dataset AE checkpoint. Metrics are still computed in raw data space after
+# decoding. Mirrors slurm_scripts/comparison/eval/submit_eval_fm_latent.sh —
+# the diffusion sampler (50 ODE steps) is the dominant per-rollout cost so
+# batch=4/timeout=360 carry over.
 #
-# Output goes to <run>/eval_latent/.
+# Output goes to <run>/eval_encode_once/.
 
 EVAL_BATCH_SIZE=4
 EVAL_N_MEMBERS=10
 TIMEOUT_MIN=360
-EVAL_SUBDIR="eval_latent"
+EVAL_SUBDIR="eval_encode_once"
 ROLLOUT_SNAPSHOT_TIMESTEPS="[0,4,12,30,99]"
 RUN_DRY_STATES=("true" "false")
 EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
@@ -34,7 +35,7 @@ RUNS=(
     # "latent_diffusion_ad|advection_diffusion|outputs/REPLACE_ME/planned_03/diff_ad64_diffusion_vit_REPLACE_ME"
 )
 
-submit_diffusion_latent() {
+submit_diffusion_encode_once() {
     local run_id="$1" run_dir_abs="$2" ae_ckpt="$3"
     if [[ ! -f "${ae_ckpt}" ]]; then
         echo "Skipping ${run_id}: AE checkpoint missing at ${ae_ckpt}" >&2
@@ -59,19 +60,20 @@ submit_diffusion_latent() {
             run_label="slurm --dry-run"
         fi
 
-        echo "Submitting diffusion cached-latent eval (mode=auto -> encode_once)"
+        echo "Submitting diffusion cached-latent eval (mode=encode_once)"
         echo "  mode: ${run_label}"
         echo "  run_id: ${run_id}"
         echo "  run_dir: ${run_dir_abs}"
         echo "  eval.checkpoint: ${eval_ckpt_abs}"
         echo "  autoencoder_checkpoint: ${ae_ckpt_abs}"
-        echo "  eval.mode: auto"
+        echo "  eval.mode: encode_once"
         echo "  output_subdir: ${EVAL_SUBDIR}"
 
         uv run autocast eval --mode slurm "${dry_run_arg[@]}" \
             --workdir "${run_dir_abs}" \
             --output-subdir "${EVAL_SUBDIR}" \
             eval.checkpoint="${eval_ckpt_abs}" \
+            eval.mode=encode_once \
             +autoencoder_checkpoint="${ae_ckpt_abs}" \
             eval.csv_path="${eval_output_dir}/evaluation_metrics.csv" \
             eval.video_dir="${eval_output_dir}/videos" \
@@ -105,5 +107,5 @@ for run_spec in "${RUNS[@]}"; do
         continue
     fi
 
-    submit_diffusion_latent "${run_id}" "${run_dir_abs}" "${ae_ckpt}"
+    submit_diffusion_encode_once "${run_id}" "${run_dir_abs}" "${ae_ckpt}"
 done

--- a/slurm_scripts/ablations/submit_eval_planned_03.sh
+++ b/slurm_scripts/ablations/submit_eval_planned_03.sh
@@ -30,9 +30,9 @@ declare -A AE_CKPT=(
 # Fill in run_dir paths once submit_planned_03_large.sh has produced runs.
 RUNS=(
     "latent_diffusion_cns|conditioned_navier_stokes|outputs/REPLACE_ME/planned_03/diff_cns64_diffusion_vit_REPLACE_ME"
-    "latent_diffusion_gs|gray_scott|outputs/REPLACE_ME/planned_03/diff_gs64_diffusion_vit_REPLACE_ME"
-    "latent_diffusion_gpe|gpe_laser_only_wake|outputs/REPLACE_ME/planned_03/diff_gpe64_diffusion_vit_REPLACE_ME"
-    "latent_diffusion_ad|advection_diffusion|outputs/REPLACE_ME/planned_03/diff_ad64_diffusion_vit_REPLACE_ME"
+    # "latent_diffusion_gs|gray_scott|outputs/REPLACE_ME/planned_03/diff_gs64_diffusion_vit_REPLACE_ME"
+    # "latent_diffusion_gpe|gpe_laser_only_wake|outputs/REPLACE_ME/planned_03/diff_gpe64_diffusion_vit_REPLACE_ME"
+    # "latent_diffusion_ad|advection_diffusion|outputs/REPLACE_ME/planned_03/diff_ad64_diffusion_vit_REPLACE_ME"
 )
 
 submit_diffusion_latent() {

--- a/slurm_scripts/ablations/submit_planned_03_large.sh
+++ b/slurm_scripts/ablations/submit_planned_03_large.sh
@@ -34,9 +34,9 @@ declare -A AE_RUN_DIRS=(
 # run_id|kind|datamodule|local_experiment
 RUNS=(
     "latent_diffusion_cns|processor|conditioned_navier_stokes|processor/conditioned_navier_stokes/diffusion_vit_large"
-    "latent_diffusion_gs|processor|gray_scott|processor/gray_scott/diffusion_vit_large"
-    "latent_diffusion_gpe|processor|gpe_laser_only_wake|processor/gpe_laser_wake_only/diffusion_vit_large"
-    "latent_diffusion_ad|processor|advection_diffusion|processor/advection_diffusion/diffusion_vit_large"
+    # "latent_diffusion_gs|processor|gray_scott|processor/gray_scott/diffusion_vit_large"
+    # "latent_diffusion_gpe|processor|gpe_laser_only_wake|processor/gpe_laser_wake_only/diffusion_vit_large"
+    # "latent_diffusion_ad|processor|advection_diffusion|processor/advection_diffusion/diffusion_vit_large"
 )
 
 run_overrides() {

--- a/slurm_scripts/ablations/submit_planned_03_timing.sh
+++ b/slurm_scripts/ablations/submit_planned_03_timing.sh
@@ -26,9 +26,9 @@ declare -A AE_RUN_DIRS=(
 # run_id|kind|datamodule|local_experiment
 RUNS=(
     "latent_diffusion_cns|processor|conditioned_navier_stokes|processor/conditioned_navier_stokes/diffusion_vit_large"
-    "latent_diffusion_gs|processor|gray_scott|processor/gray_scott/diffusion_vit_large"
-    "latent_diffusion_gpe|processor|gpe_laser_only_wake|processor/gpe_laser_wake_only/diffusion_vit_large"
-    "latent_diffusion_ad|processor|advection_diffusion|processor/advection_diffusion/diffusion_vit_large"
+    # "latent_diffusion_gs|processor|gray_scott|processor/gray_scott/diffusion_vit_large"
+    # "latent_diffusion_gpe|processor|gpe_laser_only_wake|processor/gpe_laser_wake_only/diffusion_vit_large"
+    # "latent_diffusion_ad|processor|advection_diffusion|processor/advection_diffusion/diffusion_vit_large"
 )
 
 run_overrides() {


### PR DESCRIPTION
This pull request adds new eval-only ablation scripts and updates documentation and existing scripts to support systematic evaluation of flow-matching (FM) and diffusion models under different inference settings. The main focus is on enabling and documenting evaluation sweeps for ODE solver steps and EMA weights, as well as improving the workflow for encode-once evaluation in latent space. These changes provide reproducible, script-driven evaluation pipelines for the main 2026-04-20 and planned ablation runs.

**Major new evaluation scripts and sweeps:**

*Eval-only ODE steps ablation:*
- Added `submit_eval_fm_encode_once_ode_steps.sh`, which evaluates FM cached-latent runs with varying `flow_ode_steps` (1, 5, 10, 25, 100) using encode-once metrics, writing to per-step output subdirectories. Includes robust input checking and supports dry-run mode.
- Updated `slurm_scripts/ablations/eval_only/ode_steps/README.md` to document the ODE steps ablation design, script usage, and output organization.

*Eval-only EMA ablation:*
- Added `submit_eval_fm_encode_once_ema.sh`, which evaluates FM cached-latent runs using the EMA weights stored in each checkpoint, with encode-once metrics and per-run output subdirectories.
- Updated `slurm_scripts/ablations/eval_only/ema/README.md` to provide full instructions and context for the EMA eval-only ablation.

*Encode-once evaluation workflow improvements:*
- Added `submit_eval_fm_f8_encode_once.sh` for encode-once evaluation of FM-in-latent (f8) runs, with detailed input validation and output management.
- Updated `slurm_scripts/ablations/ae_compression/README.md` to include the new script and workflow steps. [[1]](diffhunk://#diff-df6e20c8c0e7bfe67deee7f60113bb4078f507625e11323eba7f9872d4a491dcR53) [[2]](diffhunk://#diff-df6e20c8c0e7bfe67deee7f60113bb4078f507625e11323eba7f9872d4a491dcR75-R76)
- Updated `submit_fm_f8_large.sh` to use the correct number of epochs from timing output and clarified comments.

**Generalization and consistency improvements:**

- Updated `submit_eval_planned_03.sh` to use encode-once evaluation mode and output subdir for the planned ablation batch 03 latent-diffusion sweep, and partially filled in run paths for CNS. [[1]](diffhunk://#diff-12d14cfb909b2f15ba2051c2aefd97e6cbfeb764fd8fe404635290353e368e9bL6-R18) [[2]](diffhunk://#diff-12d14cfb909b2f15ba2051c2aefd97e6cbfeb764fd8fe404635290353e368e9bL30-R38) [[3]](diffhunk://#diff-12d14cfb909b2f15ba2051c2aefd97e6cbfeb764fd8fe404635290353e368e9bL63-R76)
- Updated ablation status tables in `slurm_scripts/ablations/README.md` to reflect that ODE steps and EMA eval-only scripts are now ready and cover all four main datasets.

**Summary:**  
These changes introduce robust, script-driven evaluation for ODE solver steps and EMA weights, standardize encode-once evaluation across ablation studies, and improve documentation and reproducibility for FM and diffusion model assessments.