### PR TITLE
Enhance FM trajectory script with multi-window and output features

### DIFF
--- a/scripts/plot_fm_ode_trajectory.py
+++ b/scripts/plot_fm_ode_trajectory.py
@@ -1,0 +1,648 @@
+"""Plot the FM ODE trajectory for one window from a flow-matching EPD run.
+
+Reconstructs the ambient-space EPD model from a processor-only checkpoint by
+re-using the eval pipeline's autoencoder injection + datamodule swap, then
+runs the flow-matching ODE step-by-step (Euler), capturing each intermediate
+latent. Each intermediate is decoded + denormalised and saved as one image
+tile per (intermediate, output-step, channel) so the panels can be assembled
+in Inkscape into something like the mock-up in methods_sketch_00.pdf.
+
+Example:
+    python scripts/plot_fm_ode_trajectory.py \
+        --run-dir outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3 \
+        --batch-index 0 --sample-index 0 --use-ema \
+        --intermediate-stride 5 --channel 0
+
+Deeper rollout (visualise FM ODE at the 12th 4-step window, i.e. after 48 steps):
+
+    python scripts/plot_fm_ode_trajectory.py \
+        --rollout-window 12 --use-ema --intermediate-stride 10 --channel 0
+
+Per-channel colormaps (smoke=viridis, u/v=RdBu_r):
+
+    python scripts/plot_fm_ode_trajectory.py --use-ema --all-channels \
+        --cmap viridis,RdBu_r,RdBu_r --symmetric-cmaps RdBu_r
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from omegaconf import DictConfig, OmegaConf, open_dict
+
+from autocast.processors.flow_matching import FlowMatchingProcessor
+from autocast.scripts.eval.encoder_processor_decoder import (
+    _maybe_inject_encoder_decoder_from_autoencoder_checkpoint,
+    _maybe_swap_to_ambient_datamodule,
+    _extract_processor_state_dict,
+)
+from autocast.scripts.execution import load_checkpoint_payload
+from autocast.scripts.setup import setup_datamodule, setup_epd_model
+from autocast.types import Batch
+
+log = logging.getLogger("plot_fm_ode_trajectory")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--run-dir",
+        type=Path,
+        default=Path(
+            "outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3"
+        ),
+        help="Run directory containing resolved_config.yaml and processor.ckpt.",
+    )
+    p.add_argument(
+        "--checkpoint-name",
+        default="processor.ckpt",
+        help="Checkpoint filename inside --run-dir.",
+    )
+    p.add_argument(
+        "--config-name",
+        default="resolved_config.yaml",
+        help="Config filename inside --run-dir.",
+    )
+    p.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Output directory for tiles. Defaults to <run-dir>/figures/fm_ode_traj."
+        ),
+    )
+    p.add_argument("--batch-index", type=int, default=0, help="Test batch to draw.")
+    p.add_argument(
+        "--sample-index",
+        type=int,
+        default=0,
+        help="Sample within the chosen batch.",
+    )
+    p.add_argument(
+        "--intermediate-stride",
+        type=int,
+        default=5,
+        help="Save every Nth ODE step (plus first and last).",
+    )
+    p.add_argument(
+        "--channel",
+        type=int,
+        default=0,
+        help="Channel to render (0=smoke, 1=u, 2=v for CNS).",
+    )
+    p.add_argument(
+        "--all-channels",
+        action="store_true",
+        help="Render all output channels (overrides --channel).",
+    )
+    p.add_argument(
+        "--device",
+        default=None,
+        help="Force device, e.g. 'cuda' or 'cpu' (default: auto).",
+    )
+    p.add_argument("--use-ema", action="store_true", help="Use EMA processor weights.")
+    p.add_argument("--seed", type=int, default=0, help="Seed for the noise z0.")
+    p.add_argument(
+        "--format",
+        default="pdf",
+        choices=("pdf", "png"),
+        help="Output file format per tile.",
+    )
+    p.add_argument(
+        "--cmap",
+        default="viridis",
+        help=(
+            "Matplotlib colormap. Either a single name applied to all rendered "
+            "channels, or a comma-separated list aligned with channel order, "
+            "e.g. 'viridis,RdBu_r,RdBu_r' for smoke,u,v."
+        ),
+    )
+    p.add_argument(
+        "--symmetric-cmaps",
+        default="",
+        help=(
+            "Comma-separated list of colormap names that should use symmetric "
+            "limits around zero (e.g. 'RdBu_r,seismic'). Empty by default."
+        ),
+    )
+    p.add_argument(
+        "--rollout-window",
+        type=int,
+        default=0,
+        help=(
+            "Output window (0-indexed, length n_steps_output frames each) at "
+            "which to capture the FM ODE intermediates. 0 = the first window "
+            "(uses the test_dataloader). >0 = autoregressive rollout to that "
+            "window first; uses the rollout_test_dataloader so ground truth "
+            "is available for the deeper window too."
+        ),
+    )
+    p.add_argument(
+        "--dpi",
+        type=int,
+        default=200,
+    )
+    return p.parse_args()
+
+
+def resolve_device(name: str | None) -> torch.device:
+    if name is not None:
+        return torch.device(name)
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def select_sample(batch: Batch, idx: int) -> Batch:
+    """Return a length-1 Batch containing only sample `idx`."""
+
+    def _take(t: torch.Tensor | None) -> torch.Tensor | None:
+        return t[idx : idx + 1] if t is not None else None
+
+    return Batch(
+        input_fields=batch.input_fields[idx : idx + 1].clone(),
+        output_fields=batch.output_fields[idx : idx + 1].clone(),
+        constant_scalars=_take(batch.constant_scalars),
+        constant_fields=_take(batch.constant_fields),
+        boundary_conditions=_take(batch.boundary_conditions),
+    )
+
+
+def to_device(batch: Batch, device: torch.device) -> Batch:
+    return Batch(
+        input_fields=batch.input_fields.to(device),
+        output_fields=batch.output_fields.to(device),
+        constant_scalars=(
+            batch.constant_scalars.to(device)
+            if batch.constant_scalars is not None
+            else None
+        ),
+        constant_fields=(
+            batch.constant_fields.to(device)
+            if batch.constant_fields is not None
+            else None
+        ),
+        boundary_conditions=(
+            batch.boundary_conditions.to(device)
+            if batch.boundary_conditions is not None
+            else None
+        ),
+    )
+
+
+@torch.no_grad()
+def run_fm_with_intermediates(
+    processor: FlowMatchingProcessor,
+    z_input: torch.Tensor,
+    global_cond: torch.Tensor | None,
+    capture_every: int,
+) -> tuple[torch.Tensor, list[tuple[int, torch.Tensor]]]:
+    """Re-implements ``FlowMatchingProcessor.map`` capturing intermediate z.
+
+    Returns the final z (B, T_out, *spatial, C_out) and a list of
+    (step_index, z_snapshot) including the initial noise (step=0) and the
+    final state (step=flow_ode_steps).
+    """
+    batch_size = z_input.shape[0]
+    device, dtype = z_input.device, z_input.dtype
+
+    spatial_shape = tuple(z_input.shape[2:-1])
+    z_shape = (
+        batch_size,
+        processor.n_steps_output,
+        *spatial_shape,
+        processor.n_channels_out,
+    )
+    z = torch.randn(z_shape, device=device, dtype=dtype)
+    t = torch.zeros(batch_size, device=device, dtype=dtype)
+
+    snapshots: list[tuple[int, torch.Tensor]] = [(0, z.clone())]
+
+    dt = torch.tensor(1.0 / processor.flow_ode_steps, device=device, dtype=dtype)
+    for k in range(processor.flow_ode_steps):
+        v = processor.flow_field(z, t, z_input, global_cond)
+        z = z + dt * v
+        t = t + dt
+        step = k + 1
+        if step == processor.flow_ode_steps or step % capture_every == 0:
+            snapshots.append((step, z.clone()))
+
+    return z, snapshots
+
+
+def latents_to_ambient(
+    model, z_latent: torch.Tensor, denormalise: bool = True
+) -> torch.Tensor:
+    """Decode latent (B, T_out, *spatial, C_lat) → ambient + denormalise."""
+    decoded = model.encoder_decoder.decoder.decode(z_latent)
+    if denormalise:
+        decoded = model.denormalize_tensor(decoded)
+    return decoded
+
+
+def save_tile(
+    image: np.ndarray,
+    out_path: Path,
+    *,
+    vmin: float | None,
+    vmax: float | None,
+    cmap: str,
+    dpi: int,
+) -> None:
+    """Render a 2-D array as a square axis-free image tile."""
+    fig, ax = plt.subplots(figsize=(2.0, 2.0))
+    ax.imshow(image, vmin=vmin, vmax=vmax, cmap=cmap, origin="lower")
+    ax.set_axis_off()
+    fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=dpi, bbox_inches="tight", pad_inches=0)
+    plt.close(fig)
+
+
+def channel_indices(args: argparse.Namespace, n_channels: int) -> list[int]:
+    if args.all_channels:
+        return list(range(n_channels))
+    if args.channel >= n_channels:
+        msg = f"--channel={args.channel} but tensor has only {n_channels} channels."
+        raise ValueError(msg)
+    return [args.channel]
+
+
+def parse_cmap_list(spec: str, channels: list[int]) -> dict[int, str]:
+    """Map each rendered channel index to a colormap name.
+
+    `spec` is either a single name (applied to all channels) or a
+    comma-separated list whose length matches len(channels).
+    """
+    parts = [p.strip() for p in spec.split(",") if p.strip()]
+    if len(parts) == 0:
+        msg = "--cmap must not be empty."
+        raise ValueError(msg)
+    if len(parts) == 1:
+        return {c: parts[0] for c in channels}
+    if len(parts) != len(channels):
+        msg = (
+            f"--cmap='{spec}' has {len(parts)} entries but {len(channels)} channels "
+            f"are being rendered ({channels})."
+        )
+        raise ValueError(msg)
+    return dict(zip(channels, parts, strict=True))
+
+
+def parse_symmetric_set(spec: str) -> set[str]:
+    return {p.strip() for p in spec.split(",") if p.strip()}
+
+
+@torch.no_grad()
+def advance_batch_free_running(model, batch: Batch) -> Batch:
+    """Free-running step: feed the model's predicted last frame back as input.
+
+    Mirrors ``EncoderProcessorDecoder._advance_batch`` for the case where
+    stride == n_steps_output (the typical FM setup): the new input is the
+    last ``n_steps_input`` frames of the prediction. Constants, BCs, and
+    global cond carriers are preserved.
+    """
+    pred = model(batch)
+    n_in = batch.input_fields.shape[1]
+    new_input = pred[:, -n_in:, ...].detach()
+    return Batch(
+        input_fields=new_input,
+        output_fields=batch.output_fields,
+        constant_scalars=batch.constant_scalars,
+        constant_fields=batch.constant_fields,
+        boundary_conditions=batch.boundary_conditions,
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+    args = parse_args()
+
+    run_dir: Path = args.run_dir.resolve()
+    cfg_path = run_dir / args.config_name
+    ckpt_path = run_dir / args.checkpoint_name
+    if not cfg_path.exists():
+        raise FileNotFoundError(cfg_path)
+    if not ckpt_path.exists():
+        raise FileNotFoundError(ckpt_path)
+
+    out_dir = (
+        args.out_dir.resolve()
+        if args.out_dir is not None
+        else run_dir / "figures" / "fm_ode_traj"
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info("Loading config from %s", cfg_path)
+    cfg = OmegaConf.load(cfg_path)
+    if not isinstance(cfg, DictConfig):
+        msg = f"Expected DictConfig from {cfg_path}, got {type(cfg).__name__}"
+        raise TypeError(msg)
+
+    # Eval-style augmentations: we want the ambient datamodule + injected AE.
+    eval_block = cfg.get("eval")
+    if eval_block is None or eval_block.get("checkpoint") is None:
+        # Mirror the eval CLI's resolution: `eval.checkpoint` references the
+        # processor checkpoint relative to the run dir.
+        with open_dict(cfg):
+            if "eval" not in cfg:
+                cfg.eval = OmegaConf.create({})
+            cfg.eval.checkpoint = str(ckpt_path)
+    if cfg.get("autoencoder_checkpoint") is None:
+        # In Mode 1 eval the eval CLI prints the autoencoder path but the
+        # resolved_config.yaml may still record null. Try the eval-config
+        # sibling file as a backup.
+        eval_cfg_path = run_dir / "eval" / "resolved_eval_config.yaml"
+        if eval_cfg_path.exists():
+            eval_cfg = OmegaConf.load(eval_cfg_path)
+            ae_ckpt = eval_cfg.get("autoencoder_checkpoint") if isinstance(
+                eval_cfg, DictConfig
+            ) else None
+            if ae_ckpt is not None:
+                with open_dict(cfg):
+                    cfg.autoencoder_checkpoint = ae_ckpt
+                log.info("Picked up autoencoder_checkpoint from %s", eval_cfg_path)
+
+    if cfg.get("autoencoder_checkpoint") is None:
+        msg = (
+            "Could not resolve autoencoder_checkpoint from resolved_config.yaml or "
+            "eval/resolved_eval_config.yaml; pass via Hydra override would be nice "
+            "but for this script we just abort."
+        )
+        raise RuntimeError(msg)
+
+    # Inject AE encoder/decoder configs (Mode 1 of eval).
+    cfg = _maybe_inject_encoder_decoder_from_autoencoder_checkpoint(cfg)
+
+    # Build a probe datamodule first so we can detect that the cached-latent
+    # datamodule is the active one and trigger the swap to ambient.
+    probe_datamodule, cfg, probe_stats = setup_datamodule(cfg)
+    cfg = _maybe_swap_to_ambient_datamodule(
+        cfg,
+        eval_mode="ambient",
+        example_batch=probe_stats.get("example_batch"),
+    )
+    datamodule, cfg, stats = setup_datamodule(cfg)
+    log.info("Final example batch type: %s", type(stats["example_batch"]).__name__)
+
+    # Build the EPD with AE weights loaded; then load processor weights.
+    model = setup_epd_model(cfg, stats, datamodule=datamodule)
+    log.info("Loading processor checkpoint from %s", ckpt_path)
+    payload = load_checkpoint_payload(ckpt_path)
+    proc_sd = _extract_processor_state_dict(payload, use_ema=args.use_ema)
+    load_result = model.processor.load_state_dict(proc_sd, strict=True)
+    if load_result.missing_keys or load_result.unexpected_keys:
+        msg = (
+            f"Processor load mismatch: missing={load_result.missing_keys}, "
+            f"unexpected={load_result.unexpected_keys}"
+        )
+        raise RuntimeError(msg)
+
+    if not isinstance(model.processor, FlowMatchingProcessor):
+        msg = (
+            "This script targets FlowMatchingProcessor specifically; "
+            f"got {type(model.processor).__name__}."
+        )
+        raise TypeError(msg)
+
+    device = resolve_device(args.device)
+    log.info("Using device: %s", device)
+    model.to(device)
+    model.eval()
+
+    # Choose the dataloader. Window 0 is fine on the standard test loader
+    # (n_steps_output frames of GT). Deeper windows need the rollout loader,
+    # which yields a single window per trajectory in full_trajectory_mode so
+    # we get GT for every output frame in the trajectory.
+    datamodule.setup(stage="test")
+    if args.rollout_window <= 0:
+        loader = datamodule.test_dataloader()
+        loader_name = "test_dataloader"
+    else:
+        loader = datamodule.rollout_test_dataloader()
+        loader_name = "rollout_test_dataloader"
+    log.info("Using %s for window=%s", loader_name, args.rollout_window)
+
+    batch = None
+    seen = 0
+    for i, b in enumerate(loader):
+        seen = i + 1
+        if i == args.batch_index:
+            batch = b
+            break
+    if batch is None:
+        msg = (
+            f"{loader_name} exhausted before batch_index={args.batch_index} "
+            f"(loader has {seen} batches)."
+        )
+        raise IndexError(msg)
+    if not isinstance(batch, Batch):
+        raise TypeError(f"Expected ambient Batch, got {type(batch).__name__}")
+    if args.sample_index >= batch.input_fields.shape[0]:
+        msg = (
+            f"--sample-index={args.sample_index} but batch only has "
+            f"{batch.input_fields.shape[0]} samples."
+        )
+        raise IndexError(msg)
+
+    sample = select_sample(batch, args.sample_index)
+    sample = to_device(sample, device)
+
+    n_t_out = int(model.processor.n_steps_output)
+    n_t_in = sample.input_fields.shape[1]
+    if args.rollout_window > 0:
+        # In full-trajectory mode `output_fields` holds the entire GT
+        # trajectory after the initial input, so we can slice the GT for
+        # any output window. For the visualised window we also need the
+        # *predicted* input frame at that point — produce it via free-
+        # running rollout for the preceding (rollout_window) windows.
+        gt_start = args.rollout_window * n_t_out
+        gt_end = gt_start + n_t_out
+        if gt_end > sample.output_fields.shape[1]:
+            msg = (
+                f"--rollout-window={args.rollout_window} requires GT frames "
+                f"up to index {gt_end - 1}, but the trajectory only has "
+                f"{sample.output_fields.shape[1]} output frames."
+            )
+            raise IndexError(msg)
+        target_fields_window = sample.output_fields[:, gt_start:gt_end, ...]
+
+        torch.manual_seed(args.seed)
+        if device.type == "cuda":
+            torch.cuda.manual_seed_all(args.seed)
+        log.info(
+            "Free-running rollout for %s windows before capture...",
+            args.rollout_window,
+        )
+        current = sample
+        for _ in range(args.rollout_window):
+            current = advance_batch_free_running(model, current)
+        capture_sample = current
+    else:
+        target_fields_window = sample.output_fields
+        capture_sample = sample
+        torch.manual_seed(args.seed)
+        if device.type == "cuda":
+            torch.cuda.manual_seed_all(args.seed)
+
+    # Encode → latent input + global conditioning at the chosen window.
+    with torch.no_grad():
+        z_input, global_cond = model.encoder_decoder.encoder.encode_with_cond(
+            capture_sample
+        )
+    log.info(
+        "Encoded latent shape: %s; global_cond shape: %s",
+        tuple(z_input.shape),
+        tuple(global_cond.shape) if global_cond is not None else None,
+    )
+
+    capture_every = max(args.intermediate_stride, 1)
+    log.info(
+        "Rolling out flow ODE with %s steps; capturing every %s.",
+        model.processor.flow_ode_steps,
+        capture_every,
+    )
+    _, snapshots = run_fm_with_intermediates(
+        model.processor, z_input, global_cond, capture_every=capture_every
+    )
+
+    # Decode + denormalise each snapshot, plus the input & ground truth output.
+    decoded_snapshots: list[tuple[int, np.ndarray]] = []
+    with torch.no_grad():
+        for step, z_snap in snapshots:
+            ambient = latents_to_ambient(model, z_snap, denormalise=True)
+            decoded_snapshots.append((step, ambient.detach().cpu().numpy()))
+
+        input_ambient = (
+            model.denormalize_tensor(capture_sample.input_fields).detach().cpu().numpy()
+        )
+        target_ambient = (
+            model.denormalize_tensor(target_fields_window).detach().cpu().numpy()
+        )
+
+    # decoded shapes: (1, T_out, H, W, C). Pull channel(s).
+    n_t_out_pred = decoded_snapshots[0][1].shape[1]
+    n_channels = decoded_snapshots[0][1].shape[-1]
+    chans = channel_indices(args, n_channels)
+    cmap_for = parse_cmap_list(args.cmap, chans)
+    symmetric_cmaps = parse_symmetric_set(args.symmetric_cmaps)
+    log.info(
+        "Snapshots: %d; T_out=%d; rendering channels: %s; cmaps: %s",
+        len(decoded_snapshots),
+        n_t_out_pred,
+        chans,
+        cmap_for,
+    )
+
+    # Determine shared color limits per channel from the *target/final* output
+    # so the input, ground truth, and final prediction share a scale. Earlier
+    # noisy intermediates will inevitably land outside this range — that's
+    # part of the visual story. Channels whose colormap is in the symmetric
+    # set get limits centered on zero.
+    final_pred = decoded_snapshots[-1][1]
+    color_limits: dict[int, tuple[float, float]] = {}
+    for c in chans:
+        all_vals = np.concatenate(
+            [
+                final_pred[..., c].ravel(),
+                target_ambient[..., c].ravel(),
+                input_ambient[..., c].ravel(),
+            ]
+        )
+        vmin = float(np.percentile(all_vals, 2))
+        vmax = float(np.percentile(all_vals, 98))
+        if cmap_for[c] in symmetric_cmaps:
+            extent = max(abs(vmin), abs(vmax))
+            vmin, vmax = -extent, extent
+        if vmin == vmax:
+            vmax = vmin + 1.0
+        color_limits[c] = (vmin, vmax)
+
+    suffix = args.format
+    win_tag = f"w{args.rollout_window:02d}"
+
+    # 1. Input field tiles for the visualised window.
+    for t_idx in range(input_ambient.shape[1]):
+        for c in chans:
+            vmin, vmax = color_limits[c]
+            save_tile(
+                input_ambient[0, t_idx, ..., c],
+                out_dir / f"{win_tag}_input_t{t_idx:02d}_c{c}.{suffix}",
+                vmin=vmin,
+                vmax=vmax,
+                cmap=cmap_for[c],
+                dpi=args.dpi,
+            )
+
+    # 2. Ground truth output tiles for the visualised window.
+    for t_idx in range(target_ambient.shape[1]):
+        for c in chans:
+            vmin, vmax = color_limits[c]
+            save_tile(
+                target_ambient[0, t_idx, ..., c],
+                out_dir / f"{win_tag}_truth_t{t_idx:02d}_c{c}.{suffix}",
+                vmin=vmin,
+                vmax=vmax,
+                cmap=cmap_for[c],
+                dpi=args.dpi,
+            )
+
+    # 3. ODE intermediates: one tile per (ode_step, output timestep, channel).
+    for step, decoded in decoded_snapshots:
+        for t_idx in range(decoded.shape[1]):
+            for c in chans:
+                vmin, vmax = color_limits[c]
+                save_tile(
+                    decoded[0, t_idx, ..., c],
+                    out_dir
+                    / f"{win_tag}_ode_step{step:03d}_t{t_idx:02d}_c{c}.{suffix}",
+                    vmin=vmin,
+                    vmax=vmax,
+                    cmap=cmap_for[c],
+                    dpi=args.dpi,
+                )
+
+    # 4. Contact sheet, one per rendered channel.
+    for contact_c in chans:
+        n_cols = decoded_snapshots[0][1].shape[1]  # T_out
+        n_rows = len(decoded_snapshots)
+        fig, axes = plt.subplots(
+            n_rows, n_cols, figsize=(2.0 * n_cols, 2.0 * n_rows), squeeze=False
+        )
+        vmin, vmax = color_limits[contact_c]
+        for row, (step, decoded) in enumerate(decoded_snapshots):
+            for col in range(n_cols):
+                ax = axes[row, col]
+                ax.imshow(
+                    decoded[0, col, ..., contact_c],
+                    vmin=vmin,
+                    vmax=vmax,
+                    cmap=cmap_for[contact_c],
+                    origin="lower",
+                )
+                ax.set_axis_off()
+                if col == 0:
+                    ax.set_title(f"k={step}", fontsize=8, loc="left")
+        fig.suptitle(
+            (
+                f"FM ODE trajectory — channel {contact_c}, "
+                f"batch {args.batch_index}, sample {args.sample_index}, "
+                f"rollout-window {args.rollout_window}"
+            ),
+            fontsize=10,
+        )
+        fig.tight_layout()
+        contact_path = out_dir / f"{win_tag}_contact_sheet_c{contact_c}.{suffix}"
+        fig.savefig(contact_path, dpi=args.dpi, bbox_inches="tight")
+        plt.close(fig)
+        log.info("Wrote contact sheet: %s", contact_path)
+    log.info("All tiles written to %s", out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_fm_ode_trajectory.py
+++ b/scripts/plot_fm_ode_trajectory.py
@@ -182,10 +182,11 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument(
         "--latent-cmap",
-        default="RdBu_r",
+        default="",
         help=(
             "Colormap for latent-space tiles. Single name or comma-separated "
-            "list aligned with --latent-channels."
+            "list aligned with --latent-channels. If empty (default), reuses "
+            "the ambient --cmap so latent and ambient panels match."
         ),
     )
     p.add_argument(
@@ -604,7 +605,8 @@ def main() -> None:
     latent_chans = parse_latent_channel_spec(args.latent_channels, n_latent_channels)
     latent_cmap_for: dict[int, str] = {}
     if latent_chans and not args.no_latent:
-        latent_cmap_for = parse_cmap_list(args.latent_cmap, latent_chans)
+        latent_cmap_spec = args.latent_cmap.strip() or args.cmap
+        latent_cmap_for = parse_cmap_list(latent_cmap_spec, latent_chans)
     log.info(
         "Channels: ambient=%s (cmaps=%s), latent=%s (cmaps=%s)",
         chans,

--- a/scripts/plot_fm_ode_trajectory.py
+++ b/scripts/plot_fm_ode_trajectory.py
@@ -4,8 +4,7 @@ Reconstructs the ambient-space EPD model from a processor-only checkpoint by
 re-using the eval pipeline's autoencoder injection + datamodule swap, then
 runs the flow-matching ODE step-by-step (Euler), capturing each intermediate
 latent. Each intermediate is decoded + denormalised and saved as one image
-tile per (intermediate, output-step, channel) so the panels can be assembled
-in Inkscape into something like the mock-up in methods_sketch_00.pdf.
+tile per (intermediate, output-step, channel) for assembling into diagrams.
 
 Example:
     python scripts/plot_fm_ode_trajectory.py \
@@ -59,9 +58,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument(
         "--run-dir",
         type=Path,
-        default=Path(
-            "outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3"
-        ),
+        default=Path("outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3"),
         help="Run directory containing resolved_config.yaml and processor.ckpt.",
     )
     p.add_argument(
@@ -452,9 +449,11 @@ def main() -> None:
         eval_cfg_path = run_dir / "eval" / "resolved_eval_config.yaml"
         if eval_cfg_path.exists():
             eval_cfg = OmegaConf.load(eval_cfg_path)
-            ae_ckpt = eval_cfg.get("autoencoder_checkpoint") if isinstance(
-                eval_cfg, DictConfig
-            ) else None
+            ae_ckpt = (
+                eval_cfg.get("autoencoder_checkpoint")
+                if isinstance(eval_cfg, DictConfig)
+                else None
+            )
             if ae_ckpt is not None:
                 with open_dict(cfg):
                     cfg.autoencoder_checkpoint = ae_ckpt
@@ -621,9 +620,7 @@ def main() -> None:
     if latent_chans and not args.no_latent:
         with torch.no_grad():
             for w in windows:
-                tgt = base_sample.output_fields[
-                    :, w * n_t_out : (w + 1) * n_t_out
-                ]
+                tgt = base_sample.output_fields[:, w * n_t_out : (w + 1) * n_t_out]
                 # Encoder consumes Batch.input_fields, so masquerade the
                 # target window as the input.
                 fake_batch = Batch(
@@ -640,9 +637,13 @@ def main() -> None:
 
     latent_color_limits: dict[int, tuple[float, float]] = {}
     for lc in latent_chans:
-        all_vals = np.concatenate(
-            [arr[..., lc].ravel() for arr in latent_targets_per_window.values()]
-        ) if latent_targets_per_window else np.array([0.0, 1.0])
+        all_vals = (
+            np.concatenate(
+                [arr[..., lc].ravel() for arr in latent_targets_per_window.values()]
+            )
+            if latent_targets_per_window
+            else np.array([0.0, 1.0])
+        )
         vmin = float(np.percentile(all_vals, 2))
         vmax = float(np.percentile(all_vals, 98))
         if args.latent_symmetric:
@@ -928,8 +929,7 @@ def visualise_window(
                 vmin, vmax = latent_color_limits[lc]
                 save_tile(
                     target_window_latent[0, t_idx, ..., lc],
-                    out_dir
-                    / f"{tag}_latent_truth_t{t_idx:02d}_lc{lc}.{suffix}",
+                    out_dir / f"{tag}_latent_truth_t{t_idx:02d}_lc{lc}.{suffix}",
                     vmin=vmin,
                     vmax=vmax,
                     cmap=latent_cmap_for[lc],

--- a/scripts/plot_fm_ode_trajectory.py
+++ b/scripts/plot_fm_ode_trajectory.py
@@ -10,17 +10,22 @@ in Inkscape into something like the mock-up in methods_sketch_00.pdf.
 Example:
     python scripts/plot_fm_ode_trajectory.py \
         --run-dir outputs/2026-04-20/diff_cns64_flow_matching_vit_09490da_636fcc3 \
-        --batch-index 0 --sample-index 0 --use-ema \
+        --batch-index 0 --sample-index 0 \
         --intermediate-stride 5 --channel 0
 
-Deeper rollout (visualise FM ODE at the 12th 4-step window, i.e. after 48 steps):
+Multiple rollout depths (windows are 0-indexed, n_steps_output frames each):
 
     python scripts/plot_fm_ode_trajectory.py \
-        --rollout-window 12 --use-ema --intermediate-stride 10 --channel 0
+        --rollout-windows 0,12,24 --intermediate-stride 10 --channel 0
+
+Multiple noise seeds — different ensemble members (saved with s{seed} tags):
+
+    python scripts/plot_fm_ode_trajectory.py \
+        --rollout-windows 0,12 --seeds 0,1,2
 
 Per-channel colormaps (smoke=viridis, u/v=RdBu_r):
 
-    python scripts/plot_fm_ode_trajectory.py --use-ema --all-channels \
+    python scripts/plot_fm_ode_trajectory.py --all-channels \
         --cmap viridis,RdBu_r,RdBu_r --symmetric-cmaps RdBu_r
 """
 
@@ -28,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+from datetime import datetime
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -73,7 +79,17 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=None,
         help=(
-            "Output directory for tiles. Defaults to <run-dir>/figures/fm_ode_traj."
+            "Output directory for tiles. If omitted, defaults to "
+            "<run-dir>/figures/fm_ode_traj_<timestamp>[_<label>] so re-runs "
+            "do not overwrite previous outputs."
+        ),
+    )
+    p.add_argument(
+        "--label",
+        default="",
+        help=(
+            "Optional label folded into the auto-generated output directory "
+            "name, e.g. --label cns64_w0-12-24."
         ),
     )
     p.add_argument("--batch-index", type=int, default=0, help="Test batch to draw.")
@@ -105,8 +121,22 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Force device, e.g. 'cuda' or 'cpu' (default: auto).",
     )
-    p.add_argument("--use-ema", action="store_true", help="Use EMA processor weights.")
-    p.add_argument("--seed", type=int, default=0, help="Seed for the noise z0.")
+    p.add_argument(
+        "--use-ema",
+        action="store_true",
+        help=(
+            "Use EMA processor weights. Off by default — main eval comparisons "
+            "do not use EMA, so this script matches that."
+        ),
+    )
+    p.add_argument(
+        "--seeds",
+        default="0",
+        help=(
+            "Comma-separated list of noise seeds. Each seed produces an "
+            "independent ensemble member. Output filenames are tagged s{seed}."
+        ),
+    )
     p.add_argument(
         "--format",
         default="pdf",
@@ -131,16 +161,70 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     p.add_argument(
-        "--rollout-window",
-        type=int,
-        default=0,
+        "--rollout-windows",
+        default="0",
         help=(
-            "Output window (0-indexed, length n_steps_output frames each) at "
-            "which to capture the FM ODE intermediates. 0 = the first window "
-            "(uses the test_dataloader). >0 = autoregressive rollout to that "
-            "window first; uses the rollout_test_dataloader so ground truth "
-            "is available for the deeper window too."
+            "Comma-separated list of output windows (0-indexed, n_steps_output "
+            "frames each) at which to capture the FM ODE intermediates. 0 is "
+            "the first window. For any window >0 we use the rollout test "
+            "dataloader (full-trajectory mode) so ground truth is available "
+            "at any depth."
         ),
+    )
+    p.add_argument(
+        "--latent-channels",
+        default="all",
+        help=(
+            "Comma-separated list of latent channels to render in latent-space "
+            "plots, or 'all' for every channel (typically 8). 'none' disables "
+            "latent-space output."
+        ),
+    )
+    p.add_argument(
+        "--latent-cmap",
+        default="RdBu_r",
+        help=(
+            "Colormap for latent-space tiles. Single name or comma-separated "
+            "list aligned with --latent-channels."
+        ),
+    )
+    p.add_argument(
+        "--latent-symmetric",
+        action="store_true",
+        default=True,
+        help=(
+            "Use symmetric color limits around zero for latent-space tiles "
+            "(latents are roughly zero-centred). On by default."
+        ),
+    )
+    p.add_argument(
+        "--no-latent-symmetric",
+        dest="latent_symmetric",
+        action="store_false",
+        help="Disable symmetric latent color limits.",
+    )
+    p.add_argument(
+        "--const-names",
+        default="buoyancy_y,smoothness,noise_scale,smoke_diffusivity",
+        help=(
+            "Comma-separated names for the global-cond constant scalars, "
+            "used in filenames for the constants heatmap tiles."
+        ),
+    )
+    p.add_argument(
+        "--const-cmap",
+        default="cividis",
+        help="Matplotlib colormap for constant-scalar heatmap tiles.",
+    )
+    p.add_argument(
+        "--no-constants",
+        action="store_true",
+        help="Skip the constant-scalars heatmap output.",
+    )
+    p.add_argument(
+        "--no-latent",
+        action="store_true",
+        help="Skip the latent-space ODE intermediate output.",
     )
     p.add_argument(
         "--dpi",
@@ -331,12 +415,19 @@ def main() -> None:
     if not ckpt_path.exists():
         raise FileNotFoundError(ckpt_path)
 
-    out_dir = (
-        args.out_dir.resolve()
-        if args.out_dir is not None
-        else run_dir / "figures" / "fm_ode_traj"
-    )
+    if args.out_dir is not None:
+        out_dir = args.out_dir.resolve()
+    else:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        suffix = f"fm_ode_traj_{timestamp}"
+        if args.label:
+            sanitized = "".join(
+                ch if ch.isalnum() or ch in "-_." else "_" for ch in args.label
+            )
+            suffix = f"{suffix}_{sanitized}"
+        out_dir = run_dir / "figures" / suffix
     out_dir.mkdir(parents=True, exist_ok=True)
+    log.info("Output directory: %s", out_dir)
 
     log.info("Loading config from %s", cfg_path)
     cfg = OmegaConf.load(cfg_path)
@@ -415,18 +506,26 @@ def main() -> None:
     model.to(device)
     model.eval()
 
-    # Choose the dataloader. Window 0 is fine on the standard test loader
-    # (n_steps_output frames of GT). Deeper windows need the rollout loader,
-    # which yields a single window per trajectory in full_trajectory_mode so
-    # we get GT for every output frame in the trajectory.
+    # Parse plan: which windows × which seeds.
+    seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
+    if not seeds:
+        raise ValueError("--seeds is empty.")
+    windows = sorted({int(w) for w in args.rollout_windows.split(",") if w.strip()})
+    if not windows:
+        raise ValueError("--rollout-windows is empty.")
+    log.info("Plan: windows=%s, seeds=%s", windows, seeds)
+
+    # Choose the dataloader. Window 0 only is fine on the standard test
+    # loader; any deeper window needs full trajectories, so we always use
+    # the rollout loader when max(windows) > 0.
     datamodule.setup(stage="test")
-    if args.rollout_window <= 0:
+    if max(windows) <= 0:
         loader = datamodule.test_dataloader()
         loader_name = "test_dataloader"
     else:
         loader = datamodule.rollout_test_dataloader()
         loader_name = "rollout_test_dataloader"
-    log.info("Using %s for window=%s", loader_name, args.rollout_window)
+    log.info("Using %s", loader_name)
 
     batch = None
     seen = 0
@@ -450,109 +549,46 @@ def main() -> None:
         )
         raise IndexError(msg)
 
-    sample = select_sample(batch, args.sample_index)
-    sample = to_device(sample, device)
+    base_sample = select_sample(batch, args.sample_index)
+    base_sample = to_device(base_sample, device)
 
     n_t_out = int(model.processor.n_steps_output)
-    n_t_in = sample.input_fields.shape[1]
-    if args.rollout_window > 0:
-        # In full-trajectory mode `output_fields` holds the entire GT
-        # trajectory after the initial input, so we can slice the GT for
-        # any output window. For the visualised window we also need the
-        # *predicted* input frame at that point — produce it via free-
-        # running rollout for the preceding (rollout_window) windows.
-        gt_start = args.rollout_window * n_t_out
-        gt_end = gt_start + n_t_out
-        if gt_end > sample.output_fields.shape[1]:
-            msg = (
-                f"--rollout-window={args.rollout_window} requires GT frames "
-                f"up to index {gt_end - 1}, but the trajectory only has "
-                f"{sample.output_fields.shape[1]} output frames."
-            )
-            raise IndexError(msg)
-        target_fields_window = sample.output_fields[:, gt_start:gt_end, ...]
 
-        torch.manual_seed(args.seed)
-        if device.type == "cuda":
-            torch.cuda.manual_seed_all(args.seed)
-        log.info(
-            "Free-running rollout for %s windows before capture...",
-            args.rollout_window,
+    # Sanity-check trajectory length covers the deepest window's GT slice.
+    gt_end = (max(windows) + 1) * n_t_out
+    if gt_end > base_sample.output_fields.shape[1]:
+        msg = (
+            f"Deepest window {max(windows)} requires GT frames up to "
+            f"{gt_end - 1}, but the trajectory only has "
+            f"{base_sample.output_fields.shape[1]} output frames."
         )
-        current = sample
-        for _ in range(args.rollout_window):
-            current = advance_batch_free_running(model, current)
-        capture_sample = current
-    else:
-        target_fields_window = sample.output_fields
-        capture_sample = sample
-        torch.manual_seed(args.seed)
-        if device.type == "cuda":
-            torch.cuda.manual_seed_all(args.seed)
+        raise IndexError(msg)
 
-    # Encode → latent input + global conditioning at the chosen window.
-    with torch.no_grad():
-        z_input, global_cond = model.encoder_decoder.encoder.encode_with_cond(
-            capture_sample
-        )
-    log.info(
-        "Encoded latent shape: %s; global_cond shape: %s",
-        tuple(z_input.shape),
-        tuple(global_cond.shape) if global_cond is not None else None,
-    )
-
-    capture_every = max(args.intermediate_stride, 1)
-    log.info(
-        "Rolling out flow ODE with %s steps; capturing every %s.",
-        model.processor.flow_ode_steps,
-        capture_every,
-    )
-    _, snapshots = run_fm_with_intermediates(
-        model.processor, z_input, global_cond, capture_every=capture_every
-    )
-
-    # Decode + denormalise each snapshot, plus the input & ground truth output.
-    decoded_snapshots: list[tuple[int, np.ndarray]] = []
-    with torch.no_grad():
-        for step, z_snap in snapshots:
-            ambient = latents_to_ambient(model, z_snap, denormalise=True)
-            decoded_snapshots.append((step, ambient.detach().cpu().numpy()))
-
-        input_ambient = (
-            model.denormalize_tensor(capture_sample.input_fields).detach().cpu().numpy()
-        )
-        target_ambient = (
-            model.denormalize_tensor(target_fields_window).detach().cpu().numpy()
-        )
-
-    # decoded shapes: (1, T_out, H, W, C). Pull channel(s).
-    n_t_out_pred = decoded_snapshots[0][1].shape[1]
-    n_channels = decoded_snapshots[0][1].shape[-1]
+    # Channel selection + colormap setup.
+    n_channels = base_sample.input_fields.shape[-1]
     chans = channel_indices(args, n_channels)
     cmap_for = parse_cmap_list(args.cmap, chans)
     symmetric_cmaps = parse_symmetric_set(args.symmetric_cmaps)
-    log.info(
-        "Snapshots: %d; T_out=%d; rendering channels: %s; cmaps: %s",
-        len(decoded_snapshots),
-        n_t_out_pred,
-        chans,
-        cmap_for,
-    )
 
-    # Determine shared color limits per channel from the *target/final* output
-    # so the input, ground truth, and final prediction share a scale. Earlier
-    # noisy intermediates will inevitably land outside this range — that's
-    # part of the visual story. Channels whose colormap is in the symmetric
-    # set get limits centered on zero.
-    final_pred = decoded_snapshots[-1][1]
+    # Compute global ambient color limits per channel from the union of all
+    # visualised-window GTs + the input frame, so the same scale applies
+    # across windows/seeds. Noisy intermediates will saturate against this.
+    target_slices_per_window: dict[int, np.ndarray] = {}
+    with torch.no_grad():
+        input_ambient_np = (
+            model.denormalize_tensor(base_sample.input_fields).detach().cpu().numpy()
+        )
+        for w in windows:
+            tgt = base_sample.output_fields[:, w * n_t_out : (w + 1) * n_t_out]
+            target_slices_per_window[w] = (
+                model.denormalize_tensor(tgt).detach().cpu().numpy()
+            )
+
     color_limits: dict[int, tuple[float, float]] = {}
     for c in chans:
         all_vals = np.concatenate(
-            [
-                final_pred[..., c].ravel(),
-                target_ambient[..., c].ravel(),
-                input_ambient[..., c].ravel(),
-            ]
+            [input_ambient_np[..., c].ravel()]
+            + [arr[..., c].ravel() for arr in target_slices_per_window.values()]
         )
         vmin = float(np.percentile(all_vals, 2))
         vmax = float(np.percentile(all_vals, 98))
@@ -563,36 +599,281 @@ def main() -> None:
             vmax = vmin + 1.0
         color_limits[c] = (vmin, vmax)
 
-    suffix = args.format
-    win_tag = f"w{args.rollout_window:02d}"
+    # Latent setup.
+    n_latent_channels = int(model.processor.n_channels_out)
+    latent_chans = parse_latent_channel_spec(args.latent_channels, n_latent_channels)
+    latent_cmap_for: dict[int, str] = {}
+    if latent_chans and not args.no_latent:
+        latent_cmap_for = parse_cmap_list(args.latent_cmap, latent_chans)
+    log.info(
+        "Channels: ambient=%s (cmaps=%s), latent=%s (cmaps=%s)",
+        chans,
+        cmap_for,
+        latent_chans,
+        latent_cmap_for,
+    )
 
-    # 1. Input field tiles for the visualised window.
+    # Compute global latent color limits per latent channel from each
+    # window's encoded GT (this is the destination of the FM trajectory).
+    latent_targets_per_window: dict[int, np.ndarray] = {}
+    if latent_chans and not args.no_latent:
+        with torch.no_grad():
+            for w in windows:
+                tgt = base_sample.output_fields[
+                    :, w * n_t_out : (w + 1) * n_t_out
+                ]
+                # Encoder consumes Batch.input_fields, so masquerade the
+                # target window as the input.
+                fake_batch = Batch(
+                    input_fields=tgt,
+                    output_fields=tgt,
+                    constant_scalars=base_sample.constant_scalars,
+                    constant_fields=base_sample.constant_fields,
+                    boundary_conditions=base_sample.boundary_conditions,
+                )
+                z_tgt = model.encoder_decoder.encoder.encode(fake_batch)
+                if isinstance(z_tgt, tuple):
+                    z_tgt = z_tgt[0]
+                latent_targets_per_window[w] = z_tgt.detach().cpu().numpy()
+
+    latent_color_limits: dict[int, tuple[float, float]] = {}
+    for lc in latent_chans:
+        all_vals = np.concatenate(
+            [arr[..., lc].ravel() for arr in latent_targets_per_window.values()]
+        ) if latent_targets_per_window else np.array([0.0, 1.0])
+        vmin = float(np.percentile(all_vals, 2))
+        vmax = float(np.percentile(all_vals, 98))
+        if args.latent_symmetric:
+            extent = max(abs(vmin), abs(vmax))
+            vmin, vmax = -extent, extent
+        if vmin == vmax:
+            vmax = vmin + 1.0
+        latent_color_limits[lc] = (vmin, vmax)
+
+    # Constants: render once (sample-invariant across seeds/windows).
+    if not args.no_constants and base_sample.constant_scalars is not None:
+        write_constants_tiles(
+            base_sample=base_sample,
+            full_batch_constants=batch.constant_scalars,
+            ambient_spatial_shape=tuple(base_sample.input_fields.shape[2:-1]),
+            const_names=[s.strip() for s in args.const_names.split(",") if s.strip()],
+            cmap=args.const_cmap,
+            out_dir=out_dir,
+            suffix=args.format,
+            dpi=args.dpi,
+        )
+    elif base_sample.constant_scalars is None:
+        log.info("No constant_scalars on this sample — skipping constants tiles.")
+
+    capture_every = max(args.intermediate_stride, 1)
+    log.info(
+        "FM ODE: %s steps total; capturing every %s.",
+        model.processor.flow_ode_steps,
+        capture_every,
+    )
+
+    # Outer loop: seeds (independent ensemble members).
+    # Inner loop: windows in ascending order (incremental advance).
+    for seed in seeds:
+        torch.manual_seed(seed)
+        if device.type == "cuda":
+            torch.cuda.manual_seed_all(seed)
+        log.info("=== seed=%s ===", seed)
+
+        current = base_sample
+        last_window = 0
+        for window in windows:
+            for _ in range(window - last_window):
+                current = advance_batch_free_running(model, current)
+            last_window = window
+
+            visualise_window(
+                model=model,
+                capture_sample=current,
+                target_window_ambient=target_slices_per_window[window],
+                target_window_latent=latent_targets_per_window.get(window),
+                window=window,
+                seed=seed,
+                chans=chans,
+                cmap_for=cmap_for,
+                color_limits=color_limits,
+                latent_chans=latent_chans,
+                latent_cmap_for=latent_cmap_for,
+                latent_color_limits=latent_color_limits,
+                capture_every=capture_every,
+                out_dir=out_dir,
+                suffix=args.format,
+                dpi=args.dpi,
+                batch_index=args.batch_index,
+                sample_index=args.sample_index,
+                emit_latent=not args.no_latent,
+            )
+
+    log.info("All tiles written to %s", out_dir)
+
+
+def parse_latent_channel_spec(spec: str, n_latent: int) -> list[int]:
+    s = spec.strip().lower()
+    if s == "none" or s == "":
+        return []
+    if s == "all":
+        return list(range(n_latent))
+    out = []
+    for part in spec.split(","):
+        if not part.strip():
+            continue
+        idx = int(part)
+        if not (0 <= idx < n_latent):
+            msg = f"--latent-channels={spec!r} contains out-of-range index {idx} (n_latent={n_latent})."
+            raise ValueError(msg)
+        out.append(idx)
+    return out
+
+
+def write_constants_tiles(
+    *,
+    base_sample: Batch,
+    full_batch_constants: torch.Tensor | None,
+    ambient_spatial_shape: tuple[int, ...],
+    const_names: list[str],
+    cmap: str,
+    out_dir: Path,
+    suffix: str,
+    dpi: int,
+) -> None:
+    """Render each global-cond constant as a uniform-color square tile.
+
+    Color limits per constant are taken from the min/max across the loaded
+    batch (so e.g. a buoyancy of 0.72 sits sensibly between 0.2 and 0.8 if
+    the batch covers that range). Constants whose batch has no spread fall
+    back to ±0.5 around the value so the tile is still visible.
+    """
+    cs = base_sample.constant_scalars
+    if cs is None:
+        return
+    values = cs.detach().cpu().numpy().reshape(-1)  # (n_const,)
+    n_const = values.shape[0]
+
+    if full_batch_constants is not None and full_batch_constants.dim() == 2:
+        batch_cs = full_batch_constants.detach().cpu().numpy()  # (B, n_const)
+    else:
+        batch_cs = None
+
+    if len(const_names) < n_const:
+        const_names = const_names + [f"c{i}" for i in range(len(const_names), n_const)]
+    elif len(const_names) > n_const:
+        const_names = const_names[:n_const]
+
+    h, w = ambient_spatial_shape[:2]
+    fig, axes = plt.subplots(1, n_const, figsize=(2.0 * n_const, 2.4), squeeze=False)
+    for i in range(n_const):
+        val = float(values[i])
+        if batch_cs is not None and batch_cs.shape[0] > 1:
+            vmin = float(batch_cs[:, i].min())
+            vmax = float(batch_cs[:, i].max())
+        else:
+            vmin, vmax = val, val
+        if vmin == vmax:
+            vmin = val - 0.5
+            vmax = val + 0.5
+        tile = np.full((h, w), val, dtype=np.float32)
+        save_tile(
+            tile,
+            out_dir / f"const_{i}_{const_names[i]}.{suffix}",
+            vmin=vmin,
+            vmax=vmax,
+            cmap=cmap,
+            dpi=dpi,
+        )
+        ax = axes[0, i]
+        ax.imshow(tile, vmin=vmin, vmax=vmax, cmap=cmap, origin="lower")
+        ax.set_axis_off()
+        ax.set_title(f"{const_names[i]}\n{val:.4g}", fontsize=9)
+    fig.suptitle("Constant scalars (global conditioning)", fontsize=10)
+    fig.tight_layout()
+    summary_path = out_dir / f"const_summary.{suffix}"
+    fig.savefig(summary_path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    log.info("Wrote constant scalars summary: %s", summary_path)
+
+
+def visualise_window(
+    *,
+    model,
+    capture_sample: Batch,
+    target_window_ambient: np.ndarray,
+    target_window_latent: np.ndarray | None,
+    window: int,
+    seed: int,
+    chans: list[int],
+    cmap_for: dict[int, str],
+    color_limits: dict[int, tuple[float, float]],
+    latent_chans: list[int],
+    latent_cmap_for: dict[int, str],
+    latent_color_limits: dict[int, tuple[float, float]],
+    capture_every: int,
+    out_dir: Path,
+    suffix: str,
+    dpi: int,
+    batch_index: int,
+    sample_index: int,
+    emit_latent: bool,
+) -> None:
+    """Capture FM ODE intermediates at the current window and write tiles."""
+    log.info("Capturing seed=%s window=%s", seed, window)
+
+    with torch.no_grad():
+        z_input, global_cond = model.encoder_decoder.encoder.encode_with_cond(
+            capture_sample
+        )
+
+    _, snapshots = run_fm_with_intermediates(
+        model.processor, z_input, global_cond, capture_every=capture_every
+    )
+
+    decoded_snapshots: list[tuple[int, np.ndarray]] = []
+    latent_snapshots: list[tuple[int, np.ndarray]] = []
+    with torch.no_grad():
+        for step, z_snap in snapshots:
+            ambient = latents_to_ambient(model, z_snap, denormalise=True)
+            decoded_snapshots.append((step, ambient.detach().cpu().numpy()))
+            if emit_latent and latent_chans:
+                latent_snapshots.append((step, z_snap.detach().cpu().numpy()))
+
+        input_ambient = (
+            model.denormalize_tensor(capture_sample.input_fields).detach().cpu().numpy()
+        )
+        z_input_np = z_input.detach().cpu().numpy()
+
+    tag = f"s{seed:03d}_w{window:02d}"
+
+    # 1. Ambient input frame (the visualised window's input).
     for t_idx in range(input_ambient.shape[1]):
         for c in chans:
             vmin, vmax = color_limits[c]
             save_tile(
                 input_ambient[0, t_idx, ..., c],
-                out_dir / f"{win_tag}_input_t{t_idx:02d}_c{c}.{suffix}",
+                out_dir / f"{tag}_ambient_input_t{t_idx:02d}_c{c}.{suffix}",
                 vmin=vmin,
                 vmax=vmax,
                 cmap=cmap_for[c],
-                dpi=args.dpi,
+                dpi=dpi,
             )
 
-    # 2. Ground truth output tiles for the visualised window.
-    for t_idx in range(target_ambient.shape[1]):
+    # 2. Ambient ground-truth output for this window.
+    for t_idx in range(target_window_ambient.shape[1]):
         for c in chans:
             vmin, vmax = color_limits[c]
             save_tile(
-                target_ambient[0, t_idx, ..., c],
-                out_dir / f"{win_tag}_truth_t{t_idx:02d}_c{c}.{suffix}",
+                target_window_ambient[0, t_idx, ..., c],
+                out_dir / f"{tag}_ambient_truth_t{t_idx:02d}_c{c}.{suffix}",
                 vmin=vmin,
                 vmax=vmax,
                 cmap=cmap_for[c],
-                dpi=args.dpi,
+                dpi=dpi,
             )
 
-    # 3. ODE intermediates: one tile per (ode_step, output timestep, channel).
+    # 3. Ambient ODE intermediates.
     for step, decoded in decoded_snapshots:
         for t_idx in range(decoded.shape[1]):
             for c in chans:
@@ -600,48 +881,125 @@ def main() -> None:
                 save_tile(
                     decoded[0, t_idx, ..., c],
                     out_dir
-                    / f"{win_tag}_ode_step{step:03d}_t{t_idx:02d}_c{c}.{suffix}",
+                    / f"{tag}_ambient_ode_step{step:03d}_t{t_idx:02d}_c{c}.{suffix}",
                     vmin=vmin,
                     vmax=vmax,
                     cmap=cmap_for[c],
-                    dpi=args.dpi,
+                    dpi=dpi,
                 )
 
-    # 4. Contact sheet, one per rendered channel.
+    # 4. Ambient contact sheet, one per channel.
     for contact_c in chans:
-        n_cols = decoded_snapshots[0][1].shape[1]  # T_out
-        n_rows = len(decoded_snapshots)
-        fig, axes = plt.subplots(
-            n_rows, n_cols, figsize=(2.0 * n_cols, 2.0 * n_rows), squeeze=False
+        write_contact_sheet(
+            decoded_snapshots,
+            channel=contact_c,
+            cmap=cmap_for[contact_c],
+            color_limits=color_limits[contact_c],
+            title=(
+                f"FM ODE (ambient) — c{contact_c}, batch {batch_index}, "
+                f"sample {sample_index}, window {window}, seed {seed}"
+            ),
+            out_path=out_dir / f"{tag}_ambient_contact_c{contact_c}.{suffix}",
+            dpi=dpi,
         )
-        vmin, vmax = color_limits[contact_c]
-        for row, (step, decoded) in enumerate(decoded_snapshots):
-            for col in range(n_cols):
-                ax = axes[row, col]
-                ax.imshow(
-                    decoded[0, col, ..., contact_c],
+
+    if not emit_latent or not latent_chans:
+        return
+
+    # 5. Latent input (encoder output for the visualised window's input).
+    for t_idx in range(z_input_np.shape[1]):
+        for lc in latent_chans:
+            vmin, vmax = latent_color_limits[lc]
+            save_tile(
+                z_input_np[0, t_idx, ..., lc],
+                out_dir / f"{tag}_latent_input_t{t_idx:02d}_lc{lc}.{suffix}",
+                vmin=vmin,
+                vmax=vmax,
+                cmap=latent_cmap_for[lc],
+                dpi=dpi,
+            )
+
+    # 6. Latent ground truth (encoder output for the GT window).
+    if target_window_latent is not None:
+        for t_idx in range(target_window_latent.shape[1]):
+            for lc in latent_chans:
+                vmin, vmax = latent_color_limits[lc]
+                save_tile(
+                    target_window_latent[0, t_idx, ..., lc],
+                    out_dir
+                    / f"{tag}_latent_truth_t{t_idx:02d}_lc{lc}.{suffix}",
                     vmin=vmin,
                     vmax=vmax,
-                    cmap=cmap_for[contact_c],
-                    origin="lower",
+                    cmap=latent_cmap_for[lc],
+                    dpi=dpi,
                 )
-                ax.set_axis_off()
-                if col == 0:
-                    ax.set_title(f"k={step}", fontsize=8, loc="left")
-        fig.suptitle(
-            (
-                f"FM ODE trajectory — channel {contact_c}, "
-                f"batch {args.batch_index}, sample {args.sample_index}, "
-                f"rollout-window {args.rollout_window}"
+
+    # 7. Latent ODE intermediates (this is where the ODE actually runs).
+    for step, z_snap_np in latent_snapshots:
+        for t_idx in range(z_snap_np.shape[1]):
+            for lc in latent_chans:
+                vmin, vmax = latent_color_limits[lc]
+                save_tile(
+                    z_snap_np[0, t_idx, ..., lc],
+                    out_dir
+                    / f"{tag}_latent_ode_step{step:03d}_t{t_idx:02d}_lc{lc}.{suffix}",
+                    vmin=vmin,
+                    vmax=vmax,
+                    cmap=latent_cmap_for[lc],
+                    dpi=dpi,
+                )
+
+    # 8. Latent contact sheet, one per latent channel.
+    for contact_lc in latent_chans:
+        write_contact_sheet(
+            latent_snapshots,
+            channel=contact_lc,
+            cmap=latent_cmap_for[contact_lc],
+            color_limits=latent_color_limits[contact_lc],
+            title=(
+                f"FM ODE (latent) — lc{contact_lc}, batch {batch_index}, "
+                f"sample {sample_index}, window {window}, seed {seed}"
             ),
-            fontsize=10,
+            out_path=out_dir / f"{tag}_latent_contact_lc{contact_lc}.{suffix}",
+            dpi=dpi,
         )
-        fig.tight_layout()
-        contact_path = out_dir / f"{win_tag}_contact_sheet_c{contact_c}.{suffix}"
-        fig.savefig(contact_path, dpi=args.dpi, bbox_inches="tight")
-        plt.close(fig)
-        log.info("Wrote contact sheet: %s", contact_path)
-    log.info("All tiles written to %s", out_dir)
+
+
+def write_contact_sheet(
+    snapshots: list[tuple[int, np.ndarray]],
+    *,
+    channel: int,
+    cmap: str,
+    color_limits: tuple[float, float],
+    title: str,
+    out_path: Path,
+    dpi: int,
+) -> None:
+    n_cols = snapshots[0][1].shape[1]  # T_out
+    n_rows = len(snapshots)
+    fig, axes = plt.subplots(
+        n_rows, n_cols, figsize=(2.0 * n_cols, 2.0 * n_rows), squeeze=False
+    )
+    vmin, vmax = color_limits
+    for row, (step, arr) in enumerate(snapshots):
+        for col in range(n_cols):
+            ax = axes[row, col]
+            ax.imshow(
+                arr[0, col, ..., channel],
+                vmin=vmin,
+                vmax=vmax,
+                cmap=cmap,
+                origin="lower",
+            )
+            ax.set_axis_off()
+            if col == 0:
+                ax.set_title(f"k={step}", fontsize=8, loc="left")
+    fig.suptitle(title, fontsize=10)
+    fig.tight_layout()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    log.info("Wrote contact sheet: %s", out_path)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_fm_ode_trajectory.py
+++ b/scripts/plot_fm_ode_trajectory.py
@@ -42,9 +42,9 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 
 from autocast.processors.flow_matching import FlowMatchingProcessor
 from autocast.scripts.eval.encoder_processor_decoder import (
+    _extract_processor_state_dict,
     _maybe_inject_encoder_decoder_from_autoencoder_checkpoint,
     _maybe_swap_to_ambient_datamodule,
-    _extract_processor_state_dict,
 )
 from autocast.scripts.execution import load_checkpoint_payload
 from autocast.scripts.setup import setup_datamodule, setup_epd_model
@@ -54,6 +54,7 @@ log = logging.getLogger("plot_fm_ode_trajectory")
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--run-dir",
@@ -182,8 +183,8 @@ def parse_args() -> argparse.Namespace:
         default="",
         help=(
             "Colormap for latent-space tiles. Single name or comma-separated "
-            "list aligned with --latent-channels. If empty (default), reuses "
-            "the ambient --cmap so latent and ambient panels match."
+            "list aligned with --latent-channels. If empty (default), uses "
+            "the first rendered ambient colormap for all latent channels."
         ),
     )
     p.add_argument(
@@ -233,6 +234,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def resolve_device(name: str | None) -> torch.device:
+    """Resolve the torch device used for model evaluation and plotting."""
     if name is not None:
         return torch.device(name)
     if torch.cuda.is_available():
@@ -256,6 +258,7 @@ def select_sample(batch: Batch, idx: int) -> Batch:
 
 
 def to_device(batch: Batch, device: torch.device) -> Batch:
+    """Move all tensors in a batch to the requested device."""
     return Batch(
         input_fields=batch.input_fields.to(device),
         output_fields=batch.output_fields.to(device),
@@ -347,6 +350,7 @@ def save_tile(
 
 
 def channel_indices(args: argparse.Namespace, n_channels: int) -> list[int]:
+    """Resolve ambient channel indices to render."""
     if args.all_channels:
         return list(range(n_channels))
     if args.channel >= n_channels:
@@ -366,7 +370,7 @@ def parse_cmap_list(spec: str, channels: list[int]) -> dict[int, str]:
         msg = "--cmap must not be empty."
         raise ValueError(msg)
     if len(parts) == 1:
-        return {c: parts[0] for c in channels}
+        return dict.fromkeys(channels, parts[0])
     if len(parts) != len(channels):
         msg = (
             f"--cmap='{spec}' has {len(parts)} entries but {len(channels)} channels "
@@ -377,6 +381,7 @@ def parse_cmap_list(spec: str, channels: list[int]) -> dict[int, str]:
 
 
 def parse_symmetric_set(spec: str) -> set[str]:
+    """Parse colormap names that should use symmetric color limits."""
     return {p.strip() for p in spec.split(",") if p.strip()}
 
 
@@ -401,7 +406,8 @@ def advance_batch_free_running(model, batch: Batch) -> Batch:
     )
 
 
-def main() -> None:
+def main() -> None:  # noqa: PLR0912, PLR0915
+    """Run the FM ODE trajectory plotting workflow."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
     args = parse_args()
 
@@ -472,7 +478,7 @@ def main() -> None:
 
     # Build a probe datamodule first so we can detect that the cached-latent
     # datamodule is the active one and trigger the swap to ambient.
-    probe_datamodule, cfg, probe_stats = setup_datamodule(cfg)
+    _probe_datamodule, cfg, probe_stats = setup_datamodule(cfg)
     cfg = _maybe_swap_to_ambient_datamodule(
         cfg,
         eval_mode="ambient",
@@ -506,13 +512,15 @@ def main() -> None:
     model.to(device)
     model.eval()
 
-    # Parse plan: which windows × which seeds.
+    # Parse plan: which windows and which seeds.
     seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
     if not seeds:
-        raise ValueError("--seeds is empty.")
+        msg = "--seeds is empty."
+        raise ValueError(msg)
     windows = sorted({int(w) for w in args.rollout_windows.split(",") if w.strip()})
     if not windows:
-        raise ValueError("--rollout-windows is empty.")
+        msg = "--rollout-windows is empty."
+        raise ValueError(msg)
     log.info("Plan: windows=%s, seeds=%s", windows, seeds)
 
     # Choose the dataloader. Window 0 only is fine on the standard test
@@ -604,7 +612,7 @@ def main() -> None:
     latent_chans = parse_latent_channel_spec(args.latent_channels, n_latent_channels)
     latent_cmap_for: dict[int, str] = {}
     if latent_chans and not args.no_latent:
-        latent_cmap_spec = args.latent_cmap.strip() or args.cmap
+        latent_cmap_spec = args.latent_cmap.strip() or cmap_for[chans[0]]
         latent_cmap_for = parse_cmap_list(latent_cmap_spec, latent_chans)
     log.info(
         "Channels: ambient=%s (cmaps=%s), latent=%s (cmaps=%s)",
@@ -716,8 +724,9 @@ def main() -> None:
 
 
 def parse_latent_channel_spec(spec: str, n_latent: int) -> list[int]:
+    """Resolve latent channel indices to render from a CLI string."""
     s = spec.strip().lower()
-    if s == "none" or s == "":
+    if s in {"none", ""}:
         return []
     if s == "all":
         return list(range(n_latent))
@@ -727,7 +736,10 @@ def parse_latent_channel_spec(spec: str, n_latent: int) -> list[int]:
             continue
         idx = int(part)
         if not (0 <= idx < n_latent):
-            msg = f"--latent-channels={spec!r} contains out-of-range index {idx} (n_latent={n_latent})."
+            msg = (
+                f"--latent-channels={spec!r} contains out-of-range index {idx} "
+                f"(n_latent={n_latent})."
+            )
             raise ValueError(msg)
         out.append(idx)
     return out
@@ -800,7 +812,7 @@ def write_constants_tiles(
     log.info("Wrote constant scalars summary: %s", summary_path)
 
 
-def visualise_window(
+def visualise_window(  # noqa: PLR0912
     *,
     model,
     capture_sample: Batch,
@@ -977,6 +989,7 @@ def write_contact_sheet(
     out_path: Path,
     dpi: int,
 ) -> None:
+    """Write a contact sheet from ODE snapshot arrays."""
     n_cols = snapshots[0][1].shape[1]  # T_out
     n_rows = len(snapshots)
     fig, axes = plt.subplots(

--- a/slurm_scripts/comparison/eval/submit_eval_crps_ambient_best_multiwinkler_from0p25_snapshots.sh
+++ b/slurm_scripts/comparison/eval/submit_eval_crps_ambient_best_multiwinkler_from0p25_snapshots.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -euo pipefail
+# Snapshots variant of submit_eval_crps_ambient_best_multiwinkler_from0p25.sh.
+#
+# Writes outputs to a sibling subdir suffixed `_snapshots` so the figure-only
+# re-run lives next to the original eval. Supports running each eval either via
+# SLURM (default, sbatch through the autocast workflow) or locally on the
+# current machine.
+#
+# Usage:
+#   ./submit_eval_crps_ambient_best_multiwinkler_from0p25_snapshots.sh           # slurm (default)
+#   RUN_MODE=local ./submit_eval_crps_ambient_best_multiwinkler_from0p25_snapshots.sh
+#   RUN_MODE=slurm ./submit_eval_crps_ambient_best_multiwinkler_from0p25_snapshots.sh
+#
+# In slurm mode both real and `--dry-run` submissions are performed, matching
+# the parent script. In local mode only the real run is executed (dry-run is a
+# slurm-submission concern).
+
+EVAL_BATCH_SIZE=8
+EVAL_N_MEMBERS=10
+TIMEOUT_MIN=240
+EVAL_SUBDIR="eval_best_multiwinkler_from0p25_snapshots"
+ROLLOUT_SNAPSHOT_TIMESTEPS="[0,4,12,30,99]"
+RUN_MODE="${RUN_MODE:-slurm}"
+EVAL_METRICS="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,ssr,winkler]"
+
+case "${RUN_MODE}" in
+    slurm) RUN_DRY_STATES=("true" "false") ;;
+    local) RUN_DRY_STATES=("false") ;;
+    *)
+        echo "Unknown RUN_MODE='${RUN_MODE}'. Expected 'slurm' or 'local'." >&2
+        exit 2
+        ;;
+esac
+
+RUN_DIRS=(
+    "outputs/2026-04-24/crps_gs64_vit_azula_large_bed4611_828a161"
+    "outputs/2026-04-24/crps_gpe64_vit_azula_large_bed4611_e0a6df5"
+    "outputs/2026-04-24/crps_cns64_vit_azula_large_bed4611_c99f534"
+    "outputs/2026-04-24/crps_ad64_vit_azula_large_bed4611_da01a04"
+)
+
+resolve_multiwinkler_checkpoint() {
+    local run_dir="$1"
+    local -a ckpts=()
+
+    mapfile -t ckpts < <(
+        find "${run_dir}" -path '*/checkpoints/best-multiwinkler.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    mapfile -t ckpts < <(
+        find "${run_dir}" -type f -path '*/checkpoints/best-multiwinkler-from0p25-*.ckpt' | sort
+    )
+
+    if (( ${#ckpts[@]} >= 1 )); then
+        printf '%s\n' "${ckpts[$(( ${#ckpts[@]} - 1 ))]}"
+        return 0
+    fi
+
+    return 1
+}
+
+for run_dir in "${RUN_DIRS[@]}"; do
+    run_dir_abs="$(realpath "${run_dir}")"
+    if [[ ! -f "${run_dir_abs}/resolved_config.yaml" ]]; then
+        echo "Skipping ${run_dir}: resolved_config.yaml missing" >&2
+        continue
+    fi
+
+    if ! eval_ckpt="$(resolve_multiwinkler_checkpoint "${run_dir_abs}")"; then
+        echo "Skipping ${run_dir}: no best-multiwinkler.ckpt symlink and no best-multiwinkler-from0p25-*.ckpt" >&2
+        continue
+    fi
+    eval_ckpt_abs="$(realpath "${eval_ckpt}")"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR}"
+
+    for run_dry in "${RUN_DRY_STATES[@]}"; do
+        dry_run_arg=()
+        run_label="${RUN_MODE}"
+        if [[ "${run_dry}" == "true" ]]; then
+            dry_run_arg=(--dry-run)
+            run_label="${RUN_MODE} --dry-run"
+        fi
+
+        echo "Submitting CRPS-ambient snapshots eval (best multi-Winkler from 0.25)"
+        echo "  mode: ${run_label}"
+        echo "  run_dir: ${run_dir_abs}"
+        echo "  eval.checkpoint: ${eval_ckpt_abs}"
+        echo "  eval.mode: ambient"
+        echo "  output_subdir: ${EVAL_SUBDIR}"
+        echo "  eval.rollout_snapshot_timesteps: ${ROLLOUT_SNAPSHOT_TIMESTEPS}"
+        echo "  eval.batch_size: ${EVAL_BATCH_SIZE}"
+        echo "  eval.n_members: ${EVAL_N_MEMBERS}"
+        echo "  eval.metrics: ${EVAL_METRICS}"
+
+        cmd=(uv run autocast eval --mode "${RUN_MODE}" "${dry_run_arg[@]}"
+            --workdir "${run_dir_abs}"
+            --output-subdir "${EVAL_SUBDIR}"
+            eval.checkpoint="${eval_ckpt_abs}"
+            eval.mode=ambient
+            eval.csv_path="${eval_output_dir}/evaluation_metrics.csv"
+            eval.video_dir="${eval_output_dir}/videos"
+            eval.save_rollout_snapshots=true
+            eval.rollout_snapshot_dir="${eval_output_dir}/videos/snapshots"
+            eval.rollout_snapshot_timesteps="${ROLLOUT_SNAPSHOT_TIMESTEPS}"
+            eval.rollout_snapshot_format=png
+            eval.metrics="${EVAL_METRICS}"
+            eval.batch_size="${EVAL_BATCH_SIZE}"
+            eval.n_members="${EVAL_N_MEMBERS}")
+
+        if [[ "${RUN_MODE}" == "slurm" ]]; then
+            cmd+=(hydra.launcher.timeout_min="${TIMEOUT_MIN}")
+        fi
+
+        "${cmd[@]}"
+    done
+done

--- a/src/autocast/configs/eval/README.md
+++ b/src/autocast/configs/eval/README.md
@@ -67,6 +67,8 @@ All eval configs support these parameters:
 - `rollout_snapshot_channels`: Channel indices to render (`null` means all)
 - `rollout_snapshot_dir`: Custom snapshot directory (default:
   work_dir/videos/snapshots)
+- `rollout_snapshot_dataset_label`: Optional row label for data-only snapshots
+  (default: infer from the rollout dataset when possible)
 - `accelerator`: Accelerator for evaluation (auto, cpu, cuda, mps)
 - `devices`: Number of GPUs for DDP evaluation (default: 1; set explicitly,
   e.g. 4, for multi-GPU runs)

--- a/src/autocast/configs/eval/default.yaml
+++ b/src/autocast/configs/eval/default.yaml
@@ -61,6 +61,7 @@ rollout_snapshot_dir: null  # default: <video_dir>/snapshots
 rollout_snapshot_timesteps: [0, 4, 12, 30, 99]
 rollout_snapshot_channels: null  # null means all channels
 rollout_snapshot_format: png
+rollout_snapshot_dataset_label: null  # optional label for data-only snapshot rows
 
 # Accelerator for evaluation (mirrors Lightning Fabric API)
 accelerator: auto  # auto, cpu, cuda, or mps

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -834,7 +834,7 @@ def _render_rollouts(  # noqa: PLR0912
                     fps=fps,
                     save_path=str(filename),
                     colorbar_mode="column",
-                    pred_uq_label="Ensemble Std Dev",
+                    pred_uq_label="Std Dev",
                     channel_names=names_for_plot,
                     preserve_aspect=preserve_aspect,
                 )

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -682,20 +682,22 @@ def _save_rollout_snapshot_panels(
             f"batch_{target_idx}_sample_{local_idx}_"
             f"channel_{channel_idx}_snapshots_data"
         )
-        data_only_png = data_only_base.with_suffix(".png")
+        data_only_filename = data_only_base.with_suffix(f".{snapshot_ext}")
+        data_only_extra_formats = ["pdf"] if snapshot_ext.lower() != "pdf" else []
         plot_spatiotemporal_snapshots_data_only(
             true=trues_mean[local_idx : local_idx + 1].cpu(),
             timesteps=snapshot_timesteps,
             channel=channel_idx,
             batch_idx=0,
-            save_path=str(data_only_png),
-            extra_formats=["pdf"],
+            save_path=str(data_only_filename),
+            extra_formats=data_only_extra_formats,
             ylabel=dataset_short_label,
             preserve_aspect=preserve_aspect,
         )
-        saved_paths.append(data_only_png)
-        saved_paths.append(data_only_base.with_suffix(".pdf"))
-        log.info("Saved data-only rollout snapshot panel to %s", data_only_png)
+        saved_paths.append(data_only_filename)
+        for ext in data_only_extra_formats:
+            saved_paths.append(data_only_base.with_suffix(f".{ext}"))
+        log.info("Saved data-only rollout snapshot panel to %s", data_only_filename)
 
 
 def _render_rollouts(  # noqa: PLR0912

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -75,7 +75,11 @@ from autocast.scripts.setup import (
 from autocast.scripts.training import apply_float32_matmul_precision
 from autocast.scripts.utils import get_default_config_path
 from autocast.types.batch import Batch, EncodedBatch
-from autocast.utils import plot_spatiotemporal_snapshots, plot_spatiotemporal_video
+from autocast.utils import (
+    plot_spatiotemporal_snapshots,
+    plot_spatiotemporal_snapshots_data_only,
+    plot_spatiotemporal_video,
+)
 from autocast.utils.plots import (
     compute_metrics_from_dataloader,
     compute_metrics_per_timestep_from_dataloader,
@@ -402,6 +406,49 @@ def _resolve_rollout_channel_names(dataset: Any) -> list[str] | None:
     return channel_names
 
 
+_DATASET_SHORT_LABELS: tuple[tuple[str, str], ...] = (
+    # Order matters: longer/more-specific keys first.
+    ("advection_diffusion_multichannel", "ADM"),
+    ("advection_diffusion", "AD"),
+    ("conditioned_navier_stokes", "CNS"),
+    ("gray_scott", "GS"),
+    ("gpe", "GPE"),
+    ("reaction_diffusion", "RD"),
+    ("shallow_water2d", "SW"),
+    ("lattice_boltzmann", "LB"),
+)
+
+
+def _resolve_dataset_short_label(dataset: Any) -> str | None:
+    """Best-effort short label (e.g. ``AD``, ``CNS``, ``GS``, ``GPE``) for a dataset."""
+    if dataset is None:
+        return None
+
+    candidates: list[str] = []
+    for attr_chain in (
+        ("well_dataset", "dataset_name"),
+        ("well_dataset", "well_dataset_name"),
+        ("well_metadata", "dataset_name"),
+        ("dataset_name",),
+        ("well_dataset_name",),
+    ):
+        obj: Any = dataset
+        for attr in attr_chain:
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        if isinstance(obj, str) and obj:
+            candidates.append(obj)
+
+    for raw in candidates:
+        normalized = raw.lower()
+        for key, label in _DATASET_SHORT_LABELS:
+            if key in normalized:
+                return label
+
+    return None
+
+
 def _process_metrics_results(
     results: dict[None | tuple[int, int], dict[str, Metric]],
     per_batch_rows: list[dict[str, float | str]] | None = None,
@@ -600,7 +647,10 @@ def _save_rollout_snapshot_panels(
     saved_paths: list[Path],
     names_for_plot: list[str] | None,
     preserve_aspect: bool,
+    dataset_short_label: str | None = None,
 ) -> None:
+    # Always emit PDF alongside the configured raster format.
+    extra_formats = ["pdf"] if snapshot_ext.lower() != "pdf" else []
     for channel_idx in snapshot_channels:
         snapshot_filename = snapshot_dir / (
             f"batch_{target_idx}_sample_{local_idx}_"
@@ -618,12 +668,34 @@ def _save_rollout_snapshot_panels(
             channel=channel_idx,
             batch_idx=0,
             save_path=str(snapshot_filename),
+            extra_formats=extra_formats,
             title="Rollout snapshots",
             channel_names=names_for_plot,
             preserve_aspect=preserve_aspect,
         )
         saved_paths.append(snapshot_filename)
+        for ext in extra_formats:
+            saved_paths.append(snapshot_filename.with_suffix(f".{ext}"))
         log.info("Saved rollout snapshot panel to %s", snapshot_filename)
+
+        data_only_base = snapshot_dir / (
+            f"batch_{target_idx}_sample_{local_idx}_"
+            f"channel_{channel_idx}_snapshots_data"
+        )
+        data_only_png = data_only_base.with_suffix(".png")
+        plot_spatiotemporal_snapshots_data_only(
+            true=trues_mean[local_idx : local_idx + 1].cpu(),
+            timesteps=snapshot_timesteps,
+            channel=channel_idx,
+            batch_idx=0,
+            save_path=str(data_only_png),
+            extra_formats=["pdf"],
+            ylabel=dataset_short_label,
+            preserve_aspect=preserve_aspect,
+        )
+        saved_paths.append(data_only_png)
+        saved_paths.append(data_only_base.with_suffix(".pdf"))
+        log.info("Saved data-only rollout snapshot panel to %s", data_only_png)
 
 
 def _render_rollouts(  # noqa: PLR0912
@@ -650,6 +722,7 @@ def _render_rollouts(  # noqa: PLR0912
     snapshot_dir: Path | None = None,
     snapshot_format: str = "png",
     snapshot_channels: Sequence[int] | None = None,
+    dataset_short_label: str | None = None,
 ) -> list[Path]:
     # Return early if no rollout indices are requested
     if not batch_indices:
@@ -783,6 +856,7 @@ def _render_rollouts(  # noqa: PLR0912
                         saved_paths=saved_paths,
                         names_for_plot=names_for_plot,
                         preserve_aspect=preserve_aspect,
+                        dataset_short_label=dataset_short_label,
                     )
 
             global_sample_offset += batch_size
@@ -2060,8 +2134,9 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
             rollout_test_loader = fabric.setup_dataloaders(
                 datamodule.rollout_test_dataloader(batch_size=eval_batch_size)
             )
+            rollout_dataset_for_labels = getattr(rollout_test_loader, "dataset", None)
             rollout_channel_names = _resolve_rollout_channel_names(
-                getattr(rollout_test_loader, "dataset", None)
+                rollout_dataset_for_labels
             )
             if rollout_channel_names is not None:
                 log.info(
@@ -2072,6 +2147,14 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
                 log.info(
                     "No rollout video channel labels found in core_field_names; "
                     "falling back to generic channel indices."
+                )
+            rollout_dataset_short_label = eval_cfg.get(
+                "rollout_snapshot_dataset_label"
+            ) or _resolve_dataset_short_label(rollout_dataset_for_labels)
+            if rollout_dataset_short_label is not None:
+                log.info(
+                    "Using dataset short label for data-only snapshots: %s",
+                    rollout_dataset_short_label,
                 )
 
             rollout_loader = _limit_batches(
@@ -2113,6 +2196,7 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
                 snapshot_dir=rollout_snapshot_dir,
                 snapshot_format=eval_cfg.get("rollout_snapshot_format", "png"),
                 snapshot_channels=rollout_snapshot_channels,
+                dataset_short_label=rollout_dataset_short_label,
             )
 
         # Prepare metric functions for rollouts

--- a/src/autocast/utils/__init__.py
+++ b/src/autocast/utils/__init__.py
@@ -1,8 +1,13 @@
 from .optimizer import get_optimizer_config
-from .plots import plot_spatiotemporal_snapshots, plot_spatiotemporal_video
+from .plots import (
+    plot_spatiotemporal_snapshots,
+    plot_spatiotemporal_snapshots_data_only,
+    plot_spatiotemporal_video,
+)
 
 __all__ = [
     "get_optimizer_config",
     "plot_spatiotemporal_snapshots",
+    "plot_spatiotemporal_snapshots_data_only",
     "plot_spatiotemporal_video",
 ]

--- a/src/autocast/utils/plots.py
+++ b/src/autocast/utils/plots.py
@@ -7,13 +7,46 @@ import numpy as np
 import torch
 from einops import rearrange
 from matplotlib import animation
-from matplotlib.colors import Normalize, TwoSlopeNorm
+from matplotlib.colors import LogNorm, Normalize, SymLogNorm, TwoSlopeNorm
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
 from torchmetrics import Metric
 
 from autocast.metrics.coverage import Coverage, MultiCoverage
 from autocast.types import Tensor, TensorBTSC, TensorBTSCM
+
+# A4 typeset linewidth (~160mm of text width with 25mm side margins) in inches.
+A4_LINEWIDTH_IN = 6.3
+
+# Paper-ready Matplotlib rc settings: Times serif at 10pt, used for the
+# spatiotemporal snapshot panels so they sit at \linewidth in LaTeX figures.
+_SNAPSHOT_PAPER_RC: dict[str, object] = {
+    "font.family": "serif",
+    "font.serif": ["Times", "Times New Roman", "DejaVu Serif", "serif"],
+    "font.size": 10,
+    "axes.titlesize": 10,
+    "axes.labelsize": 10,
+    "xtick.labelsize": 9,
+    "ytick.labelsize": 9,
+    "legend.fontsize": 9,
+    "figure.titlesize": 10,
+    "mathtext.fontset": "stix",
+}
+
+
+def _panel_size_for_width(
+    target_width_in: float,
+    ncols: int,
+    spatial: tuple[int, ...],
+    preserve_aspect: bool,
+) -> tuple[float, float]:
+    panel_width = max(target_width_in / max(ncols, 1), 0.5)
+    if preserve_aspect and len(spatial) == 2 and spatial[0] > 0 and spatial[1] > 0:
+        width, height = spatial
+        panel_height = panel_width * (height / width)
+    else:
+        panel_height = panel_width
+    return panel_width, panel_height
 
 
 def plot_spatiotemporal_video(  # noqa: PLR0915, PLR0912
@@ -317,9 +350,12 @@ def plot_spatiotemporal_snapshots(  # noqa: PLR0912, PLR0915
     save_path: str | None = None,
     extra_formats: Iterable[str] | None = None,
     title: str = "Ground Truth vs Prediction",
-    pred_uq_label: str = "Ensemble Std Dev",
+    pred_uq_label: str = "Std Dev",
     channel_names: list[str] | None = None,
     preserve_aspect: bool = False,
+    target_width_in: float = A4_LINEWIDTH_IN,
+    diff_log: bool = True,
+    uq_log: bool = True,
 ) -> Figure:
     """Create a still panel at selected timesteps for one spatial channel."""
     true_batch = true[batch_idx]
@@ -371,86 +407,104 @@ def plot_spatiotemporal_snapshots(  # noqa: PLR0912, PLR0915
     primary_norm = Normalize(vmin=min_val, vmax=max_val)
 
     diff_channel = None
-    diff_norm = None
+    diff_norm: Normalize | TwoSlopeNorm | SymLogNorm | None = None
     if pred_channel is not None:
         diff_channel = true_channel - pred_channel
         diff_max = float(np.abs(diff_channel).max())
         diff_span = diff_max if diff_max > 0 else 1e-9
-        diff_norm = TwoSlopeNorm(vmin=-diff_span, vcenter=0, vmax=diff_span)
+        if diff_log:
+            linthresh = max(diff_span * 1e-3, 1e-12)
+            diff_norm = SymLogNorm(
+                linthresh=linthresh,
+                vmin=-diff_span,
+                vmax=diff_span,
+                base=10,
+            )
+        else:
+            diff_norm = TwoSlopeNorm(vmin=-diff_span, vcenter=0, vmax=diff_span)
 
-    rows_to_plot: list[tuple[np.ndarray, str, str, Normalize | TwoSlopeNorm | None]] = [
+    NormLike = Normalize | TwoSlopeNorm | LogNorm | SymLogNorm | None
+    rows_to_plot: list[tuple[np.ndarray, str, str, NormLike]] = [
         (true_channel, "Ground Truth", cmap, primary_norm),
     ]
     if pred_channel is not None:
         rows_to_plot.append((pred_channel, "Prediction", cmap, primary_norm))
         assert diff_channel is not None
-        rows_to_plot.append(
-            (diff_channel, "Difference (True - Pred)", "RdBu", diff_norm)
-        )
+        rows_to_plot.append((diff_channel, "Difference", "RdBu", diff_norm))
     if pred_uq_channel is not None:
-        uq_norm = Normalize(
-            vmin=float(pred_uq_channel.min()),
-            vmax=float(pred_uq_channel.max()),
-        )
+        uq_finite = pred_uq_channel[np.isfinite(pred_uq_channel)]
+        uq_positive = uq_finite[uq_finite > 0]
+        if uq_log and uq_positive.size > 0:
+            uq_vmin = float(uq_positive.min())
+            uq_vmax = float(uq_finite.max())
+            if uq_vmax <= uq_vmin:
+                uq_vmax = uq_vmin * 10.0 + 1e-12
+            uq_norm: Normalize | LogNorm = LogNorm(vmin=uq_vmin, vmax=uq_vmax)
+        else:
+            uq_norm = Normalize(
+                vmin=float(pred_uq_channel.min()),
+                vmax=float(pred_uq_channel.max()),
+            )
         rows_to_plot.append((pred_uq_channel, pred_uq_label, "inferno", uq_norm))
 
     nrows = len(rows_to_plot)
     ncols = len(selected_timesteps)
-    width, height = spatial
-    base = 3.0
-    if preserve_aspect and height > 0 and width > 0:
-        ratio = width / height
-        panel_width = base if ratio >= 1 else min(base / ratio, 3 * base)
-        panel_height = min(base * ratio, 3 * base) if ratio >= 1 else base
-    else:
-        panel_width = base
-        panel_height = base
-
-    fig, axes = plt.subplots(
-        nrows,
-        ncols,
-        figsize=(ncols * panel_width, nrows * panel_height),
-        squeeze=False,
-        constrained_layout=True,
+    panel_width, panel_height = _panel_size_for_width(
+        target_width_in, ncols, tuple(spatial), preserve_aspect
     )
-    image_rows = []
-    for row_idx, (data, row_label, row_cmap, norm) in enumerate(rows_to_plot):
-        row_images = []
-        for col_idx, timestep in enumerate(selected_timesteps):
-            ax = axes[row_idx][col_idx]
-            im = ax.imshow(data[timestep], cmap=row_cmap, aspect="auto", norm=norm)
-            row_images.append(im)
-            ax.set_xticks([])
-            ax.set_yticks([])
-            if row_idx == 0:
-                ax.set_title(f"t={timestep}")
-            if col_idx == 0:
-                ax.set_ylabel(row_label)
-        image_rows.append(row_images)
 
-    for row_idx, row_images in enumerate(image_rows):
-        fig.colorbar(
-            row_images[-1],
-            ax=axes[row_idx, :].tolist(),
-            fraction=0.025,
-            pad=0.02,
+    with plt.rc_context(_SNAPSHOT_PAPER_RC):
+        fig, axes = plt.subplots(
+            nrows,
+            ncols,
+            figsize=(ncols * panel_width, nrows * panel_height),
+            squeeze=False,
+            constrained_layout=True,
         )
+        image_rows = []
+        for row_idx, (data, row_label, row_cmap, norm) in enumerate(rows_to_plot):
+            row_images = []
+            for col_idx, timestep in enumerate(selected_timesteps):
+                ax = axes[row_idx][col_idx]
+                # LogNorm warns on non-positive values; clip to positive floor.
+                if isinstance(norm, LogNorm):
+                    floor = float(norm.vmin) if norm.vmin is not None else 1e-12
+                    plot_data = np.clip(data[timestep], floor, None)
+                else:
+                    plot_data = data[timestep]
+                im = ax.imshow(plot_data, cmap=row_cmap, aspect="auto", norm=norm)
+                row_images.append(im)
+                ax.set_xticks([])
+                ax.set_yticks([])
+                if row_idx == 0:
+                    ax.set_title(f"$i={timestep}$")
+                if col_idx == 0:
+                    ax.set_ylabel(row_label)
+            image_rows.append(row_images)
 
-    channel_label = (
-        f"channel {channel}"
-        if channel_names is None
-        else f"{channel_names[channel]} (channel {channel})"
-    )
-    fig.suptitle(f"{title} - {channel_label}", fontsize=14, fontweight="bold")
+        for row_idx, row_images in enumerate(image_rows):
+            fig.colorbar(
+                row_images[-1],
+                ax=axes[row_idx, :].tolist(),
+                fraction=0.025,
+                pad=0.02,
+            )
 
-    if save_path:
-        fig.savefig(save_path, dpi=150, bbox_inches="tight")
-        for ext in extra_formats or ():
-            ext_clean = ext.lstrip(".")
-            alt_path = str(Path(save_path).with_suffix(f".{ext_clean}"))
-            if alt_path != str(save_path):
-                fig.savefig(alt_path, dpi=150, bbox_inches="tight")
-        plt.close(fig)
+        channel_label = (
+            f"channel {channel}"
+            if channel_names is None
+            else f"{channel_names[channel]} (channel {channel})"
+        )
+        fig.suptitle(f"{title} - {channel_label}", fontweight="bold")
+
+        if save_path:
+            fig.savefig(save_path, dpi=300, bbox_inches="tight")
+            for ext in extra_formats or ():
+                ext_clean = ext.lstrip(".")
+                alt_path = str(Path(save_path).with_suffix(f".{ext_clean}"))
+                if alt_path != str(save_path):
+                    fig.savefig(alt_path, dpi=300, bbox_inches="tight")
+            plt.close(fig)
 
     return fig
 
@@ -468,12 +522,13 @@ def plot_spatiotemporal_snapshots_data_only(
     extra_formats: Iterable[str] | None = None,
     ylabel: str | None = None,
     preserve_aspect: bool = False,
+    target_width_in: float = A4_LINEWIDTH_IN,
 ) -> Figure:
-    """Single-row snapshot panel of ground-truth data with no axis ticks.
+    r"""Single-row snapshot panel of ground-truth data with no axis ticks.
 
     Each panel is titled ``$i={t}$``. The leftmost panel carries ``ylabel`` if
     provided (typically a dataset short label, e.g. ``AD``, ``CNS``, ``GS``,
-    ``GPE``).
+    ``GPE``). Sized for A4 ``\linewidth`` with Times 10pt.
     """
     true_batch = true[batch_idx]
     T, *spatial, C = true_batch.shape
@@ -504,41 +559,36 @@ def plot_spatiotemporal_snapshots_data_only(
     max_val = vmax if vmax is not None else float(true_np.max())
     norm = Normalize(vmin=min_val, vmax=max_val)
 
-    width, height = spatial
-    base = 3.0
-    if preserve_aspect and height > 0 and width > 0:
-        ratio = width / height
-        panel_width = base if ratio >= 1 else min(base / ratio, 3 * base)
-        panel_height = min(base * ratio, 3 * base) if ratio >= 1 else base
-    else:
-        panel_width = base
-        panel_height = base
-
     ncols = len(selected_timesteps)
-    fig, axes = plt.subplots(
-        1,
-        ncols,
-        figsize=(ncols * panel_width, panel_height),
-        squeeze=False,
-        constrained_layout=True,
+    panel_width, panel_height = _panel_size_for_width(
+        target_width_in, ncols, tuple(spatial), preserve_aspect
     )
-    for col_idx, timestep in enumerate(selected_timesteps):
-        ax = axes[0][col_idx]
-        ax.imshow(true_np[timestep], cmap=cmap, aspect="auto", norm=norm)
-        ax.set_xticks([])
-        ax.set_yticks([])
-        ax.set_title(f"$i={timestep}$")
-        if col_idx == 0 and ylabel:
-            ax.set_ylabel(ylabel)
 
-    if save_path:
-        fig.savefig(save_path, dpi=150, bbox_inches="tight")
-        for ext in extra_formats or ():
-            ext_clean = ext.lstrip(".")
-            alt_path = str(Path(save_path).with_suffix(f".{ext_clean}"))
-            if alt_path != str(save_path):
-                fig.savefig(alt_path, dpi=150, bbox_inches="tight")
-        plt.close(fig)
+    with plt.rc_context(_SNAPSHOT_PAPER_RC):
+        fig, axes = plt.subplots(
+            1,
+            ncols,
+            figsize=(ncols * panel_width, panel_height),
+            squeeze=False,
+            constrained_layout=True,
+        )
+        for col_idx, timestep in enumerate(selected_timesteps):
+            ax = axes[0][col_idx]
+            ax.imshow(true_np[timestep], cmap=cmap, aspect="auto", norm=norm)
+            ax.set_xticks([])
+            ax.set_yticks([])
+            ax.set_title(f"$i={timestep}$")
+            if col_idx == 0 and ylabel:
+                ax.set_ylabel(ylabel)
+
+        if save_path:
+            fig.savefig(save_path, dpi=300, bbox_inches="tight")
+            for ext in extra_formats or ():
+                ext_clean = ext.lstrip(".")
+                alt_path = str(Path(save_path).with_suffix(f".{ext_clean}"))
+                if alt_path != str(save_path):
+                    fig.savefig(alt_path, dpi=300, bbox_inches="tight")
+            plt.close(fig)
 
     return fig
 

--- a/src/autocast/utils/plots.py
+++ b/src/autocast/utils/plots.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal, TypeAlias, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,6 +33,8 @@ _SNAPSHOT_PAPER_RC: dict[str, object] = {
     "mathtext.fontset": "stix",
 }
 
+NormLike: TypeAlias = Normalize | TwoSlopeNorm | LogNorm | SymLogNorm | None
+
 
 def _panel_size_for_width(
     target_width_in: float,
@@ -42,8 +44,8 @@ def _panel_size_for_width(
 ) -> tuple[float, float]:
     panel_width = max(target_width_in / max(ncols, 1), 0.5)
     if preserve_aspect and len(spatial) == 2 and spatial[0] > 0 and spatial[1] > 0:
-        width, height = spatial
-        panel_height = panel_width * (height / width)
+        rows, cols = spatial
+        panel_height = panel_width * (rows / cols)
     else:
         panel_height = panel_width
     return panel_width, panel_height
@@ -423,7 +425,6 @@ def plot_spatiotemporal_snapshots(  # noqa: PLR0912, PLR0915
         else:
             diff_norm = TwoSlopeNorm(vmin=-diff_span, vcenter=0, vmax=diff_span)
 
-    NormLike = Normalize | TwoSlopeNorm | LogNorm | SymLogNorm | None
     rows_to_plot: list[tuple[np.ndarray, str, str, NormLike]] = [
         (true_channel, "Ground Truth", cmap, primary_norm),
     ]

--- a/src/autocast/utils/plots.py
+++ b/src/autocast/utils/plots.py
@@ -354,8 +354,8 @@ def plot_spatiotemporal_snapshots(  # noqa: PLR0912, PLR0915
     channel_names: list[str] | None = None,
     preserve_aspect: bool = False,
     target_width_in: float = A4_LINEWIDTH_IN,
-    diff_log: bool = True,
-    uq_log: bool = True,
+    diff_log: bool = False,
+    uq_log: bool = False,
 ) -> Figure:
     """Create a still panel at selected timesteps for one spatial channel."""
     true_batch = true[batch_idx]

--- a/src/autocast/utils/plots.py
+++ b/src/autocast/utils/plots.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Iterable
+from pathlib import Path
 from typing import Literal, cast
 
 import matplotlib.pyplot as plt
@@ -314,6 +315,7 @@ def plot_spatiotemporal_snapshots(  # noqa: PLR0912, PLR0915
     vmax: float | None = None,
     cmap: str = "viridis",
     save_path: str | None = None,
+    extra_formats: Iterable[str] | None = None,
     title: str = "Ground Truth vs Prediction",
     pred_uq_label: str = "Ensemble Std Dev",
     channel_names: list[str] | None = None,
@@ -443,6 +445,99 @@ def plot_spatiotemporal_snapshots(  # noqa: PLR0912, PLR0915
 
     if save_path:
         fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        for ext in extra_formats or ():
+            ext_clean = ext.lstrip(".")
+            alt_path = str(Path(save_path).with_suffix(f".{ext_clean}"))
+            if alt_path != str(save_path):
+                fig.savefig(alt_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+
+    return fig
+
+
+def plot_spatiotemporal_snapshots_data_only(
+    true: TensorBTSC,
+    *,
+    timesteps: Iterable[int],
+    channel: int = 0,
+    batch_idx: int = 0,
+    vmin: float | None = None,
+    vmax: float | None = None,
+    cmap: str = "viridis",
+    save_path: str | None = None,
+    extra_formats: Iterable[str] | None = None,
+    ylabel: str | None = None,
+    preserve_aspect: bool = False,
+) -> Figure:
+    """Single-row snapshot panel of ground-truth data with no axis ticks.
+
+    Each panel is titled ``$i={t}$``. The leftmost panel carries ``ylabel`` if
+    provided (typically a dataset short label, e.g. ``AD``, ``CNS``, ``GS``,
+    ``GPE``).
+    """
+    true_batch = true[batch_idx]
+    T, *spatial, C = true_batch.shape
+    if len(spatial) != 2:
+        msg = (
+            "plot_spatiotemporal_snapshots_data_only expects exactly two "
+            f"spatial dimensions, got shape {tuple(true_batch.shape)}."
+        )
+        raise ValueError(msg)
+    if not 0 <= channel < C:
+        msg = f"channel must be in [0, {C - 1}], got {channel}."
+        raise ValueError(msg)
+
+    selected_timesteps = [int(t) for t in timesteps]
+    invalid_timesteps = [t for t in selected_timesteps if t < 0 or t >= T]
+    if invalid_timesteps:
+        msg = (
+            f"timesteps must be in [0, {T - 1}], got invalid values "
+            f"{invalid_timesteps}."
+        )
+        raise ValueError(msg)
+    if not selected_timesteps:
+        msg = "At least one timestep is required for snapshot plotting."
+        raise ValueError(msg)
+
+    true_np = true_batch.detach().cpu().numpy()[:, :, :, channel]
+    min_val = vmin if vmin is not None else float(true_np.min())
+    max_val = vmax if vmax is not None else float(true_np.max())
+    norm = Normalize(vmin=min_val, vmax=max_val)
+
+    width, height = spatial
+    base = 3.0
+    if preserve_aspect and height > 0 and width > 0:
+        ratio = width / height
+        panel_width = base if ratio >= 1 else min(base / ratio, 3 * base)
+        panel_height = min(base * ratio, 3 * base) if ratio >= 1 else base
+    else:
+        panel_width = base
+        panel_height = base
+
+    ncols = len(selected_timesteps)
+    fig, axes = plt.subplots(
+        1,
+        ncols,
+        figsize=(ncols * panel_width, panel_height),
+        squeeze=False,
+        constrained_layout=True,
+    )
+    for col_idx, timestep in enumerate(selected_timesteps):
+        ax = axes[0][col_idx]
+        ax.imshow(true_np[timestep], cmap=cmap, aspect="auto", norm=norm)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_title(f"$i={timestep}$")
+        if col_idx == 0 and ylabel:
+            ax.set_ylabel(ylabel)
+
+    if save_path:
+        fig.savefig(save_path, dpi=150, bbox_inches="tight")
+        for ext in extra_formats or ():
+            ext_clean = ext.lstrip(".")
+            alt_path = str(Path(save_path).with_suffix(f".{ext_clean}"))
+            if alt_path != str(save_path):
+                fig.savefig(alt_path, dpi=150, bbox_inches="tight")
         plt.close(fig)
 
     return fig

--- a/tests/scripts/test_eval_encoder_processor_decoder.py
+++ b/tests/scripts/test_eval_encoder_processor_decoder.py
@@ -29,6 +29,7 @@ from autocast.scripts.eval.encoder_processor_decoder import (
     _resolve_rollout_batch_limit,
     _resolve_rollout_channel_names,
     _resolve_rollout_timestep_limit,
+    _save_rollout_snapshot_panels,
     _should_skip_metric,
     _split_metric_and_metadata_rows,
     _training_runtime_rows,
@@ -36,6 +37,7 @@ from autocast.scripts.eval.encoder_processor_decoder import (
     _validate_resolved_eval_path,
 )
 from autocast.types import Batch, EncodedBatch
+from autocast.utils.plots import _panel_size_for_width
 
 
 def test_resolve_rollout_batch_limit_falls_back_to_test_limit_when_null():
@@ -433,6 +435,84 @@ def test_render_rollouts_resolves_indices_within_batched_samples(tmp_path, monke
     assert len(captured_paths) == 4
     for idx in range(4):
         assert any(f"batch_{idx}_sample_{idx}.mp4" in p for p in captured_paths)
+
+
+def test_snapshot_panel_size_preserves_imshow_row_col_aspect():
+    panel_width, panel_height = _panel_size_for_width(
+        target_width_in=6.0,
+        ncols=3,
+        spatial=(8, 4),
+        preserve_aspect=True,
+    )
+
+    assert panel_width == pytest.approx(2.0)
+    assert panel_height == pytest.approx(4.0)
+
+
+def test_save_rollout_snapshot_panels_uses_snapshot_extension_for_data_only(
+    tmp_path,
+    monkeypatch,
+):
+    calls: list[tuple[str, str, tuple[str, ...]]] = []
+
+    def _fake_snapshots(**kwargs):
+        calls.append(
+            (
+                "full",
+                kwargs["save_path"],
+                tuple(kwargs.get("extra_formats") or ()),
+            )
+        )
+
+    def _fake_data_only(**kwargs):
+        calls.append(
+            (
+                "data",
+                kwargs["save_path"],
+                tuple(kwargs.get("extra_formats") or ()),
+            )
+        )
+
+    monkeypatch.setattr(
+        "autocast.scripts.eval.encoder_processor_decoder.plot_spatiotemporal_snapshots",
+        _fake_snapshots,
+    )
+    monkeypatch.setattr(
+        "autocast.scripts.eval.encoder_processor_decoder."
+        "plot_spatiotemporal_snapshots_data_only",
+        _fake_data_only,
+    )
+
+    saved_paths = []
+    values = torch.zeros(1, 3, 2, 2, 1)
+    _save_rollout_snapshot_panels(
+        trues_mean=values,
+        preds_mean=values,
+        preds_uq=None,
+        local_idx=0,
+        target_idx=2,
+        snapshot_dir=tmp_path,
+        snapshot_timesteps=[0, 1],
+        snapshot_channels=[0],
+        snapshot_ext="jpg",
+        saved_paths=saved_paths,
+        names_for_plot=None,
+        preserve_aspect=True,
+        dataset_short_label="AD",
+    )
+
+    full_base = tmp_path / "batch_2_sample_0_channel_0_snapshots"
+    data_base = tmp_path / "batch_2_sample_0_channel_0_snapshots_data"
+    assert calls == [
+        ("full", str(full_base.with_suffix(".jpg")), ("pdf",)),
+        ("data", str(data_base.with_suffix(".jpg")), ("pdf",)),
+    ]
+    assert saved_paths == [
+        full_base.with_suffix(".jpg"),
+        full_base.with_suffix(".pdf"),
+        data_base.with_suffix(".jpg"),
+        data_base.with_suffix(".pdf"),
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces improvements to the evaluation and visualization pipeline for model rollouts, with a focus on generating publication-ready snapshot panels and data-only figures for selected timesteps. The main updates include enhanced plotting utilities, support for log-scaled difference and uncertainty visualizations, and improved labeling for datasets and figures.

**Visualization and Plotting Enhancements:**

* Added a new function `plot_spatiotemporal_snapshots_data_only` to generate "data-only" rollout snapshot panels, intended for publication-quality figures without extraneous plot elements. This function is now called during evaluation to save both PNG and PDF versions of the panels. [[1]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR671-R699) [[2]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR650-R653) [[3]](diffhunk://#diff-c353850c7fd830d104758458a392da19e6556691f4987441239481c126c3a18bL2-R11)
* Improved the main `plot_spatiotemporal_snapshots` function:
  - Added options for log-scaled difference (`diff_log`) and uncertainty (`uq_log`) panels, and updated normalization logic to support `LogNorm` and `SymLogNorm` color scaling. [[1]](diffhunk://#diff-f8d234e5383d08fa0067d7bd38e1249a239542c5bab8fd1b4d36d8e35e186254R351-R358) [[2]](diffhunk://#diff-f8d234e5383d08fa0067d7bd38e1249a239542c5bab8fd1b4d36d8e35e186254L372-R443)
  - Standardized figure appearance for publication (A4 typeset width, Times font, etc.) and improved aspect ratio handling. [[1]](diffhunk://#diff-f8d234e5383d08fa0067d7bd38e1249a239542c5bab8fd1b4d36d8e35e186254R2-R50) [[2]](diffhunk://#diff-f8d234e5383d08fa0067d7bd38e1249a239542c5bab8fd1b4d36d8e35e186254L397-R456)
  - Enhanced axis labeling and colorbar handling for clarity and consistency.
  - Changed the uncertainty label from "Ensemble Std Dev" to "Std Dev" for brevity. [[1]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bL764-R837) [[2]](diffhunk://#diff-f8d234e5383d08fa0067d7bd38e1249a239542c5bab8fd1b4d36d8e35e186254R351-R358)

**Evaluation Script and Data Labeling Improvements:**

* Added logic to infer a short dataset label (e.g., "GS", "CNS", "AD") for use in figure labels, supporting both automatic resolution and manual override. This label is now passed through the evaluation pipeline and used in snapshot panels. [[1]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR409-R451) [[2]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR2151-R2158) [[3]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR2199) [[4]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR725) [[5]](diffhunk://#diff-138a882593c74bd19ada0479200cd1e61c7943f04bd822406e1e030c1730ad1bR859)
* Updated the evaluation submission script (`submit_eval_crps_ambient_best_multiwinkler_from0p25_snapshots.sh`) to support generating and organizing snapshot outputs for multiple experiments, with options for SLURM or local execution.

These changes together streamline the process of generating high-quality, publication-ready visualizations of model rollouts and improve figure labeling and reproducibility.