### PR TITLE
Disable data_path when simulated data is being used

### DIFF
--- a/src/autocast/scripts/data.py
+++ b/src/autocast/scripts/data.py
@@ -61,6 +61,7 @@ def build_datamodule(
                 "Simulator config provided; ignoring datamodule.data_path and "
                 "using generated data instead."
             )
+            dm_container["data_path"] = None
         simulator = instantiate(simulator_cfg)
 
         # Generate data splits from simulator and assign to datamodule config


### PR DESCRIPTION
Without this line, training an autoencoder (or possibly other models -- I haven't gotten there yet) with simulated data errors, I think because it still attempts to read in data from `data_path`:

```bash
$ uv run autocast ae simulator=reaction_diffusion +trainer.max_epochs=2

[2026-05-13 16:00:23,776][autocast.scripts.training][INFO] - Starting autoencoder experiment: ae
[2026-05-13 16:00:23,776][autocast.scripts.training][INFO] - Set torch.float32_matmul_precision to 'high'
Seed set to 42
[2026-05-13 16:00:23,782][autocast.scripts.data][WARNING] - Simulator config provided; ignoring datamodule.data_path and using generated data instead.
[2026-05-13 16:00:24,392][autocast.scripts.data][INFO] - Generating synthetic dataset (train=4, valid=2, test=2)
[2026-05-13 16:00:24,392][autoemulate][INFO] - Running batch simulation for 4 samples
[2026-05-13 16:00:24,401][autoemulate][DEBUG] - Running simulation for sample 1/4
[2026-05-13 16:00:25,481][autoemulate][DEBUG] - Simulation 1/4 successful
[2026-05-13 16:00:25,481][autoemulate][DEBUG] - Running simulation for sample 2/4
[2026-05-13 16:00:26,856][autoemulate][DEBUG] - Simulation 2/4 successful
[2026-05-13 16:00:26,856][autoemulate][DEBUG] - Running simulation for sample 3/4
[2026-05-13 16:00:28,370][autoemulate][DEBUG] - Simulation 3/4 successful
[2026-05-13 16:00:28,371][autoemulate][DEBUG] - Running simulation for sample 4/4
[2026-05-13 16:00:29,321][autoemulate][DEBUG] - Simulation 4/4 successful
[2026-05-13 16:00:29,321][autoemulate][INFO] - Successfully completed 4/4 simulations (100.0%)
[2026-05-13 16:00:29,322][autoemulate][INFO] - Running batch simulation for 2 samples
[2026-05-13 16:00:29,322][autoemulate][DEBUG] - Running simulation for sample 1/2
[2026-05-13 16:00:30,307][autoemulate][DEBUG] - Simulation 1/2 successful
[2026-05-13 16:00:30,307][autoemulate][DEBUG] - Running simulation for sample 2/2
[2026-05-13 16:00:31,727][autoemulate][DEBUG] - Simulation 2/2 successful
[2026-05-13 16:00:31,727][autoemulate][INFO] - Successfully completed 2/2 simulations (100.0%)
[2026-05-13 16:00:31,728][autoemulate][INFO] - Running batch simulation for 2 samples
[2026-05-13 16:00:31,728][autoemulate][DEBUG] - Running simulation for sample 1/2
[2026-05-13 16:00:32,984][autoemulate][DEBUG] - Simulation 1/2 successful
[2026-05-13 16:00:32,984][autoemulate][DEBUG] - Running simulation for sample 2/2
[2026-05-13 16:00:33,978][autoemulate][DEBUG] - Simulation 2/2 successful
[2026-05-13 16:00:33,978][autoemulate][INFO] - Successfully completed 2/2 simulations (100.0%)
Error executing job with overrides: ['logging.wandb.name=ae_default_f8dcbd6_f3542d7', 'simulator=reaction_diffusion', '+trainer.max_epochs=2']
Error in call to target 'autocast.data.datamodule.SpatioTemporalDataModule':
FileNotFoundError(2, 'No such file or directory')
[...]
```