### PR TITLE
feat: add predict_incremental_diff skip connection to EPD model

### DIFF
--- a/src/autocast/configs/model/encoder_processor_decoder.yaml
+++ b/src/autocast/configs/model/encoder_processor_decoder.yaml
@@ -10,3 +10,4 @@ train_in_latent_space: true
 freeze_encoder_decoder: true
 loss_func:
   _target_: torch.nn.MSELoss
+predict_incremental_diff: false

--- a/src/autocast/models/encoder_processor_decoder.py
+++ b/src/autocast/models/encoder_processor_decoder.py
@@ -47,6 +47,7 @@ class EncoderProcessorDecoder(
         test_metrics: Sequence[Metric] | None = None,
         input_noise_injector: NoiseInjector | None = None,
         norm: ZScoreNormalization | None = None,
+        predict_incremental_diff: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__()
@@ -61,6 +62,7 @@ class EncoderProcessorDecoder(
         self.freeze_encoder_decoder = freeze_encoder_decoder
         self.input_noise_injector = input_noise_injector
         self.norm = norm
+        self.predict_incremental_diff = predict_incremental_diff
 
         if self.train_in_latent_space or self.freeze_encoder_decoder:
             self.encoder_decoder.freeze()
@@ -98,6 +100,11 @@ class EncoderProcessorDecoder(
         encoded, global_cond = self.encoder_decoder.encoder.encode_with_cond(batch)
         mapped = self.processor.map(encoded, global_cond)
         decoded = self.encoder_decoder.decoder.decode(mapped)
+        if self.predict_incremental_diff:
+            # Skip connection: network predicts the increment; add last input frame.
+            # Slice input channels to match output channels (first C_out channels).
+            last_input = batch.input_fields[:, -1:, ..., : decoded.shape[-1]]
+            decoded = decoded + last_input
         return decoded
 
     def loss(self, batch: Batch) -> tuple[Tensor, Tensor | None]:


### PR DESCRIPTION
Closes #88. Adds predict_incremental_diff flag (default: false) to EncoderProcessorDecoder. When enabled the network predicts the per-step increment; the last input frame is added back as a skip connection so the output remains an absolute field value.

**Note**: this slicing would not work if the input and output channels are different, which AutoCast do not yet support at the moment, I will add it later, we will probably need to ask users to specify the indices of the output channel in data module yaml config(my current approach in my personal branch).

Maybe after this is merged, I can push a follow up fix for input output channels discrepancy, will make sure the slicing is correct.