### PR TITLE
Fix eval.mode=auto misresolving full-EPD checkpoints with stateless epd

### DIFF
--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -1859,6 +1859,26 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     # Setup datamodule and resolve config
     datamodule, cfg, stats = setup_datamodule(cfg)
 
+    # Stateless encoders/decoders (e.g. PermuteConcat/ChannelsLast, Identity)
+    # contribute no `encoder_decoder.*` params, so a full EPD checkpoint can
+    # look processor-only. Reclassify *before* resolving eval.mode=auto so
+    # the auto resolution sees the true checkpoint type; otherwise such
+    # checkpoints get auto-resolved to `latent` and then fail validation
+    # once the resolved eval path comes back as `ambient_epd`.
+    if (
+        processor_only
+        and isinstance(stats.get("example_batch"), Batch)
+        and not cfg.get("autoencoder_checkpoint")
+        and cfg.get("model", {}).get("encoder") is not None
+        and cfg.get("model", {}).get("decoder") is not None
+    ):
+        log.info(
+            "Checkpoint contains no encoder_decoder.* params, but datamodule "
+            "returns raw Batch and model has encoder+decoder config. "
+            "Assuming full EPD checkpoint with stateless encoder/decoder."
+        )
+        processor_only = False
+
     # Resolve `auto` once we know the checkpoint/datamodule shape, then
     # swap to the autoencoder's raw-data datamodule if ambient/encode_once
     # is about to run on cached-latent inputs (explicit `datamodule=...`
@@ -1898,22 +1918,6 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
     #                        (data-space metrics) or opt-in latent-only.
 
     example_batch = stats.get("example_batch")
-
-    # Stateless encoders/decoders (e.g. PermuteConcat/ChannelsLast) contribute no
-    # `encoder_decoder.*` params, so a full EPD checkpoint can look processor-only.
-    if (
-        processor_only
-        and isinstance(example_batch, Batch)
-        and not cfg.get("autoencoder_checkpoint")
-        and cfg.get("model", {}).get("encoder") is not None
-        and cfg.get("model", {}).get("decoder") is not None
-    ):
-        log.info(
-            "Checkpoint contains no encoder_decoder.* params, but datamodule "
-            "returns raw Batch and model has encoder+decoder config. "
-            "Assuming full EPD checkpoint with stateless encoder/decoder."
-        )
-        processor_only = False
 
     log.info(
         "Checkpoint type: %s",

--- a/tests/scripts/test_eval_encoder_processor_decoder.py
+++ b/tests/scripts/test_eval_encoder_processor_decoder.py
@@ -35,6 +35,7 @@ from autocast.scripts.eval.encoder_processor_decoder import (
     _training_runtime_rows,
     _validate_latent_space_metrics_flag,
     _validate_resolved_eval_path,
+    run_evaluation,
 )
 from autocast.types import Batch, EncodedBatch
 from autocast.utils.plots import _panel_size_for_width
@@ -903,3 +904,65 @@ def test_maybe_swap_to_ambient_datamodule_errors_without_data_path():
         _maybe_swap_to_ambient_datamodule(
             cfg, eval_mode="ambient", example_batch=encoded
         )
+
+
+def test_run_evaluation_auto_resolves_stateless_epd_to_ambient(tmp_path, monkeypatch):
+    """Regression: a full EPD checkpoint with a stateless encoder/decoder.
+
+    Stateless encoders/decoders (PermuteConcat/ChannelsLast, Identity, ...)
+    contribute no ``encoder_decoder.*`` params, so the checkpoint initially
+    looks processor-only. ``run_evaluation`` must reclassify it as full EPD
+    *before* resolving ``eval.mode=auto`` so the auto resolution returns
+    ``ambient``; otherwise it picks ``latent`` (no autoencoder reachable) and
+    later fails ``_validate_resolved_eval_path`` against the ``ambient_epd``
+    path. We drive ``run_evaluation`` far enough to capture the resolved mode,
+    then abort before any model is built.
+    """
+    eval_mod = "autocast.scripts.eval.encoder_processor_decoder"
+
+    cfg = OmegaConf.create(
+        {
+            "eval": {"mode": "auto", "checkpoint": str(tmp_path / "ckpt.ckpt")},
+            "model": {
+                # Stateless encoder/decoder: present in config, no learned params.
+                "encoder": {"_target_": "autocast.models.encoders.PermuteConcat"},
+                "decoder": {"_target_": "autocast.models.decoders.ChannelsLast"},
+            },
+        }
+    )
+    raw_batch = _example_batch("batch")
+
+    # Checkpoint with only processor weights -> _is_processor_only_checkpoint True.
+    monkeypatch.setattr(
+        f"{eval_mod}.load_checkpoint_payload",
+        lambda _path: {"state_dict": {"processor.layer.weight": torch.zeros(1)}},
+    )
+    monkeypatch.setattr(
+        f"{eval_mod}.resolve_checkpoint_path",
+        lambda *_args, **_kwargs: tmp_path / "ckpt.ckpt",
+    )
+    # Datamodule yields a raw Batch (the ambient/full-EPD signal).
+    monkeypatch.setattr(
+        f"{eval_mod}.setup_datamodule",
+        lambda config: (object(), config, {"example_batch": raw_batch}),
+    )
+
+    class _StopAfterResolve(Exception):
+        pass
+
+    captured: dict[str, str] = {}
+
+    def _capture_and_stop(_cfg, *, eval_mode, **_kwargs):
+        # First call after eval.mode=auto is resolved; record and bail out
+        # before the heavy model-setup path runs.
+        captured["eval_mode"] = eval_mode
+        raise _StopAfterResolve
+
+    monkeypatch.setattr(
+        f"{eval_mod}._maybe_swap_to_ambient_datamodule", _capture_and_stop
+    )
+
+    with pytest.raises(_StopAfterResolve):
+        run_evaluation(cast(Any, cfg), work_dir=tmp_path)
+
+    assert captured["eval_mode"] == "ambient"


### PR DESCRIPTION
Move the stateless-encoder/decoder reclassification to run before _resolve_auto_eval_mode so full-EPD checkpoints (IdentityEncoder/Decoder, PermuteConcat, etc) are not misclassified as processor-only and auto-resolved to 'latent', which then fails _validate_resolved_eval_path against the ambient_epd path.