### PR TITLE
Add API support for time-varying scalars (#364)

### DIFF
--- a/src/autocast/benchmarking/inference.py
+++ b/src/autocast/benchmarking/inference.py
@@ -34,6 +34,9 @@ def make_synthetic_batch(example_batch: Batch, batch_size: int) -> Batch:
         constant_scalars=_slice_optional_first(example_batch.constant_scalars),
         constant_fields=_slice_optional_first(example_batch.constant_fields),
         boundary_conditions=_slice_optional_first(example_batch.boundary_conditions),
+        time_varying_scalars=_slice_optional_first(
+            getattr(example_batch, "time_varying_scalars", None)
+        ),
     )
     return single.repeat(batch_size) if batch_size > 1 else single
 

--- a/src/autocast/benchmarking/inference.py
+++ b/src/autocast/benchmarking/inference.py
@@ -34,9 +34,7 @@ def make_synthetic_batch(example_batch: Batch, batch_size: int) -> Batch:
         constant_scalars=_slice_optional_first(example_batch.constant_scalars),
         constant_fields=_slice_optional_first(example_batch.constant_fields),
         boundary_conditions=_slice_optional_first(example_batch.boundary_conditions),
-        time_varying_scalars=_slice_optional_first(
-            getattr(example_batch, "time_varying_scalars", None)
-        ),
+        time_varying_scalars=_slice_optional_first(example_batch.time_varying_scalars),
     )
     return single.repeat(batch_size) if batch_size > 1 else single
 

--- a/src/autocast/data/calendar.py
+++ b/src/autocast/data/calendar.py
@@ -92,3 +92,56 @@ def month_start_indices(
             init_dates.append(dates[init_day])
         i += 1
     return start_idxs, init_dates
+
+
+def fixed_interval_indices(
+    n_timesteps: int,
+    n_steps_input: int,
+    max_rollout_steps: int,
+    init_interval: int,
+    init_offset: int = 0,
+) -> list[int]:
+    """Input-window start indices for initialisations on a fixed-period grid.
+
+    The calendar-agnostic counterpart to :func:`month_start_indices`: forecasts are
+    launched at a regular cadence (every ``init_interval`` steps), covering
+    environmental use cases without a month anchor (e.g. an init every 5 days).
+
+    Initialisation ``k`` is at step ``init_offset + k * init_interval`` — the last
+    input frame — so its input-window start is
+    ``init_offset + k * init_interval - (n_steps_input - 1)``. A start is kept only
+    when the input window fits before it (``start >= 0``) and the rollout horizon
+    fits after it (``init_day + max_rollout_steps < n_timesteps``).
+
+    Parameters
+    ----------
+    n_timesteps:
+        Number of time steps in the trajectory.
+    n_steps_input:
+        Input window length.
+    max_rollout_steps:
+        Rollout horizon required beyond each initialisation. Pass the dataset's
+        ``n_steps_output`` so the starts line up with the subtrajectory window
+        length ``n_steps_input + n_steps_output``.
+    init_interval:
+        Spacing between consecutive initialisations, in time steps.
+    init_offset:
+        Step of the first candidate initialisation. Defaults to 0.
+
+    Returns
+    -------
+    list[int]
+        Input-window start indices, ready to feed straight into
+        ``SpatioTemporalDataset(subtrajectory_start_idxs=...)``.
+    """
+    if init_interval <= 0:
+        msg = f"init_interval must be positive, got {init_interval}."
+        raise ValueError(msg)
+    start_idxs: list[int] = []
+    init_day = init_offset
+    while init_day + max_rollout_steps < n_timesteps:
+        start = init_day - (n_steps_input - 1)
+        if init_day >= 0 and start >= 0:
+            start_idxs.append(start)
+        init_day += init_interval
+    return start_idxs

--- a/src/autocast/data/calendar.py
+++ b/src/autocast/data/calendar.py
@@ -1,0 +1,94 @@
+"""Calendar helpers for selecting month-anchored rollout subtrajectories.
+
+These utilities map integer time-step indices to calendar dates so that
+rollout subtrajectories can be initialised on the first of each month — the
+"monthly initialisation" protocol used for forecast evaluation.
+
+The default calendar is *no-leap* (365 days/year, Feb 29 dropped). This matches
+datasets stored with a ``(doy - 1) / 365`` day-of-year encoding (e.g. the
+OSISAF/ERA5 sea-ice data): if the data drops Feb 29 at preprocessing, the
+index-to-date mapping must drop it too, otherwise every month start after a
+leap-year February would be shifted one step off the stored data. Set
+``drop_leap_day=False`` for datasets stored on a standard (proleptic Gregorian)
+calendar.
+"""
+
+from __future__ import annotations
+
+import calendar
+from datetime import date, timedelta
+
+
+def calendar_dates(years: list[int], *, drop_leap_day: bool = True) -> list[date]:
+    """Daily dates spanning ``years`` (inclusive), one per stored time step.
+
+    Parameters
+    ----------
+    years:
+        Calendar years to enumerate, in order (e.g. ``[2019, 2020]``).
+    drop_leap_day:
+        If True (default), Feb 29 is omitted so each year has 365 days,
+        matching a no-leap stored calendar. If False, leap days are kept.
+    """
+    dates: list[date] = []
+    for year in years:
+        d = date(year, 1, 1)
+        end = date(year, 12, 31)
+        while d <= end:
+            is_leap_day = d.month == 2 and d.day == 29
+            if not (drop_leap_day and is_leap_day and calendar.isleap(d.year)):
+                dates.append(d)
+            d += timedelta(days=1)
+    return dates
+
+
+def month_start_indices(
+    test_years: list[int],
+    n_steps_input: int,
+    max_rollout_steps: int,
+    stride: int = 1,
+    *,
+    drop_leap_day: bool = True,
+) -> tuple[list[int], list[date]]:
+    """Input-window start indices for subtrajectories initialised on the 1st.
+
+    Each subtrajectory has an input window of ``n_steps_input`` steps; its
+    *initialisation* (the last input frame, from which the rollout predicts
+    forward) is the first of a month. A subtrajectory at input-window start
+    ``s`` therefore initialises on global step ``s + n_steps_input - 1`` and
+    needs ``max_rollout_steps`` steps of lookahead beyond that.
+
+    A candidate is kept only when both the input window and the full rollout
+    horizon fit inside the data:
+
+    - the input window fits because ``s = i * stride >= 0`` (so the very first
+      month start, with no room for the lead-in, is naturally skipped); and
+    - the horizon fits because ``s + n_steps_input + max_rollout_steps <= n``
+      (so a trailing partial month is skipped).
+
+    Pass ``max_rollout_steps`` equal to the dataset's ``n_steps_output`` so the
+    returned starts line up with the subtrajectory window length
+    ``n_steps_input + n_steps_output``.
+
+    Returns
+    -------
+    (start_idxs, init_dates)
+        ``start_idxs`` are input-window start indices (feed straight into
+        ``SpatioTemporalDataset(subtrajectory_start_idxs=...)``); ``init_dates``
+        are the matching first-of-month initialisation dates, handy for labels.
+    """
+    dates = calendar_dates(test_years, drop_leap_day=drop_leap_day)
+    n = len(dates)
+    start_idxs: list[int] = []
+    init_dates: list[date] = []
+    i = 0
+    while True:
+        start = i * stride
+        init_day = start + n_steps_input - 1
+        if init_day + max_rollout_steps >= n:
+            break
+        if dates[init_day].day == 1:
+            start_idxs.append(start)
+            init_dates.append(dates[init_day])
+        i += 1
+    return start_idxs, init_dates

--- a/src/autocast/data/datamodule.py
+++ b/src/autocast/data/datamodule.py
@@ -180,13 +180,26 @@ class SpatioTemporalDataModule(LightningDataModule):
         normalization_path: None | str = None,
         normalization_stats: dict | DictConfig | None = None,
         num_workers: int | None = None,
-        n_tvs_extra_steps: int = 0,
+        subtrajectory_mode: bool = False,
+        subtrajectory_start_idxs: list[int] | None = None,
     ):
         super().__init__()
         self.verbose = verbose
         self.use_normalization = use_normalization
         self.autoencoder_mode = autoencoder_mode
-        self.n_tvs_extra_steps = n_tvs_extra_steps
+        self.subtrajectory_mode = subtrajectory_mode
+        self.subtrajectory_start_idxs = subtrajectory_start_idxs
+        # Rollout datasets need future steps available per sample. With
+        # `subtrajectory_mode` they are windowed at explicit (e.g. month-start)
+        # indices; otherwise they fall back to full-trajectory rollout.
+        rollout_mode_kwargs: dict = (
+            {
+                "subtrajectory_mode": True,
+                "subtrajectory_start_idxs": subtrajectory_start_idxs,
+            }
+            if subtrajectory_mode
+            else {"full_trajectory_mode": True}
+        )
         # Auto-detect num_workers based on available CPUs, capped at 8
         self.num_workers = (
             num_workers if num_workers is not None else min(os.cpu_count() or 1, 8)
@@ -214,7 +227,6 @@ class SpatioTemporalDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             normalization_stats=normalization_stats,
-            n_tvs_extra_steps=n_tvs_extra_steps,
         )
 
         # # Compute normalization from training data if requested
@@ -246,7 +258,6 @@ class SpatioTemporalDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             normalization_stats=normalization_stats,
-            n_tvs_extra_steps=n_tvs_extra_steps,
         )
         self.test_dataset = dataset_cls(
             data_path=str(test_path) if test_path is not None else None,
@@ -263,7 +274,6 @@ class SpatioTemporalDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             normalization_stats=normalization_stats,
-            n_tvs_extra_steps=n_tvs_extra_steps,
         )
 
         self.batch_size = batch_size
@@ -276,14 +286,13 @@ class SpatioTemporalDataModule(LightningDataModule):
                 n_steps_output=n_steps_output,
                 stride=stride,
                 channel_idxs=channel_idxs,
-                full_trajectory_mode=True,
                 dtype=dtype,
                 verbose=self.verbose,
                 use_normalization=use_normalization,
                 normalization_type=normalization_type,
                 normalization_path=normalization_path,
                 normalization_stats=normalization_stats,
-                n_tvs_extra_steps=n_tvs_extra_steps,
+                **rollout_mode_kwargs,
             )
             self.rollout_test_dataset = dataset_cls(
                 data_path=str(test_path) if test_path is not None else None,
@@ -292,14 +301,13 @@ class SpatioTemporalDataModule(LightningDataModule):
                 n_steps_output=n_steps_output,
                 stride=stride,
                 channel_idxs=channel_idxs,
-                full_trajectory_mode=True,
                 dtype=dtype,
                 verbose=self.verbose,
                 use_normalization=use_normalization,
                 normalization_type=normalization_type,
                 normalization_path=normalization_path,
                 normalization_stats=normalization_stats,
-                n_tvs_extra_steps=n_tvs_extra_steps,
+                **rollout_mode_kwargs,
             )
 
     def train_dataloader(self) -> DataLoader:

--- a/src/autocast/data/datamodule.py
+++ b/src/autocast/data/datamodule.py
@@ -180,11 +180,13 @@ class SpatioTemporalDataModule(LightningDataModule):
         normalization_path: None | str = None,
         normalization_stats: dict | DictConfig | None = None,
         num_workers: int | None = None,
+        n_tvs_extra_steps: int = 0,
     ):
         super().__init__()
         self.verbose = verbose
         self.use_normalization = use_normalization
         self.autoencoder_mode = autoencoder_mode
+        self.n_tvs_extra_steps = n_tvs_extra_steps
         # Auto-detect num_workers based on available CPUs, capped at 8
         self.num_workers = (
             num_workers if num_workers is not None else min(os.cpu_count() or 1, 8)
@@ -212,6 +214,7 @@ class SpatioTemporalDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             normalization_stats=normalization_stats,
+            n_tvs_extra_steps=n_tvs_extra_steps,
         )
 
         # # Compute normalization from training data if requested
@@ -243,6 +246,7 @@ class SpatioTemporalDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             normalization_stats=normalization_stats,
+            n_tvs_extra_steps=n_tvs_extra_steps,
         )
         self.test_dataset = dataset_cls(
             data_path=str(test_path) if test_path is not None else None,
@@ -259,6 +263,7 @@ class SpatioTemporalDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             normalization_stats=normalization_stats,
+            n_tvs_extra_steps=n_tvs_extra_steps,
         )
 
         self.batch_size = batch_size
@@ -278,6 +283,7 @@ class SpatioTemporalDataModule(LightningDataModule):
                 normalization_type=normalization_type,
                 normalization_path=normalization_path,
                 normalization_stats=normalization_stats,
+                n_tvs_extra_steps=n_tvs_extra_steps,
             )
             self.rollout_test_dataset = dataset_cls(
                 data_path=str(test_path) if test_path is not None else None,
@@ -293,6 +299,7 @@ class SpatioTemporalDataModule(LightningDataModule):
                 normalization_type=normalization_type,
                 normalization_path=normalization_path,
                 normalization_stats=normalization_stats,
+                n_tvs_extra_steps=n_tvs_extra_steps,
             )
 
     def train_dataloader(self) -> DataLoader:

--- a/src/autocast/data/dataset.py
+++ b/src/autocast/data/dataset.py
@@ -48,7 +48,8 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
         normalization_type: type[ZScoreNormalization] | None = ZScoreNormalization,
         normalization_path: str | None = None,
         normalization_stats: dict | DictConfig | None = None,
-        n_tvs_extra_steps: int = 0,
+        subtrajectory_mode: bool = False,
+        subtrajectory_start_idxs: list[int] | None = None,
     ):
         """
         Initialize the dataset.
@@ -88,12 +89,20 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             Path to normalization statistics file (yaml). Defaults to None.
         normalization_stats: dict | None
             Preloaded normalization statistics. Defaults to None.
-        n_tvs_extra_steps: int
-            Number of additional `time_varying_scalars` steps to keep beyond
-            `n_steps_output` so that autoregressive rollouts can read a fresh
-            scalar slice at every step. Set to `autoregressive_train_steps *
-            stride` (or larger) to cover the full rollout horizon. Defaults to
-            0 (single-step inference only).
+        subtrajectory_mode: bool
+            If True, build rollout subtrajectories at explicit start indices
+            (`subtrajectory_start_idxs`) instead of sliding a window at every
+            stride. Each subtrajectory spans `n_steps_input + n_steps_output`
+            steps; `n_steps_output` is the rollout horizon and is *not*
+            auto-expanded to the full trajectory (unlike `full_trajectory_mode`).
+            Use `data.calendar.month_start_indices` to generate month-anchored
+            starts. Cannot be combined with `full_trajectory_mode` or
+            `autoencoder_mode`. Defaults to False.
+        subtrajectory_start_idxs: list[int] | None
+            Input-window start indices for `subtrajectory_mode`. Each start `s`
+            selects the window `data[traj, s : s + n_steps_input + n_steps_output]`
+            (applied to every trajectory). Required when `subtrajectory_mode` is
+            True. Defaults to None.
         """
         self.dtype = dtype
         self.verbose = verbose
@@ -123,6 +132,15 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
         if autoencoder_mode and full_trajectory_mode:
             msg = "autoencoder_mode and full_trajectory_mode cannot both be True."
             raise ValueError(msg)
+        if subtrajectory_mode and full_trajectory_mode:
+            msg = "subtrajectory_mode and full_trajectory_mode cannot both be True."
+            raise ValueError(msg)
+        if subtrajectory_mode and autoencoder_mode:
+            msg = "subtrajectory_mode and autoencoder_mode cannot both be True."
+            raise ValueError(msg)
+        if subtrajectory_mode and not subtrajectory_start_idxs:
+            msg = "subtrajectory_mode requires non-empty subtrajectory_start_idxs."
+            raise ValueError(msg)
         if autoencoder_mode:
             # In autoencoder mode, input and output steps are overridde
             n_steps_input = 1
@@ -135,11 +153,16 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
 
         self.full_trajectory_mode = full_trajectory_mode
         self.autoencoder_mode = autoencoder_mode
+        self.subtrajectory_mode = subtrajectory_mode
+        self.subtrajectory_start_idxs = (
+            list(subtrajectory_start_idxs)
+            if subtrajectory_start_idxs is not None
+            else None
+        )
         self.n_steps_input = n_steps_input
         self.n_steps_output = n_steps_output
         self.stride = stride
         self.channel_idxs = channel_idxs
-        self.n_tvs_extra_steps = n_tvs_extra_steps
 
         # Destructured here
         (
@@ -157,15 +180,12 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
         self.all_constant_fields = []
         self.all_time_varying_scalars: list[torch.Tensor] = []
 
+        # Each sample spans `n_steps_input + n_steps_output` steps.
+        window_size = self.n_steps_input + self.n_steps_output
+
         # Create input-output pairs
         for traj_idx in range(self.n_trajectories):
-            # Create subtrajectories for this trajectory
-            fields = (
-                self.data[traj_idx]
-                .unfold(0, self.n_steps_input + self.n_steps_output, self.stride)
-                # [num_subtrajectories, T_in + T_out, W, H, C]
-                .permute(0, -1, 1, 2, 3)
-            )
+            fields, starts = self._build_windows(traj_idx, window_size)
 
             # Split into input and output
             input_fields = fields[:, : self.n_steps_input, ...]
@@ -176,12 +196,12 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             )
 
             # Store each subtrajectory separately
-            for sub_idx in range(input_fields.shape[0]):
+            for local_idx, start in enumerate(starts):
                 self.all_input_fields.append(
-                    input_fields[sub_idx].to(self.dtype)
+                    input_fields[local_idx].to(self.dtype)
                 )  # [T_in, W, H, C]
                 self.all_output_fields.append(
-                    output_fields[sub_idx].to(self.dtype)
+                    output_fields[local_idx].to(self.dtype)
                 )  # [T_out, W, H, C]
 
                 # Handle constant scalars
@@ -196,19 +216,23 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
                         self.constant_fields[traj_idx].to(self.dtype)
                     )
 
-                # Slice time-varying scalars: `n_steps_output + n_tvs_extra_steps`
-                # steps total starting at the first prediction timestep. The
-                # rollout consumes one slice per step; `n_tvs_extra_steps` must
-                # be large enough to cover the autoregressive horizon.
+                # Time-varying scalars are aligned 1:1 with frames: index 0 is
+                # input frame 0, so `encode_cond` only ever reads the current
+                # input window (the last `n_tvs_steps` of it) and never looks
+                # ahead of it. In full-trajectory / subtrajectory mode the buffer
+                # is extended across the rollout-horizon frames so that, as the
+                # input window slides forward (`_advance_batch`), each new window
+                # position still has its own per-frame scalars — those frames are
+                # "past" relative to each rollout step, not look-ahead.
                 if self.time_varying_scalars is not None:
-                    t_out_start = sub_idx * self.stride + self.n_steps_input
-                    t_out_end = (
-                        t_out_start + self.n_steps_output + self.n_tvs_extra_steps
-                    )
+                    t_start = start
+                    t_end = start + self.n_steps_input
+                    if self.full_trajectory_mode or self.subtrajectory_mode:
+                        t_end = t_end + self.n_steps_output
                     self.all_time_varying_scalars.append(
-                        self.time_varying_scalars[
-                            traj_idx, t_out_start:t_out_end, :
-                        ].to(self.dtype)
+                        self.time_varying_scalars[traj_idx, t_start:t_end, :].to(
+                            self.dtype
+                        )
                     )
 
         if self.verbose:
@@ -216,6 +240,38 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             print(f"Each input sample shape: {self.all_input_fields[0].shape}")
             print(f"Each output sample shape: {self.all_output_fields[0].shape}")
             print(f"Data type: {self.all_input_fields[0].dtype}")
+
+    def _build_windows(
+        self, traj_idx: int, window_size: int
+    ) -> tuple[torch.Tensor, list[int]]:
+        """Return `(windows, start_idxs)` for one trajectory.
+
+        `windows` has shape `[n_windows, window_size, W, H, C]`; `start_idxs[i]`
+        is the raw time-step index where window `i` begins.
+        """
+        if self.subtrajectory_mode:
+            starts = self.subtrajectory_start_idxs or []
+            for s in starts:
+                if s < 0 or s + window_size > self.n_timesteps:
+                    msg = (
+                        f"subtrajectory_start_idxs contains out-of-range start "
+                        f"{s}: window [{s}, {s + window_size}) does not fit in a "
+                        f"trajectory of length {self.n_timesteps}."
+                    )
+                    raise ValueError(msg)
+            windows = torch.stack(
+                [self.data[traj_idx, s : s + window_size] for s in starts], dim=0
+            )
+            return windows, list(starts)
+
+        windows = (
+            self.data[traj_idx]
+            .unfold(0, window_size, self.stride)
+            # [n_windows, window_size, W, H, C]
+            .permute(0, -1, 1, 2, 3)
+        )
+        starts = [i * self.stride for i in range(windows.shape[0])]
+        return windows, starts
 
     def _from_f(self, f):
         assert "data" in f, "HDF5 file must contain 'data' dataset"

--- a/src/autocast/data/dataset.py
+++ b/src/autocast/data/dataset.py
@@ -32,7 +32,7 @@ class BatchMixin:
 class SpatioTemporalDataset(Dataset, BatchMixin):
     """A class for spatio-temporal datasets."""
 
-    def __init__(  # noqa: PLR0915
+    def __init__(  # noqa: PLR0912, PLR0915
         self,
         data_path: str | None,
         data: dict | None = None,
@@ -203,9 +203,7 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
                 if self.time_varying_scalars is not None:
                     t_out_start = sub_idx * self.stride + self.n_steps_input
                     t_out_end = (
-                        t_out_start
-                        + self.n_steps_output
-                        + self.n_tvs_extra_steps
+                        t_out_start + self.n_steps_output + self.n_tvs_extra_steps
                     )
                     self.all_time_varying_scalars.append(
                         self.time_varying_scalars[

--- a/src/autocast/data/dataset.py
+++ b/src/autocast/data/dataset.py
@@ -25,6 +25,7 @@ class BatchMixin:
             constant_scalars=data.get("constant_scalars"),
             constant_fields=data.get("constant_fields"),
             boundary_conditions=data.get("boundary_conditions"),
+            time_varying_scalars=data.get("time_varying_scalars"),
         )
 
 
@@ -47,6 +48,7 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
         normalization_type: type[ZScoreNormalization] | None = ZScoreNormalization,
         normalization_path: str | None = None,
         normalization_stats: dict | DictConfig | None = None,
+        n_tvs_extra_steps: int = 0,
     ):
         """
         Initialize the dataset.
@@ -86,6 +88,12 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             Path to normalization statistics file (yaml). Defaults to None.
         normalization_stats: dict | None
             Preloaded normalization statistics. Defaults to None.
+        n_tvs_extra_steps: int
+            Number of additional `time_varying_scalars` steps to keep beyond
+            `n_steps_output` so that autoregressive rollouts can read a fresh
+            scalar slice at every step. Set to `autoregressive_train_steps *
+            stride` (or larger) to cover the full rollout horizon. Defaults to
+            0 (single-step inference only).
         """
         self.dtype = dtype
         self.verbose = verbose
@@ -131,6 +139,7 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
         self.n_steps_output = n_steps_output
         self.stride = stride
         self.channel_idxs = channel_idxs
+        self.n_tvs_extra_steps = n_tvs_extra_steps
 
         # Destructured here
         (
@@ -146,6 +155,7 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
         self.all_output_fields = []
         self.all_constant_scalars = []
         self.all_constant_fields = []
+        self.all_time_varying_scalars: list[torch.Tensor] = []
 
         # Create input-output pairs
         for traj_idx in range(self.n_trajectories):
@@ -186,6 +196,23 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
                         self.constant_fields[traj_idx].to(self.dtype)
                     )
 
+                # Slice time-varying scalars: `n_steps_output + n_tvs_extra_steps`
+                # steps total starting at the first prediction timestep. The
+                # rollout consumes one slice per step; `n_tvs_extra_steps` must
+                # be large enough to cover the autoregressive horizon.
+                if self.time_varying_scalars is not None:
+                    t_out_start = sub_idx * self.stride + self.n_steps_input
+                    t_out_end = (
+                        t_out_start
+                        + self.n_steps_output
+                        + self.n_tvs_extra_steps
+                    )
+                    self.all_time_varying_scalars.append(
+                        self.time_varying_scalars[
+                            traj_idx, t_out_start:t_out_end, :
+                        ].to(self.dtype)
+                    )
+
         if self.verbose:
             print(f"Created {len(self.all_input_fields)} subtrajectory samples")
             print(f"Each input sample shape: {self.all_input_fields[0].shape}")
@@ -217,6 +244,26 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             else None
         )
 
+        # Time-varying scalars: [N, T, C] — one scalar vector per timestep per
+        # trajectory.
+        self.time_varying_scalars = (
+            torch.Tensor(f["time_varying_scalars"][:]).to(self.dtype)  # type: ignore  # noqa: PGH003
+            if "time_varying_scalars" in f
+            and f["time_varying_scalars"] is not None
+            and f["time_varying_scalars"] != {}
+            else None
+        )
+        if (
+            self.time_varying_scalars is not None
+            and self.time_varying_scalars.shape[1] < self.data.shape[1]
+        ):
+            msg = (
+                f"time_varying_scalars time dimension "
+                f"({self.time_varying_scalars.shape[1]}) must be >= data time "
+                f"dimension ({self.data.shape[1]})."
+            )
+            raise ValueError(msg)
+
     def read_data(self, data_path: str):
         """Read data.
 
@@ -239,6 +286,17 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             )
             self.constant_scalars = data.get("constant_scalars", None)
             self.constant_fields = data.get("constant_fields", None)
+            self.time_varying_scalars = data.get("time_varying_scalars", None)
+            if (
+                self.time_varying_scalars is not None
+                and self.time_varying_scalars.shape[1] < self.data.shape[1]
+            ):
+                msg = (
+                    f"time_varying_scalars time dimension "
+                    f"({self.time_varying_scalars.shape[1]}) must be >= data "
+                    f"time dimension ({self.data.shape[1]})."
+                )
+                raise ValueError(msg)
             return
         msg = "No data provided to parse."
         raise ValueError(msg)
@@ -290,6 +348,8 @@ class SpatioTemporalDataset(Dataset, BatchMixin):
             item["constant_scalars"] = self.all_constant_scalars[idx]
         if len(self.all_constant_fields) > 0:
             item["constant_fields"] = self.all_constant_fields[idx]
+        if len(self.all_time_varying_scalars) > 0:
+            item["time_varying_scalars"] = self.all_time_varying_scalars[idx]
 
         return self.to_sample(item)
 

--- a/src/autocast/encoders/base.py
+++ b/src/autocast/encoders/base.py
@@ -141,6 +141,10 @@ class EncoderWithCond(Encoder):
         """Encode global conditioning tensor from the batch.
 
         Default implementation flattens constant scalars and boundary conditions.
+        When `time_varying_scalars` are provided, the slice corresponding to the
+        current prediction step (index 0 along the time axis) is concatenated to
+        the conditioning vector. The rollout/training loop is responsible for
+        advancing this tensor (see `EncoderProcessorDecoder._advance_batch`).
         """
         global_cond = None
         if batch.constant_scalars is not None:
@@ -152,6 +156,21 @@ class EncoderWithCond(Encoder):
                 global_cond = bc
             else:
                 global_cond = torch.cat([global_cond, bc], dim=1)
+        if batch.time_varying_scalars is not None:
+            if batch.time_varying_scalars.shape[1] == 0:
+                msg = (
+                    "time_varying_scalars is exhausted (shape[1] == 0). "
+                    "The autoregressive rollout has consumed all pre-computed "
+                    "steps. Increase `n_tvs_extra_steps` in the datamodule "
+                    "config so the dataset stores enough future steps."
+                )
+                raise RuntimeError(msg)
+            # Slice the current prediction step (index 0 along time axis).
+            tvs = batch.time_varying_scalars[:, 0, :]  # (B, C_tvs)
+            if global_cond is None:
+                global_cond = tvs
+            else:
+                global_cond = torch.cat([global_cond, tvs], dim=1)
 
         return global_cond
 

--- a/src/autocast/encoders/base.py
+++ b/src/autocast/encoders/base.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 from typing import Generic, TypeVar
 
 import torch
+from einops import rearrange
 from torch import nn
 
 from autocast.types import Batch, EncodedBatch, TensorBNC
@@ -137,14 +138,21 @@ class Encoder(_Encoder):
 class EncoderWithCond(Encoder):
     """Encoder that returns encoded tensor and optional conditioning."""
 
+    #: Number of `time_varying_scalars` time steps (ending at the current input
+    #: window) to flatten into `global_cond`. The resulting contribution has
+    #: width `n_tvs_steps * C_tvs`. Default 1 uses only the most recent step.
+    n_tvs_steps: int = 1
+
     def encode_cond(self, batch: Batch) -> Tensor | None:
         """Encode global conditioning tensor from the batch.
 
         Default implementation flattens constant scalars and boundary conditions.
-        When `time_varying_scalars` are provided, the slice corresponding to the
-        current prediction step (index 0 along the time axis) is concatenated to
-        the conditioning vector. The rollout/training loop is responsible for
-        advancing this tensor (see `EncoderProcessorDecoder._advance_batch`).
+        When `time_varying_scalars` are provided, the last `n_tvs_steps` steps of
+        the current input window are flattened (`b t c -> b (t c)`) and
+        concatenated to the conditioning vector. The rollout/training loop is
+        responsible for advancing this tensor (see
+        `EncoderProcessorDecoder._advance_batch`), which keeps index 0 aligned to
+        the start of the current input window.
         """
         global_cond = None
         if batch.constant_scalars is not None:
@@ -157,20 +165,33 @@ class EncoderWithCond(Encoder):
             else:
                 global_cond = torch.cat([global_cond, bc], dim=1)
         if batch.time_varying_scalars is not None:
-            if batch.time_varying_scalars.shape[1] == 0:
+            n_steps_input = batch.input_fields.shape[1]
+            available = batch.time_varying_scalars.shape[1]
+            if self.n_tvs_steps > n_steps_input:
                 msg = (
-                    "time_varying_scalars is exhausted (shape[1] == 0). "
-                    "The autoregressive rollout has consumed all pre-computed "
-                    "steps. Increase `n_tvs_extra_steps` in the datamodule "
-                    "config so the dataset stores enough future steps."
+                    f"n_tvs_steps ({self.n_tvs_steps}) cannot exceed the input "
+                    f"window length n_steps_input ({n_steps_input})."
+                )
+                raise ValueError(msg)
+            if available < n_steps_input:
+                msg = (
+                    f"time_varying_scalars is exhausted (has {available} steps, "
+                    f"needs {n_steps_input} to cover the input window). The "
+                    "autoregressive rollout has consumed all pre-computed steps; "
+                    "increase n_steps_output (the rollout horizon) on the dataset "
+                    "so enough future steps are stored."
                 )
                 raise RuntimeError(msg)
-            # Slice the current prediction step (index 0 along time axis).
-            tvs = batch.time_varying_scalars[:, 0, :]  # (B, C_tvs)
+            # Last `n_tvs_steps` steps of the current input window. Index 0 is
+            # kept aligned to the input-window start by `_advance_batch`.
+            window = batch.time_varying_scalars[
+                :, n_steps_input - self.n_tvs_steps : n_steps_input, :
+            ]
+            time_varying_scalars = rearrange(window, "b t c -> b (t c)")
             if global_cond is None:
-                global_cond = tvs
+                global_cond = time_varying_scalars
             else:
-                global_cond = torch.cat([global_cond, tvs], dim=1)
+                global_cond = torch.cat([global_cond, time_varying_scalars], dim=1)
 
         return global_cond
 

--- a/src/autocast/encoders/permute_concat.py
+++ b/src/autocast/encoders/permute_concat.py
@@ -16,11 +16,17 @@ class PermuteConcat(EncoderWithCond):
     outputs_time_channel_concat: bool = True
 
     def __init__(
-        self, in_channels: int, n_steps_input: int, with_constants: bool = False
+        self,
+        in_channels: int,
+        n_steps_input: int,
+        with_constants: bool = False,
+        n_tvs_steps: int = 1,
     ) -> None:
         super().__init__()
         self.with_constants = with_constants
         self.latent_channels = in_channels * n_steps_input
+        # Number of time_varying_scalars steps to flatten into global_cond.
+        self.n_tvs_steps = n_tvs_steps
 
     def encode(self, batch: Batch) -> TensorBNC:
         # Destructure batch, time, space, channels

--- a/src/autocast/models/encoder_processor_decoder.py
+++ b/src/autocast/models/encoder_processor_decoder.py
@@ -82,6 +82,8 @@ class EncoderProcessorDecoder(
                 output_fields=batch.output_fields,
                 constant_scalars=batch.constant_scalars,
                 constant_fields=batch.constant_fields,
+                boundary_conditions=batch.boundary_conditions,
+                time_varying_scalars=batch.time_varying_scalars,
             )
         return batch
 
@@ -193,6 +195,11 @@ class EncoderProcessorDecoder(
                 if batch.boundary_conditions is not None
                 else None
             ),
+            time_varying_scalars=(
+                batch.time_varying_scalars.clone()
+                if batch.time_varying_scalars is not None
+                else None
+            ),
         )
 
     def _predict(self, batch: Batch) -> Tensor:
@@ -240,4 +247,14 @@ class EncoderProcessorDecoder(
             constant_scalars=batch.constant_scalars,
             constant_fields=batch.constant_fields,
             boundary_conditions=batch.boundary_conditions,
+            time_varying_scalars=(
+                batch.time_varying_scalars[:, stride:, :]
+                if batch.time_varying_scalars is not None
+                and batch.time_varying_scalars.shape[1] > stride
+                else (
+                    batch.time_varying_scalars[:, 0:0, :]
+                    if batch.time_varying_scalars is not None
+                    else None
+                )
+            ),
         )

--- a/src/autocast/scripts/data.py
+++ b/src/autocast/scripts/data.py
@@ -125,4 +125,9 @@ def batch_to_device(batch: Batch, device: torch.device) -> Batch:
             if batch.boundary_conditions is not None
             else None
         ),
+        time_varying_scalars=(
+            batch.time_varying_scalars.to(device)
+            if batch.time_varying_scalars is not None
+            else None
+        ),
     )

--- a/src/autocast/scripts/setup.py
+++ b/src/autocast/scripts/setup.py
@@ -264,11 +264,17 @@ def setup_datamodule(
         n_constant_field_channels = (
             batch.constant_fields.shape[-1] if batch.constant_fields is not None else 0
         )
+        n_time_varying_scalars = (
+            batch.time_varying_scalars.shape[-1]
+            if batch.time_varying_scalars is not None
+            else 0
+        )
     elif isinstance(batch, EncodedBatch):
         train_inputs = batch.encoded_inputs
         train_outputs = batch.encoded_output_fields
         n_constant_scalars = None
         n_constant_field_channels = None
+        n_time_varying_scalars = None
     else:
         raise TypeError(f"Unsupported batch type: {type(batch)}")
 
@@ -282,6 +288,7 @@ def setup_datamodule(
         "n_steps_output": output_shape[1],
         "n_constant_scalars": n_constant_scalars,
         "n_constant_field_channels": n_constant_field_channels,
+        "n_time_varying_scalars": n_time_varying_scalars,
         "input_shape": input_shape,
         "output_shape": output_shape,
         "example_batch": batch,

--- a/src/autocast/types/batch.py
+++ b/src/autocast/types/batch.py
@@ -8,13 +8,16 @@ from autocast.types.types import (
     TensorBC,
     TensorBNC,
     TensorBSC,
+    TensorBTC,
     TensorBTSC,
     TensorC,
     TensorNC,
     TensorS,
     TensorSC,
+    TensorTC,
     TensorTSC,
 )
+
 
 # Generic batch type variable
 BatchT = TypeVar("BatchT")
@@ -29,6 +32,7 @@ class Sample:
     constant_scalars: TensorC | None
     constant_fields: TensorSC | None
     boundary_conditions: TensorS | None
+    time_varying_scalars: TensorTC | None = None
 
 
 @dataclass
@@ -50,6 +54,7 @@ class Batch:
     constant_scalars: TensorBC | None
     constant_fields: TensorBSC | None
     boundary_conditions: TensorS | None = None
+    time_varying_scalars: TensorBTC | None = None
 
     def repeat(self, m: int) -> "Batch":
         """Repeat batch members.
@@ -79,6 +84,11 @@ class Batch:
                 if self.boundary_conditions is not None
                 else None
             ),
+            time_varying_scalars=(
+                self.time_varying_scalars.repeat_interleave(m, dim=0)
+                if self.time_varying_scalars is not None
+                else None
+            ),
         )
 
     def to(self, device: torch.device | str) -> "Batch":
@@ -99,6 +109,11 @@ class Batch:
             boundary_conditions=(
                 self.boundary_conditions.to(device)
                 if self.boundary_conditions is not None
+                else None
+            ),
+            time_varying_scalars=(
+                self.time_varying_scalars.to(device)
+                if self.time_varying_scalars is not None
                 else None
             ),
         )

--- a/src/autocast/types/batch.py
+++ b/src/autocast/types/batch.py
@@ -18,7 +18,6 @@ from autocast.types.types import (
     TensorTSC,
 )
 
-
 # Generic batch type variable
 BatchT = TypeVar("BatchT")
 

--- a/src/autocast/types/collation/__init__.py
+++ b/src/autocast/types/collation/__init__.py
@@ -26,6 +26,7 @@ def collate_batches(samples: Sequence[Sample]) -> Batch:
     constant_scalars = _stack_optional("constant_scalars")
     constant_fields = _stack_optional("constant_fields")
     boundary_conditions = _stack_optional("boundary_conditions")
+    time_varying_scalars = _stack_optional("time_varying_scalars")
 
     return Batch(
         input_fields=input_fields,
@@ -33,6 +34,7 @@ def collate_batches(samples: Sequence[Sample]) -> Batch:
         constant_scalars=constant_scalars,
         constant_fields=constant_fields,
         boundary_conditions=boundary_conditions,
+        time_varying_scalars=time_varying_scalars,
     )
 
 

--- a/src/autocast/types/types.py
+++ b/src/autocast/types/types.py
@@ -34,6 +34,7 @@ TensorBCS = Float[Tensor, "batch channel spatial *spatial"]  # No time dimension
 TensorBSSC = Float[Tensor, "batch spatial *spatial channel"]  # No time dimension
 
 TensorTSC = Float[Tensor, "time spatial *spatial channel"]  # No batch dimension
+TensorTC = Float[Tensor, "time channel"]  # No batch or spatial dimension
 TensorNC = Float[Tensor, "*optional_dims channel"]  # No batch dimension
 TensorSC = Float[Tensor, "spatial *spatial channel"]  # No batch dimension
 TensorS = Float[Tensor, "spatial *spatial"]  # No batch or channel dimension

--- a/tests/data/test_calendar.py
+++ b/tests/data/test_calendar.py
@@ -2,7 +2,13 @@
 
 from datetime import date
 
-from autocast.data.calendar import calendar_dates, month_start_indices
+import pytest
+
+from autocast.data.calendar import (
+    calendar_dates,
+    fixed_interval_indices,
+    month_start_indices,
+)
 
 # First-of-month indices for a 365-day no-leap year (Jan 1 == index 0).
 _NO_LEAP_MONTH_STARTS = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
@@ -55,3 +61,30 @@ def test_month_start_indices_leap_handling_shifts_post_february():
     standard, _ = month_start_indices([2004], 1, 1, drop_leap_day=False)
     # March is the 3rd kept month start (Jan, Feb, Mar, ...).
     assert standard[2] == no_leap[2] + 1
+
+
+def test_fixed_interval_indices_regular_cadence():
+    n_timesteps, n_steps_input, horizon, interval = 100, 3, 10, 5
+    starts = fixed_interval_indices(n_timesteps, n_steps_input, horizon, interval)
+    # Init days on the 0,5,10,... grid; init day 0 is dropped (no lead-in for a
+    # 3-step input window). start = init_day - (n_steps_input - 1).
+    assert starts == list(range(3, 84, 5))
+    # Horizon must fit: last init day 85 (85 + 10 < 100); 90 would not.
+    assert starts[-1] == 85 - (n_steps_input - 1)
+
+
+def test_fixed_interval_indices_offset_and_single_input():
+    starts = fixed_interval_indices(
+        n_timesteps=50,
+        n_steps_input=1,
+        max_rollout_steps=5,
+        init_interval=10,
+        init_offset=2,
+    )
+    # n_steps_input=1 -> start == init day; grid 2,12,...; keep while +5 < 50.
+    assert starts == [2, 12, 22, 32, 42]
+
+
+def test_fixed_interval_indices_rejects_nonpositive_interval():
+    with pytest.raises(ValueError, match="init_interval must be positive"):
+        fixed_interval_indices(100, 3, 10, 0)

--- a/tests/data/test_calendar.py
+++ b/tests/data/test_calendar.py
@@ -1,0 +1,57 @@
+"""Tests for month-anchored subtrajectory index selection."""
+
+from datetime import date
+
+from autocast.data.calendar import calendar_dates, month_start_indices
+
+# First-of-month indices for a 365-day no-leap year (Jan 1 == index 0).
+_NO_LEAP_MONTH_STARTS = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334]
+
+
+def test_calendar_dates_no_leap_drops_feb_29():
+    no_leap = calendar_dates([2004], drop_leap_day=True)  # 2004 is a leap year
+    standard = calendar_dates([2004], drop_leap_day=False)
+    assert len(no_leap) == 365
+    assert len(standard) == 366
+    assert date(2004, 2, 29) not in no_leap
+    assert date(2004, 2, 29) in standard
+
+
+def test_month_start_indices_skips_first_and_returns_input_window_starts():
+    n_steps_input = 3
+    max_rollout_steps = 5
+    starts, init_dates = month_start_indices(
+        test_years=[2001],
+        n_steps_input=n_steps_input,
+        max_rollout_steps=max_rollout_steps,
+        stride=1,
+    )
+
+    # January is dropped: there is no room for the n_steps_input lead-in before
+    # Jan 1, so the earliest init is Feb 1.
+    expected_starts = [idx - (n_steps_input - 1) for idx in _NO_LEAP_MONTH_STARTS[1:]]
+    assert starts == expected_starts
+    assert [d.month for d in init_dates] == list(range(2, 13))
+    assert all(d.day == 1 for d in init_dates)
+
+    # Each start's init (last input frame) lands on the 1st of the month.
+    for start, init_date in zip(starts, init_dates, strict=True):
+        init_day = start + n_steps_input - 1
+        assert calendar_dates([2001])[init_day] == init_date
+
+
+def test_month_start_indices_drops_trailing_partial_month():
+    # A long horizon means the final months cannot complete a rollout.
+    starts_short, dates_short = month_start_indices([2001], 3, 5, stride=1)
+    starts_long, dates_long = month_start_indices([2001], 3, 60, stride=1)
+    assert dates_long[-1] < dates_short[-1]
+    assert len(starts_long) < len(starts_short)
+
+
+def test_month_start_indices_leap_handling_shifts_post_february():
+    # With Feb 29 dropped, March starts one step earlier than on a standard
+    # calendar — the reason the no-leap mapping must match the stored data.
+    no_leap, _ = month_start_indices([2004], 1, 1, drop_leap_day=True)
+    standard, _ = month_start_indices([2004], 1, 1, drop_leap_day=False)
+    # March is the 3rd kept month start (Jan, Feb, Mar, ...).
+    assert standard[2] == no_leap[2] + 1

--- a/tests/data/test_time_varying_scalars.py
+++ b/tests/data/test_time_varying_scalars.py
@@ -1,0 +1,120 @@
+"""Tests for time-varying-scalar windowing in SpatioTemporalDataset."""
+
+import pytest
+import torch
+
+from autocast.data.dataset import SpatioTemporalDataset
+
+
+def _make_data(n_traj=1, t=12, w=2, h=2, c=1, c_tvs=3):
+    data = torch.randn(n_traj, t, w, h, c)
+    # Distinct, easily-checked values per (traj, time, channel).
+    n_tvs = n_traj * t * c_tvs
+    tvs = torch.arange(n_tvs, dtype=torch.float32).reshape(n_traj, t, c_tvs)
+    return {"data": data, "time_varying_scalars": tvs}
+
+
+def test_tvs_window_is_input_aligned_in_normal_mode():
+    data = _make_data(t=12, c_tvs=3)
+    n_steps_input, n_steps_output, stride = 2, 3, 1
+    ds = SpatioTemporalDataset(
+        data_path=None,
+        data=data,
+        n_steps_input=n_steps_input,
+        n_steps_output=n_steps_output,
+        stride=stride,
+    )
+    window = n_steps_input + n_steps_output
+    n_windows = (12 - window) // stride + 1
+    assert len(ds) == n_windows
+    for i in range(n_windows):
+        sample = ds[i]
+        # Normal mode: TVS spans only the input window.
+        assert sample.time_varying_scalars.shape == (n_steps_input, 3)
+        start = i * stride
+        expected = data["time_varying_scalars"][0, start : start + n_steps_input]
+        assert torch.equal(sample.time_varying_scalars, expected)
+
+
+def test_tvs_window_spans_input_plus_output_in_full_trajectory_mode():
+    data = _make_data(t=12, c_tvs=3)
+    n_steps_input = 2
+    ds = SpatioTemporalDataset(
+        data_path=None,
+        data=data,
+        n_steps_input=n_steps_input,
+        n_steps_output=5,  # ignored; full-trajectory expands to T - n_steps_input
+        full_trajectory_mode=True,
+    )
+    assert len(ds) == 1
+    sample = ds[0]
+    # Spans the whole trajectory so the rollout can stride forward.
+    assert sample.time_varying_scalars.shape == (12, 3)
+    assert torch.equal(sample.time_varying_scalars, data["time_varying_scalars"][0])
+
+
+def test_subtrajectory_mode_windows_at_explicit_starts():
+    data = _make_data(t=12, c_tvs=3)
+    n_steps_input, n_steps_output = 2, 3
+    starts = [0, 4, 7]
+    window = n_steps_input + n_steps_output
+    ds = SpatioTemporalDataset(
+        data_path=None,
+        data=data,
+        n_steps_input=n_steps_input,
+        n_steps_output=n_steps_output,
+        subtrajectory_mode=True,
+        subtrajectory_start_idxs=starts,
+    )
+    assert len(ds) == len(starts)
+    for local_idx, start in enumerate(starts):
+        sample = ds[local_idx]
+        assert sample.input_fields.shape == (n_steps_input, 2, 2, 1)
+        assert sample.output_fields.shape == (n_steps_output, 2, 2, 1)
+        assert torch.equal(
+            sample.input_fields, data["data"][0, start : start + n_steps_input]
+        )
+        assert torch.equal(
+            sample.output_fields,
+            data["data"][0, start + n_steps_input : start + window],
+        )
+        # Subtrajectory mode spans input + output for rollout striding.
+        assert sample.time_varying_scalars.shape == (window, 3)
+        assert torch.equal(
+            sample.time_varying_scalars,
+            data["time_varying_scalars"][0, start : start + window],
+        )
+
+
+def test_subtrajectory_mode_requires_start_idxs():
+    data = _make_data()
+    with pytest.raises(ValueError, match="subtrajectory_start_idxs"):
+        SpatioTemporalDataset(
+            data_path=None, data=data, subtrajectory_mode=True
+        )
+
+
+def test_subtrajectory_mode_rejects_out_of_range_start():
+    data = _make_data(t=12)
+    with pytest.raises(ValueError, match="out-of-range"):
+        SpatioTemporalDataset(
+            data_path=None,
+            data=data,
+            n_steps_input=2,
+            n_steps_output=3,
+            subtrajectory_mode=True,
+            subtrajectory_start_idxs=[8],  # 8 + 5 = 13 > 12
+        )
+
+
+@pytest.mark.parametrize("other", ["full_trajectory_mode", "autoencoder_mode"])
+def test_subtrajectory_mode_is_mutually_exclusive(other):
+    data = _make_data()
+    with pytest.raises(ValueError, match="cannot both be True"):
+        SpatioTemporalDataset(
+            data_path=None,
+            data=data,
+            subtrajectory_mode=True,
+            subtrajectory_start_idxs=[0],
+            **{other: True},
+        )

--- a/tests/encoders/test_encode_cond_tvs.py
+++ b/tests/encoders/test_encode_cond_tvs.py
@@ -1,0 +1,70 @@
+"""Tests for time-varying-scalar conditioning in EncoderWithCond.encode_cond."""
+
+import pytest
+import torch
+from einops import rearrange
+
+from autocast.encoders.permute_concat import PermuteConcat
+from autocast.types import Batch
+
+
+def _make_batch(batch_size=2, t_in=3, w=4, h=4, c=1, c_tvs=2, tvs_steps=None):
+    tvs_steps = tvs_steps if tvs_steps is not None else t_in
+    return Batch(
+        input_fields=torch.randn(batch_size, t_in, w, h, c),
+        output_fields=torch.randn(batch_size, t_in, w, h, c),
+        constant_scalars=None,
+        constant_fields=None,
+        time_varying_scalars=torch.randn(batch_size, tvs_steps, c_tvs),
+    )
+
+
+def test_encode_cond_default_uses_last_input_step():
+    t_in, c_tvs = 3, 2
+    batch = _make_batch(t_in=t_in, c_tvs=c_tvs)
+    encoder = PermuteConcat(in_channels=1, n_steps_input=t_in)  # n_tvs_steps=1
+    cond = encoder.encode_cond(batch)
+    assert cond is not None
+    assert cond.shape == (batch.input_fields.shape[0], c_tvs)
+    # Default n_tvs_steps=1 -> last input step (index n_steps_input - 1).
+    assert torch.equal(cond, batch.time_varying_scalars[:, t_in - 1, :])
+
+
+def test_encode_cond_rearranges_multiple_steps():
+    t_in, c_tvs, n_tvs_steps = 3, 2, 2
+    batch = _make_batch(t_in=t_in, c_tvs=c_tvs)
+    encoder = PermuteConcat(in_channels=1, n_steps_input=t_in, n_tvs_steps=n_tvs_steps)
+    cond = encoder.encode_cond(batch)
+    assert cond is not None
+    assert cond.shape == (batch.input_fields.shape[0], n_tvs_steps * c_tvs)
+    window = batch.time_varying_scalars[:, t_in - n_tvs_steps : t_in, :]
+    assert torch.equal(cond, rearrange(window, "b t c -> b (t c)"))
+
+
+def test_encode_cond_concatenates_after_constant_scalars():
+    t_in, c_tvs, n_const = 3, 2, 4
+    batch = _make_batch(t_in=t_in, c_tvs=c_tvs)
+    batch.constant_scalars = torch.randn(batch.input_fields.shape[0], n_const)
+    encoder = PermuteConcat(in_channels=1, n_steps_input=t_in)
+    cond = encoder.encode_cond(batch)
+    assert cond is not None
+    assert cond.shape == (batch.input_fields.shape[0], n_const + c_tvs)
+    assert torch.equal(cond[:, :n_const], batch.constant_scalars)
+    assert torch.equal(cond[:, n_const:], batch.time_varying_scalars[:, t_in - 1, :])
+
+
+def test_encode_cond_rejects_window_longer_than_input():
+    t_in = 2
+    batch = _make_batch(t_in=t_in)
+    encoder = PermuteConcat(in_channels=1, n_steps_input=t_in, n_tvs_steps=t_in + 1)
+    with pytest.raises(ValueError, match="cannot exceed"):
+        encoder.encode_cond(batch)
+
+
+def test_encode_cond_raises_when_tvs_exhausted():
+    t_in = 3
+    # Fewer TVS steps than the input window (e.g. rollout consumed them).
+    batch = _make_batch(t_in=t_in, tvs_steps=t_in - 1)
+    encoder = PermuteConcat(in_channels=1, n_steps_input=t_in)
+    with pytest.raises(RuntimeError, match="exhausted"):
+        encoder.encode_cond(batch)

--- a/tests/models/test_tvs_rollout.py
+++ b/tests/models/test_tvs_rollout.py
@@ -1,0 +1,78 @@
+"""Tests for time-varying-scalar handling across the rollout machinery."""
+
+import torch
+from conftest import CondCaptureProcessor, get_optimizer_config
+
+from autocast.decoders.channels_last import ChannelsLast
+from autocast.encoders.permute_concat import PermuteConcat
+from autocast.models.encoder_decoder import EncoderDecoder
+from autocast.models.encoder_processor_decoder import EncoderProcessorDecoder
+from autocast.types import Batch
+
+
+def _build_model(n_steps_input, channels, n_tvs_steps=1):
+    encoder = PermuteConcat(
+        in_channels=channels, n_steps_input=n_steps_input, n_tvs_steps=n_tvs_steps
+    )
+    decoder = ChannelsLast(output_channels=channels, time_steps=n_steps_input)
+    encoder_decoder = EncoderDecoder(encoder=encoder, decoder=decoder)
+    return EncoderProcessorDecoder(
+        encoder_decoder=encoder_decoder,
+        processor=CondCaptureProcessor(),
+        optimizer_config=get_optimizer_config(),
+    )
+
+
+def test_advance_batch_strides_time_varying_scalars():
+    batch_size, n_steps_input, w, h, c, c_tvs = 2, 2, 8, 8, 1, 3
+    tvs_len = 10
+    model = _build_model(n_steps_input, c)
+    batch = Batch(
+        input_fields=torch.randn(batch_size, n_steps_input, w, h, c),
+        output_fields=torch.randn(batch_size, n_steps_input, w, h, c),
+        constant_scalars=None,
+        constant_fields=None,
+        time_varying_scalars=torch.randn(batch_size, tvs_len, c_tvs),
+    )
+    next_inputs = torch.randn(batch_size, n_steps_input, w, h, c)
+
+    stride = 2
+    advanced = model._advance_batch(batch, next_inputs, stride=stride)
+    assert advanced.time_varying_scalars is not None
+    assert advanced.time_varying_scalars.shape == (batch_size, tvs_len - stride, c_tvs)
+    assert torch.equal(
+        advanced.time_varying_scalars, batch.time_varying_scalars[:, stride:, :]
+    )
+
+
+def test_advance_batch_empties_tvs_when_consumed():
+    batch_size, n_steps_input, w, h, c, c_tvs = 2, 1, 8, 8, 1, 3
+    model = _build_model(n_steps_input, c)
+    batch = Batch(
+        input_fields=torch.randn(batch_size, n_steps_input, w, h, c),
+        output_fields=torch.randn(batch_size, n_steps_input, w, h, c),
+        constant_scalars=None,
+        constant_fields=None,
+        time_varying_scalars=torch.randn(batch_size, 2, c_tvs),
+    )
+    next_inputs = torch.randn(batch_size, n_steps_input, w, h, c)
+    advanced = model._advance_batch(batch, next_inputs, stride=3)
+    assert advanced.time_varying_scalars is not None
+    assert advanced.time_varying_scalars.shape == (batch_size, 0, c_tvs)
+
+
+def test_forward_conditions_on_current_tvs_step():
+    batch_size, n_steps_input, w, h, c, c_tvs = 2, 3, 8, 8, 2, 4
+    model = _build_model(n_steps_input, c)
+    batch = Batch(
+        input_fields=torch.randn(batch_size, n_steps_input, w, h, c),
+        output_fields=torch.randn(batch_size, n_steps_input, w, h, c),
+        constant_scalars=None,
+        constant_fields=None,
+        time_varying_scalars=torch.randn(batch_size, n_steps_input, c_tvs),
+    )
+    _ = model(batch)
+    captured = model.processor.last_global_cond
+    assert captured is not None
+    # n_tvs_steps=1 -> conditioning is the last input step's scalars.
+    assert torch.equal(captured, batch.time_varying_scalars[:, n_steps_input - 1, :])


### PR DESCRIPTION
Adds a time-varying scalars (TVS) channel, end-to-end from datasets through the encoder's global conditioning vector and is correctly sliced during autoregressive rollouts.

## Usage
Provide a `time_varying_scalars` array of shape `(n_trajectories, n_timesteps, n_channels)` in your HDF5 data file alongside the existing data arrays, the dictionary key should be "time_varying_scalars", and set `n_tvs_extra_steps` on the datamodule to at least `autoregressive_train_steps * stride` so rollout always has a fresh slice; the encoder will then automatically concatenate the current TVS slice onto `global_cond` at every step, no model-side changes required.


## Changes
- types: new TensorTC alias; Sample/Batch carry optional time_varying_scalars with collation, repeat(), and to() support.
- data: HDF5Dataset loads per-trajectory time_varying_scalars and stores a window of n_steps_output + n_tvs_extra_steps slices per sample(which I set to 365, this is just to slice long enough TVS so the sequence won't be all consumed during rollout, such parameter needs to exist, to make sure the shape is consistent for all samples); new n_tvs_extra_steps dataset/datamodule parameter so rollout has enough future slices.
- encoders.base: encode_cond appends the current TVS slice to global_cond and raises a clear error if the buffer is exhausted.
- models.encoder_processor_decoder: _clone_batch clones TVS; _advance_batch shifts TVS by stride at every rollout step.
- scripts/setup: expose n_time_varying_scalars in logic_stats.
- scripts/data, benchmarking/inference: TVS-aware device move and synthetic batch construction.

Closes #364.