### PR TITLE
Add multinode Slurm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ core
 .github/copilot-instructions.md
 .agent
 .codex
+.claude

--- a/README.md
+++ b/README.md
@@ -173,11 +173,30 @@ Workdir/chdir behavior:
 - Training configs set `hydra.job.chdir=true`, so script execution runs inside that run directory.
 - Script internals resolve workdir via Hydra runtime output dir (`resolve_hydra_work_dir(...)`), avoiding cwd/path mismatches.
 
-Multi-GPU is supported by passing trainer/Hydra overrides, e.g.:
+Multi-GPU and multi-node SLURM runs are supported through distributed presets
+under `src/autocast/configs/distributed/`:
 ```bash
 uv run autocast epd --mode slurm \
 	datamodule=reaction_diffusion \
-	trainer.devices=4 trainer.strategy=ddp hydra.launcher.gpus_per_node=4
+	+distributed=ddp_4gpu_slurm
+```
+
+For a 2-node, 4-GPU-per-node DDP run:
+```bash
+uv run autocast epd --mode slurm \
+	datamodule=reaction_diffusion \
+	+distributed=ddp_4gpu_2node_slurm
+```
+
+The preset sets both Lightning `trainer.devices`/`trainer.num_nodes` and the
+matching Slurm `hydra.launcher.nodes`/`gpus_per_node`/`tasks_per_node` values.
+Equivalent explicit overrides also work, e.g.:
+```bash
+uv run autocast epd --mode slurm \
+	datamodule=reaction_diffusion \
+	trainer.devices=4 trainer.num_nodes=2 trainer.strategy=ddp \
+	hydra.launcher.nodes=2 hydra.launcher.gpus_per_node=4 \
+	hydra.launcher.tasks_per_node=4
 ```
 
 ### Experiment Tracking with Weights & Biases

--- a/docs/SCRIPTS_AND_CONFIGS.md
+++ b/docs/SCRIPTS_AND_CONFIGS.md
@@ -61,14 +61,23 @@ submission.
 - Mapping rule: config key `X` maps to CLI override `hydra.launcher.X=<value>`
     - `timeout_min` -> `hydra.launcher.timeout_min=...`
     - `cpus_per_task` -> `hydra.launcher.cpus_per_task=...`
+    - `nodes` -> `hydra.launcher.nodes=...`
     - `gpus_per_node` -> `hydra.launcher.gpus_per_node=...`
     - `tasks_per_node` -> `hydra.launcher.tasks_per_node=...`
     - `use_srun` -> `hydra.launcher.use_srun=<true|false>`
     - `additional_parameters.mem` -> `hydra.launcher.additional_parameters.mem=...`
 
 - SLURM launch behavior:
-    - Default is auto: batch script uses `srun` when `tasks_per_node > 1` or `gpus_per_node > 1`.
+    - Default is auto: batch script uses `srun` when `nodes > 1`,
+        `tasks_per_node > 1`, or `gpus_per_node > 1`.
     - Override explicitly with `hydra.launcher.use_srun=true` or `hydra.launcher.use_srun=false`.
+
+- Distributed presets under `src/autocast/configs/distributed/` set both the
+    Lightning runtime and SLURM allocation. For example,
+    `+distributed=ddp_4gpu_2node_slurm` sets `trainer.devices=4`,
+    `trainer.num_nodes=2`, `hydra.launcher.nodes=2`,
+    `hydra.launcher.gpus_per_node=4`, and
+    `hydra.launcher.tasks_per_node=4`.
 
 - For `autocast train-eval` specifically:
     - Positional overrides apply to **train**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "timm>=0.9",
     "torch>=2.9.1",
     "wandb>=0.18.7",
+    "nvidia-ml-py>=13.595.45",
 ]
 
 [project.optional-dependencies]

--- a/slurm_scripts/comparison/ae/submit_ae_multinode_smoke.sh
+++ b/slurm_scripts/comparison/ae/submit_ae_multinode_smoke.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+!/bin/bash
 
 set -euo pipefail
 # Smoke-test multi-node DDP/NCCL with the comparison AE config.
@@ -27,7 +27,7 @@ RUN_ID="${RUN_ID:-ae_multinode_${DATAMODULE}}"
 MAX_EPOCHS="${MAX_EPOCHS:-1}"
 MAX_TIME="${MAX_TIME:-00:00:30:00}"
 TIMEOUT_MIN="${TIMEOUT_MIN:-35}"
-WANDB_ENABLED="${WANDB_ENABLED:-false}"
+WANDB_ENABLED="${WANDB_ENABLED:-true}"
 DRY_RUN="${DRY_RUN:-false}"
 
 dry_run_arg=()
@@ -55,6 +55,6 @@ uv run autocast ae --mode slurm "${dry_run_arg[@]}" \
     local_experiment="${EXPERIMENT}" \
     distributed=ddp_4gpu_2node_slurm \
     logging.wandb.enabled="${WANDB_ENABLED}" \
-    trainer.max_epochs="${MAX_EPOCHS}" \
+    +trainer.max_epochs="${MAX_EPOCHS}" \
     trainer.max_time="${MAX_TIME}" \
     hydra.launcher.timeout_min="${TIMEOUT_MIN}"

--- a/slurm_scripts/comparison/ae/submit_ae_multinode_smoke.sh
+++ b/slurm_scripts/comparison/ae/submit_ae_multinode_smoke.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 
 set -euo pipefail
 # Smoke-test multi-node DDP/NCCL with the comparison AE config.
@@ -24,10 +24,13 @@ if [[ -z "${EXPERIMENT:-}" ]]; then
 fi
 RUN_GROUP="${RUN_GROUP:-$(date +%Y-%m-%d)/multinode_smoke}"
 RUN_ID="${RUN_ID:-ae_multinode_${DATAMODULE}}"
-MAX_EPOCHS="${MAX_EPOCHS:-1}"
-MAX_TIME="${MAX_TIME:-00:00:30:00}"
-TIMEOUT_MIN="${TIMEOUT_MIN:-35}"
+MAX_EPOCHS="${MAX_EPOCHS:-10}"
+MAX_TIME="${MAX_TIME:-00:01:00:00}"
+TIMEOUT_MIN="${TIMEOUT_MIN:-70}"
+NUM_WORKERS="${NUM_WORKERS:-4}"
+CPUS_PER_TASK="${CPUS_PER_TASK:-8}"
 WANDB_ENABLED="${WANDB_ENABLED:-true}"
+LOG_GPU_UTIL="${LOG_GPU_UTIL:-true}"
 DRY_RUN="${DRY_RUN:-false}"
 
 dry_run_arg=()
@@ -44,6 +47,9 @@ echo "  local_experiment: ${EXPERIMENT}"
 echo "  distributed: ddp_4gpu_2node_slurm (2 nodes, 4 GPUs per node)"
 echo "  max_epochs: ${MAX_EPOCHS}"
 echo "  max_time: ${MAX_TIME}"
+echo "  datamodule.num_workers: ${NUM_WORKERS}"
+echo "  cpus_per_task: ${CPUS_PER_TASK}"
+echo "  log_gpu_util: ${LOG_GPU_UTIL} (per-rank GPU util in the SLURM log)"
 echo "  run_group: ${RUN_GROUP}"
 echo "  run_id: ${RUN_ID}"
 echo ""
@@ -55,6 +61,15 @@ uv run autocast ae --mode slurm "${dry_run_arg[@]}" \
     local_experiment="${EXPERIMENT}" \
     distributed=ddp_4gpu_2node_slurm \
     logging.wandb.enabled="${WANDB_ENABLED}" \
+    +log_gpu_util="${LOG_GPU_UTIL}" \
     +trainer.max_epochs="${MAX_EPOCHS}" \
     trainer.max_time="${MAX_TIME}" \
+    datamodule.num_workers="${NUM_WORKERS}" \
+    hydra.launcher.cpus_per_task="${CPUS_PER_TASK}" \
     hydra.launcher.timeout_min="${TIMEOUT_MIN}"
+
+echo ""
+echo "After the job finishes, summarise per-GPU utilization (one line per epoch per rank) with:"
+echo "  grep GpuUtilizationLogCallback <output_dir>/slurm-<jobid>.out | sort"
+echo "Expect MAX_EPOCHS x 8 lines (epoch=N, global_rank=0..7 across 2 hosts);"
+echo "look for high busy(>=80%%) and near-zero idle(<10%%) on every rank/epoch."

--- a/slurm_scripts/comparison/ae/submit_ae_multinode_smoke.sh
+++ b/slurm_scripts/comparison/ae/submit_ae_multinode_smoke.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+# Smoke-test multi-node DDP/NCCL with the comparison AE config.
+#
+# Defaults to one short conditioned_navier_stokes AE run on 2 nodes with
+# 4 GPUs per node via distributed=ddp_4gpu_2node_slurm. Override the shell
+# variables below when a longer run or a different AE dataset is useful.
+
+declare -A EXPERIMENTS=(
+    ["gray_scott"]="ae/gray_scott/ae_dc_large"
+    ["gpe_laser_only_wake"]="ae/gpe_laser_wake_only/ae_dc_large"
+    ["conditioned_navier_stokes"]="ae/conditioned_navier_stokes/ae_dc_large"
+    ["advection_diffusion"]="ae/advection_diffusion/ae_dc_large"
+)
+
+DATAMODULE="${DATAMODULE:-conditioned_navier_stokes}"
+if [[ -z "${EXPERIMENT:-}" ]]; then
+    if [[ -z "${EXPERIMENTS[${DATAMODULE}]+x}" ]]; then
+        echo "Unknown DATAMODULE=${DATAMODULE}; set EXPERIMENT explicitly."
+        exit 1
+    fi
+    EXPERIMENT="${EXPERIMENTS[${DATAMODULE}]}"
+fi
+RUN_GROUP="${RUN_GROUP:-$(date +%Y-%m-%d)/multinode_smoke}"
+RUN_ID="${RUN_ID:-ae_multinode_${DATAMODULE}}"
+MAX_EPOCHS="${MAX_EPOCHS:-1}"
+MAX_TIME="${MAX_TIME:-00:00:30:00}"
+TIMEOUT_MIN="${TIMEOUT_MIN:-35}"
+WANDB_ENABLED="${WANDB_ENABLED:-false}"
+DRY_RUN="${DRY_RUN:-false}"
+
+dry_run_arg=()
+run_label="slurm"
+if [[ "${DRY_RUN}" == "true" ]]; then
+    dry_run_arg=(--dry-run)
+    run_label="slurm --dry-run"
+fi
+
+echo "Submitting multi-node autoencoder smoke test"
+echo "  mode: ${run_label}"
+echo "  datamodule: ${DATAMODULE}"
+echo "  local_experiment: ${EXPERIMENT}"
+echo "  distributed: ddp_4gpu_2node_slurm (2 nodes, 4 GPUs per node)"
+echo "  max_epochs: ${MAX_EPOCHS}"
+echo "  max_time: ${MAX_TIME}"
+echo "  run_group: ${RUN_GROUP}"
+echo "  run_id: ${RUN_ID}"
+echo ""
+
+uv run autocast ae --mode slurm "${dry_run_arg[@]}" \
+    --run-group "${RUN_GROUP}" \
+    --run-id "${RUN_ID}" \
+    datamodule="${DATAMODULE}" \
+    local_experiment="${EXPERIMENT}" \
+    distributed=ddp_4gpu_2node_slurm \
+    logging.wandb.enabled="${WANDB_ENABLED}" \
+    trainer.max_epochs="${MAX_EPOCHS}" \
+    trainer.max_time="${MAX_TIME}" \
+    hydra.launcher.timeout_min="${TIMEOUT_MIN}"

--- a/src/autocast/callbacks/gpu_util.py
+++ b/src/autocast/callbacks/gpu_util.py
@@ -61,11 +61,23 @@ class GpuUtilizationLogCallback(Callback):
         self._thread: threading.Thread | None = None
 
     def _sample_loop(self) -> None:
+        warned = False
         while not self._stop.is_set():
             try:
                 util = torch.cuda.utilization(self._device)
-            except Exception:  # NVML may be unavailable on some drivers/builds.
-                pass
+            except Exception as exc:  # e.g. missing pynvml or NVML init failure.
+                # Log the reason once so an empty summary is self-explaining
+                # rather than a silent "no samples collected".
+                if not warned:
+                    log.warning(
+                        "GpuUtilizationLogCallback[host=%s cuda:%s]: sampling "
+                        "disabled, torch.cuda.utilization failed: %s: %s",
+                        socket.gethostname(),
+                        self._device,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    warned = True
             else:
                 with self._lock:
                     self._samples.append(int(util))

--- a/src/autocast/callbacks/gpu_util.py
+++ b/src/autocast/callbacks/gpu_util.py
@@ -1,0 +1,176 @@
+"""Per-rank GPU-utilization logging for multi-node sanity checks."""
+
+import logging
+import os
+import socket
+import statistics
+import threading
+
+import lightning as L
+import torch
+from lightning.pytorch.callbacks import Callback
+
+log = logging.getLogger(__name__)
+
+
+class GpuUtilizationLogCallback(Callback):
+    """Sample the local rank's GPU utilization and log a per-epoch distribution.
+
+    W&B's built-in system metrics are only collected on the global-rank-0 node,
+    so a multi-node run shows utilization for just that node's GPUs. This
+    callback closes that gap: every DDP rank samples ``torch.cuda.utilization``
+    for *its own* device and logs one summary line **per epoch**, tagged with
+    the global rank and host. Because all ranks log independently into the
+    shared SLURM stdout, the combined log shows utilization for every GPU across
+    every node, broken down by epoch.
+
+    Sampling runs on a background thread at a fixed *wall-clock* cadence rather
+    than on training-loop hooks. Loop hooks (e.g. ``on_train_batch_end``) fire
+    immediately after a batch's compute, which biases the reading high and hides
+    the idle gaps -- such as data-loading stalls -- that a smoke test wants to
+    surface. Wall-clock sampling captures the true duty cycle, including those
+    gaps. The summary reports percentiles and busy/idle fractions, not just a
+    mean, which a few outliers could skew.
+
+    Epoch boundaries follow ``TrainingTimerCallback``: a bucket spans one
+    ``on_train_epoch_start`` to the next (so it includes that epoch's training
+    *and* its validation loop), and the final epoch is closed out in
+    ``on_train_end``.
+
+    ``torch.cuda.utilization`` is an NVML counter read by device index: it
+    launches no GPU kernels, needs no CUDA context in the sampling thread, and
+    makes no collective calls -- so it neither perturbs the measurement nor
+    risks a DDP hang.
+    """
+
+    def __init__(
+        self,
+        sample_interval_s: float = 0.5,
+        busy_threshold: int = 80,
+        idle_threshold: int = 10,
+    ) -> None:
+        self.sample_interval_s = max(0.05, float(sample_interval_s))
+        self.busy_threshold = int(busy_threshold)
+        self.idle_threshold = int(idle_threshold)
+        self._enabled = False
+        self._device: int | None = None
+        self._epoch_index: int | None = None
+        self._lock = threading.Lock()
+        self._samples: list[int] = []
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _sample_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                util = torch.cuda.utilization(self._device)
+            except Exception:  # NVML may be unavailable on some drivers/builds.
+                pass
+            else:
+                with self._lock:
+                    self._samples.append(int(util))
+            # Returns early if stop is set, so shutdown is prompt.
+            self._stop.wait(self.sample_interval_s)
+
+    def _drain_samples(self) -> list[int]:
+        """Atomically take the samples buffered so far and reset it."""
+        with self._lock:
+            samples = self._samples
+            self._samples = []
+        return samples
+
+    def on_train_start(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
+        del trainer, pl_module
+        if not torch.cuda.is_available():
+            log.info(
+                "GpuUtilizationLogCallback[host=%s]: no CUDA device; not sampling",
+                socket.gethostname(),
+            )
+            return
+        self._enabled = True
+        self._device = torch.cuda.current_device()
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._sample_loop, name="gpu-util-sampler", daemon=True
+        )
+        self._thread.start()
+
+    def on_train_epoch_start(
+        self, trainer: L.Trainer, pl_module: L.LightningModule
+    ) -> None:
+        del pl_module
+        if not self._enabled:
+            return
+        # Close out the previous epoch (its training + validation cycle).
+        if self._epoch_index is not None:
+            self._log_epoch(trainer, self._epoch_index)
+        self._epoch_index = getattr(trainer, "current_epoch", 0)
+
+    def on_train_end(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
+        del pl_module
+        if not self._enabled:
+            return
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.sample_interval_s + 2.0)
+        # Close out the final epoch.
+        if self._epoch_index is not None:
+            self._log_epoch(trainer, self._epoch_index)
+
+    def _log_epoch(self, trainer: L.Trainer, epoch: int) -> None:
+        rank = getattr(trainer, "global_rank", 0)
+        local_rank = os.environ.get("LOCAL_RANK", "?")
+        host = socket.gethostname()
+        device = self._device if self._device is not None else 0
+        ordered = sorted(self._drain_samples())
+        if not ordered:
+            log.info(
+                "GpuUtilizationLogCallback[epoch=%d global_rank=%s local_rank=%s "
+                "host=%s cuda:%d]: no samples collected",
+                epoch,
+                rank,
+                local_rank,
+                host,
+                device,
+            )
+            return
+
+        n = len(ordered)
+        mean = sum(ordered) / n
+        p50 = statistics.median(ordered)
+        if n >= 2:
+            # "inclusive" keeps results within [min, max] (no >100% overshoot).
+            deciles = statistics.quantiles(ordered, n=10, method="inclusive")
+            p10, p90 = deciles[0], deciles[8]
+        else:
+            p10 = p90 = float(ordered[0])
+        busy_frac = 100.0 * sum(v >= self.busy_threshold for v in ordered) / n
+        idle_frac = 100.0 * sum(v < self.idle_threshold for v in ordered) / n
+        # Coarse shape: sample counts per 10% utilization bucket (0-10, .., 90-100).
+        hist = [0] * 10
+        for v in ordered:
+            hist[min(v // 10, 9)] += 1
+
+        log.info(
+            "GpuUtilizationLogCallback[epoch=%d global_rank=%s local_rank=%s "
+            "host=%s cuda:%d]: samples=%d mean=%.1f%% p10=%.0f%% p50=%.0f%% "
+            "p90=%.0f%% min=%d%% max=%d%% busy(>=%d%%)=%.1f%% idle(<%d%%)=%.1f%% "
+            "deciles[0-100]=%s",
+            epoch,
+            rank,
+            local_rank,
+            host,
+            device,
+            n,
+            mean,
+            p10,
+            p50,
+            p90,
+            min(ordered),
+            max(ordered),
+            self.busy_threshold,
+            busy_frac,
+            self.idle_threshold,
+            idle_frac,
+            ",".join(str(c) for c in hist),
+        )

--- a/src/autocast/configs/distributed/ddp_4gpu_2node_slurm.yaml
+++ b/src/autocast/configs/distributed/ddp_4gpu_2node_slurm.yaml
@@ -1,0 +1,26 @@
+# @package _global_
+defaults:
+  - override /hydra/launcher: slurm
+  - _self_
+
+trainer:
+  max_time: "00:12:00:00"
+  accelerator: gpu
+  devices: 4
+  strategy: ddp
+  num_nodes: 2
+
+eval:
+  accelerator: auto
+  strategy: ddp
+  devices: 4
+  num_nodes: 2
+
+hydra:
+  launcher:
+    nodes: 2
+    gpus_per_node: 4
+    tasks_per_node: 4
+    additional_parameters:
+      # Since each process is bound to a GPU, avoid requesting CPU memory per GPU.
+      mem: 0

--- a/src/autocast/configs/eval/README.md
+++ b/src/autocast/configs/eval/README.md
@@ -85,6 +85,9 @@ multi-GPU explicitly (or via a distributed preset):
 # 4-GPU evaluation via the distributed config
 autocast eval +distributed=ddp_4gpu_slurm eval.checkpoint=path/to/model.ckpt
 
+# 2-node, 4-GPU-per-node evaluation
+autocast eval +distributed=ddp_4gpu_2node_slurm eval.checkpoint=path/to/model.ckpt
+
 # Explicit GPU count override
 autocast eval eval.devices=4 eval.checkpoint=path/to/model.ckpt
 ```

--- a/src/autocast/configs/eval/default.yaml
+++ b/src/autocast/configs/eval/default.yaml
@@ -65,7 +65,9 @@ rollout_snapshot_dataset_label: null  # optional label for data-only snapshot ro
 
 # Accelerator for evaluation (mirrors Lightning Fabric API)
 accelerator: auto  # auto, cpu, cuda, or mps
+strategy: auto
 devices: 1 # default single-GPU eval; override with int (e.g. 4) for multi-GPU DDP
+num_nodes: 1
 
 # Rollout settings
 max_rollout_steps: 10

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -2012,8 +2012,15 @@ def run_evaluation(cfg: DictConfig, work_dir: Path | None = None) -> None:  # no
             "using eval.accelerator=%s.",
             accelerator,
         )
+    strategy = eval_cfg.get("strategy", "auto")
     devices = eval_cfg.get("devices", 1)
-    fabric = L.Fabric(accelerator=accelerator, devices=devices)
+    num_nodes = eval_cfg.get("num_nodes", 1)
+    fabric = L.Fabric(
+        accelerator=accelerator,
+        strategy=strategy,
+        devices=devices,
+        num_nodes=num_nodes,
+    )
     fabric.launch()
 
     # Setup model and loader with Fabric

--- a/src/autocast/scripts/training.py
+++ b/src/autocast/scripts/training.py
@@ -14,6 +14,7 @@ from lightning.pytorch.callbacks import Callback, ModelCheckpoint, Timer
 from matplotlib import pyplot as plt
 from omegaconf import DictConfig, OmegaConf
 
+from autocast.callbacks.gpu_util import GpuUtilizationLogCallback
 from autocast.data.datamodule import SpatioTemporalDataModule, TheWellDataModule
 from autocast.logging import create_wandb_logger
 from autocast.logging.wandb import maybe_watch_model
@@ -598,6 +599,10 @@ def train_autoencoder(
         trainer_cfg, logger=wandb_logger, default_root_dir=str(work_dir)
     )
     trainer.callbacks.append(TrainingTimerCallback())
+    if config.get("log_gpu_util", False):
+        # Diagnostic only (e.g. multi-node smoke tests): each rank logs its own
+        # GPU utilization, so the combined SLURM log covers every GPU/node.
+        trainer.callbacks.append(GpuUtilizationLogCallback())
     output_cfg = config.get("output", {})
     if output_cfg.get("save_config", False) and trainer.is_global_zero:
         save_resolved_config(

--- a/src/autocast/scripts/training.py
+++ b/src/autocast/scripts/training.py
@@ -367,6 +367,17 @@ class TrainingTimerCallback(Callback):
         self._epoch_times_s = list(state_dict.get("epoch_times_s", []))
 
 
+def _gpu_util_callbacks(config: DictConfig) -> list[Callback]:
+    """Return a per-rank GPU-utilization logger if ``log_gpu_util`` is set.
+
+    Diagnostic only (e.g. multi-node smoke tests): each rank logs its own GPU
+    utilization, so the combined SLURM log covers every GPU across every node.
+    """
+    if config.get("log_gpu_util", False):
+        return [GpuUtilizationLogCallback()]
+    return []
+
+
 def run_training(
     config: DictConfig,
     model: L.LightningModule,
@@ -425,8 +436,11 @@ def run_training(
         ):
             callback.setdefault("save_last", "link")
 
-    callbacks.append(CheckpointAliasSymlinkCallback(checkpoint_path))
-    callbacks.append(TrainingTimerCallback())
+    callbacks += [
+        CheckpointAliasSymlinkCallback(checkpoint_path),
+        TrainingTimerCallback(),
+        *_gpu_util_callbacks(config),
+    ]
     trainer_cfg["callbacks"] = callbacks
 
     trainer = instantiate(
@@ -599,10 +613,7 @@ def train_autoencoder(
         trainer_cfg, logger=wandb_logger, default_root_dir=str(work_dir)
     )
     trainer.callbacks.append(TrainingTimerCallback())
-    if config.get("log_gpu_util", False):
-        # Diagnostic only (e.g. multi-node smoke tests): each rank logs its own
-        # GPU utilization, so the combined SLURM log covers every GPU/node.
-        trainer.callbacks.append(GpuUtilizationLogCallback())
+    trainer.callbacks.extend(_gpu_util_callbacks(config))
     output_cfg = config.get("output", {})
     if output_cfg.get("save_config", False) and trainer.is_global_zero:
         save_resolved_config(

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -41,6 +41,25 @@ def _parse_override_scalar(value: str) -> int | str | bool:
     return int(stripped) if stripped.isdigit() else stripped
 
 
+def _as_positive_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return 0
+    return parsed if parsed > 0 else 0
+
+
+def _launcher_positive_int(launcher_cfg: dict, key: str) -> int:
+    value = launcher_cfg.get(key)
+    if value is None:
+        additional_parameters = launcher_cfg.get("additional_parameters", {})
+        if isinstance(additional_parameters, dict):
+            value = additional_parameters.get(key)
+    return _as_positive_int(value)
+
+
 def _nested_set(target: dict, dotted_key: str, value: int | str | bool) -> None:
     parts = dotted_key.split(".")
     current = target
@@ -123,13 +142,40 @@ def _extract_distributed_preset_name(
     return None
 
 
+def _extract_distributed_override_name(overrides: list[str]) -> str | None:
+    for override in reversed(overrides):
+        norm = normalized_override(override)
+        if norm.startswith(("distributed=", "/distributed=")):
+            value = norm.split("=", 1)[1].strip()
+            return value or None
+    return None
+
+
 def _load_distributed_cfg(name: str) -> dict:
     cfg_root = Path(__file__).resolve().parents[2] / "configs"
-    path = cfg_root / "distributed" / f"{name}.yaml"
-    if not path.exists():
+    candidate_paths = [
+        cfg_root / "distributed" / f"{name}.yaml",
+        Path.cwd() / "local_hydra" / "distributed" / f"{name}.yaml",
+    ]
+    external_config_root = os.environ.get("AUTOCAST_CONFIG_PATH")
+    if external_config_root:
+        candidate_paths.append(
+            Path(external_config_root) / "distributed" / f"{name}.yaml"
+        )
+    for path in candidate_paths:
+        if not path.exists():
+            continue
+        loaded = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
+        return loaded if isinstance(loaded, dict) else {}
+    return {}
+
+
+def _extract_launcher_cfg(cfg: dict) -> dict:
+    hydra_cfg = cfg.get("hydra")
+    if not isinstance(hydra_cfg, dict):
         return {}
-    loaded = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
-    return loaded if isinstance(loaded, dict) else {}
+    launcher_cfg = hydra_cfg.get("launcher")
+    return launcher_cfg if isinstance(launcher_cfg, dict) else {}
 
 
 def _load_launcher_from_file(path: Path) -> dict:
@@ -150,11 +196,14 @@ def _load_launcher_from_file(path: Path) -> dict:
         cfg = raw
     if not isinstance(cfg, dict):
         return {}
-    hydra_cfg = cfg.get("hydra")
-    if not isinstance(hydra_cfg, dict):
+    return _extract_launcher_cfg(cfg)
+
+
+def _load_direct_distributed_launcher_cfg(overrides: list[str]) -> dict:
+    distributed = _extract_distributed_override_name(overrides)
+    if distributed is None:
         return {}
-    launcher_cfg = hydra_cfg.get("launcher")
-    return launcher_cfg if isinstance(launcher_cfg, dict) else {}
+    return _extract_launcher_cfg(_load_distributed_cfg(distributed))
 
 
 def _load_preset_launcher_cfg(overrides: list[str]) -> dict:
@@ -205,11 +254,13 @@ def _resolve_launcher_submission_context(
         overrides
     )
     preset_launcher_cfg = _load_preset_launcher_cfg(overrides)
+    direct_distributed_launcher_cfg = _load_direct_distributed_launcher_cfg(overrides)
     launcher_cfg = load_launcher_defaults(launcher_name)
     merged_launcher_cfg = OmegaConf.to_container(
         OmegaConf.merge(
             launcher_cfg,
             preset_launcher_cfg,
+            direct_distributed_launcher_cfg,
             launcher_override_cfg,
         ),
         resolve=True,
@@ -294,18 +345,11 @@ def _should_use_srun(launcher_cfg: dict) -> bool:
         if lowered in {"false", "0", "no", "off"}:
             return False
 
-    def _as_positive_int(value: object) -> int:
-        if isinstance(value, bool):
-            return int(value)
-        try:
-            parsed = int(str(value).strip())
-        except (TypeError, ValueError):
-            return 0
-        return parsed if parsed > 0 else 0
-
-    tasks_per_node = _as_positive_int(launcher_cfg.get("tasks_per_node"))
-    gpus_per_node = _as_positive_int(launcher_cfg.get("gpus_per_node"))
-    return tasks_per_node > 1 or gpus_per_node > 1
+    nodes = _launcher_positive_int(launcher_cfg, "nodes")
+    tasks_per_node = _launcher_positive_int(launcher_cfg, "tasks_per_node")
+    gpus_per_node = _launcher_positive_int(launcher_cfg, "gpus_per_node")
+    ntasks = _launcher_positive_int(launcher_cfg, "ntasks")
+    return nodes > 1 or tasks_per_node > 1 or gpus_per_node > 1 or ntasks > 1
 
 
 def _build_sbatch_command(
@@ -328,19 +372,25 @@ def _build_sbatch_command(
     if formatted_time is not None:
         sbatch_cmd.append(f"--time={formatted_time}")
 
-    for cfg_key, sbatch_flag in [
+    mapped_sbatch_flags = [
+        ("nodes", "nodes"),
         ("cpus_per_task", "cpus-per-task"),
         ("gpus_per_node", "gpus-per-node"),
         ("tasks_per_node", "ntasks-per-node"),
         ("partition", "partition"),
-    ]:
+    ]
+    handled_additional_keys: set[str] = set()
+    for cfg_key, sbatch_flag in mapped_sbatch_flags:
         val = launcher_cfg.get(cfg_key)
         if val is not None:
             sbatch_cmd.append(f"--{sbatch_flag}={val}")
+            handled_additional_keys.add(cfg_key)
 
     additional_parameters = launcher_cfg.get("additional_parameters", {})
     if isinstance(additional_parameters, dict):
         for key, value in additional_parameters.items():
+            if key in handled_additional_keys:
+                continue
             sbatch_cmd.append(f"--{key}={value}")
 
     sbatch_cmd.append(str(batch_script_path))
@@ -564,9 +614,15 @@ def submit_manifest_via_sbatch(
 
     launcher_name, launcher_override_cfg, _ = extract_launcher_overrides(overrides)
     preset_launcher_cfg = _load_preset_launcher_cfg(overrides)
+    direct_distributed_launcher_cfg = _load_direct_distributed_launcher_cfg(overrides)
     launcher_cfg = load_launcher_defaults(launcher_name)
     merged_launcher_cfg = OmegaConf.to_container(
-        OmegaConf.merge(launcher_cfg, preset_launcher_cfg, launcher_override_cfg),
+        OmegaConf.merge(
+            launcher_cfg,
+            preset_launcher_cfg,
+            direct_distributed_launcher_cfg,
+            launcher_override_cfg,
+        ),
         resolve=True,
     )
     if not isinstance(merged_launcher_cfg, dict):

--- a/tests/scripts/test_config_integration.py
+++ b/tests/scripts/test_config_integration.py
@@ -22,10 +22,12 @@ def config_dir(REPO_ROOT: Path) -> str:
     return str(REPO_ROOT / "src" / "autocast" / "configs")
 
 
-def _load_config(config_dir: str, config_name: str) -> DictConfig:
+def _load_config(
+    config_dir: str, config_name: str, overrides: list[str] | None = None
+) -> DictConfig:
     """Load a config by name."""
     with initialize_config_dir(version_base=None, config_dir=config_dir):
-        return compose(config_name=config_name)
+        return compose(config_name=config_name, overrides=overrides or [])
 
 
 # --- Parametrized tests over top-level configs ---
@@ -47,6 +49,18 @@ def test_top_level_config_has_trainer(config_dir: str, config_name: str):
     """Verify top-level configs have trainer section."""
     cfg = _load_config(config_dir, config_name)
     assert "trainer" in cfg
+
+
+def test_multinode_distributed_config_sets_trainer_nodes(config_dir: str):
+    cfg = _load_config(
+        config_dir,
+        "encoder_processor_decoder",
+        overrides=["+distributed=ddp_4gpu_2node_slurm"],
+    )
+
+    assert cfg.trainer.devices == 4
+    assert cfg.trainer.num_nodes == 2
+    assert cfg.trainer.strategy == "ddp"
 
 
 # --- Parametrized tests over component configs ---

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -42,6 +42,8 @@ from autocast.scripts.workflow.overrides import (
     strip_hydra_sweep_controls,
 )
 from autocast.scripts.workflow.slurm import (
+    _build_sbatch_command,
+    _load_direct_distributed_launcher_cfg,
     _load_preset_launcher_cfg,
     _parse_override_scalar,
     _should_use_srun,
@@ -172,6 +174,14 @@ def test_should_use_srun_auto_for_multi_task_or_gpu():
     assert _should_use_srun({"tasks_per_node": 1, "gpus_per_node": 2}) is True
 
 
+def test_should_use_srun_auto_for_multinode():
+    assert _should_use_srun({"nodes": 2, "tasks_per_node": 1}) is True
+    assert (
+        _should_use_srun({"additional_parameters": {"nodes": 2}, "tasks_per_node": 1})
+        is True
+    )
+
+
 def test_should_use_srun_auto_false_for_single_task_single_gpu():
     assert _should_use_srun({"tasks_per_node": 1, "gpus_per_node": 1}) is False
 
@@ -185,6 +195,27 @@ def test_should_use_srun_respects_explicit_override():
         _should_use_srun({"tasks_per_node": 2, "gpus_per_node": 2, "use_srun": False})
         is False
     )
+
+
+def test_build_sbatch_command_includes_nodes(tmp_path: Path):
+    batch_script = tmp_path / "submit.sh"
+    cmd = _build_sbatch_command(
+        job_name="autocast-test",
+        log_dir=tmp_path,
+        launcher_cfg={
+            "nodes": 2,
+            "gpus_per_node": 4,
+            "tasks_per_node": 4,
+            "additional_parameters": {"mem": 0, "nodes": 99},
+        },
+        batch_script_path=batch_script,
+    )
+
+    assert "--nodes=2" in cmd
+    assert "--gpus-per-node=4" in cmd
+    assert "--ntasks-per-node=4" in cmd
+    assert "--mem=0" in cmd
+    assert "--nodes=99" not in cmd
 
 
 def test_load_preset_launcher_cfg_ignores_unrelated_interpolation(
@@ -249,6 +280,16 @@ def test_load_preset_launcher_cfg_walks_local_experiment_parent_chain(
     monkeypatch.chdir(tmp_path)
     launcher_cfg = _load_preset_launcher_cfg(["local_experiment=child"])
 
+    assert launcher_cfg.get("gpus_per_node") == 4
+    assert launcher_cfg.get("tasks_per_node") == 4
+
+
+def test_load_direct_distributed_launcher_cfg_supports_multinode():
+    launcher_cfg = _load_direct_distributed_launcher_cfg(
+        ["+distributed=ddp_4gpu_2node_slurm"]
+    )
+
+    assert launcher_cfg.get("nodes") == 2
     assert launcher_cfg.get("gpus_per_node") == 4
     assert launcher_cfg.get("tasks_per_node") == 4
 

--- a/uv.lock
+++ b/uv.lock
@@ -183,6 +183,7 @@ dependencies = [
     { name = "jaxtyping" },
     { name = "lightning" },
     { name = "neuraloperator" },
+    { name = "nvidia-ml-py" },
     { name = "the-well" },
     { name = "timm" },
     { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
@@ -213,6 +214,7 @@ requires-dist = [
     { name = "jaxtyping", specifier = ">=0.3.3" },
     { name = "lightning", specifier = ">=2.5.6" },
     { name = "neuraloperator", specifier = ">=2.0.0" },
+    { name = "nvidia-ml-py", specifier = ">=13.595.45" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.4.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.407" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
@@ -1559,6 +1561,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-ml-py"
+version = "13.595.45"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/49/c29f6e30d8662d2e94fef17739ea7309cc76aba269922ae999e4cc07f268/nvidia_ml_py-13.595.45.tar.gz", hash = "sha256:c9f34897fe0441ff35bc8f35baf80f830a20b0f4e6ce71e0a325bc0e66acf079", size = 50780, upload-time = "2026-03-19T16:59:44.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/24/fc256107d23597fa33d319505ce77160fa1a2349c096d01901ffc7cb7fc4/nvidia_ml_py-13.595.45-py3-none-any.whl", hash = "sha256:b65a7977f503d56154b14d683710125ef93594adb63fbf7e559336e3318f1376", size = 51776, upload-time = "2026-03-19T16:59:43.603Z" },
+]
+
+[[package]]
 name = "nvidia-nccl-cu12"
 version = "2.27.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2567,12 +2578,12 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3a5fb967ffb53ffa0d2579c9819491cfc36c557040de6fdeabcfcfb45df019bc" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a9a9ba3b2baf23c044499ffbcbed88e04b6e38b94189c7dc42dd2cfcdd8c55c0" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:4749cd32e32ed55179ff2ff0407e0ae5077fe4d332bfa49258f4578d09eccb40" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:81264238b3d8840276dd30c31f393e325b8f5da6390d18ac2a80dacecfd693ea" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2a7a569206f07965eff69b28e147676540bb0ba6e1a39410802b6e4708cb8356" },
-    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:95d8409b8a15191de4c2958e86ca47f3ea8f9739b994ee4ca0e7586f37336413" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3a5fb967ffb53ffa0d2579c9819491cfc36c557040de6fdeabcfcfb45df019bc", upload-time = "2026-01-21T19:34:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a9a9ba3b2baf23c044499ffbcbed88e04b6e38b94189c7dc42dd2cfcdd8c55c0", upload-time = "2026-01-21T19:34:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp311-cp311-win_amd64.whl", hash = "sha256:4749cd32e32ed55179ff2ff0407e0ae5077fe4d332bfa49258f4578d09eccb40", upload-time = "2026-01-21T19:34:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:81264238b3d8840276dd30c31f393e325b8f5da6390d18ac2a80dacecfd693ea", upload-time = "2026-01-21T19:34:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2a7a569206f07965eff69b28e147676540bb0ba6e1a39410802b6e4708cb8356", upload-time = "2026-01-21T19:34:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu126/torch-2.10.0%2Bcu126-cp312-cp312-win_amd64.whl", hash = "sha256:95d8409b8a15191de4c2958e86ca47f3ea8f9739b994ee4ca0e7586f37336413", upload-time = "2026-01-21T19:34:42Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #361.

## Summary

- Add `ddp_4gpu_2node_slurm` distributed preset (2 nodes × 4 GPUs, DDP) that
  keeps Lightning `trainer`/`eval` settings and Slurm `hydra.launcher` allocation
  in sync.
- Extend Slurm workflow so `+distributed=...` presets are picked up for
  submission (nodes, gpus/tasks per node, `mem` in `additional_parameters`), and
  multi-node jobs use `srun` automatically.
- Add `GpuUtilizationLogCallback` and `+log_gpu_util=true` so every DDP rank
  logs per-epoch GPU utilization to the shared Slurm stdout (useful when W&B
  system metrics only cover rank-0's node).
- Add `slurm_scripts/comparison/ae/submit_ae_multinode_smoke.sh` for a short
  multi-node AE smoke test; document distributed presets in README and
  `docs/SCRIPTS_AND_CONFIGS.md`.

## Test plan

- [x] `uv run pytest tests/scripts/test_workflow.py tests/scripts/test_config_integration.py`
- [x] Dry-run smoke submit: `DRY_RUN=true ./slurm_scripts/comparison/ae/submit_ae_multinode_smoke.sh`
      and confirm sbatch uses `--nodes=2`, `--gpus-per-node=4`, `--ntasks-per-node=4`, and `srun`.
- [x] On cluster: run the smoke script (default ~10 epochs, 2×4 GPUs) and verify
      training completes across both nodes.
- [x] After the job: `grep GpuUtilizationLogCallback <output_dir>/slurm-<jobid>.out | sort`
      — expect `MAX_EPOCHS × 8` lines (one per epoch per global rank); busy ≥80%,
      idle <10% on all ranks.