### PR TITLE
add ++ to suggested overrides

### DIFF
--- a/src/autocast/scripts/workflow/commands.py
+++ b/src/autocast/scripts/workflow/commands.py
@@ -1023,9 +1023,9 @@ def _print_timing_results(
     print(f"{'=' * 60}")
     print("\nRecommended overrides:")
     print(
-        f"  +trainer.max_epochs={result['max_epochs']} "
-        f"trainer.max_time={max_time_str} "
-        f"optimizer=adamw_half"
+        f"  ++trainer.max_epochs={result['max_epochs']} "
+        f"++trainer.max_time={max_time_str} "
+        f"++optimizer=adamw_half"
     )
     return result
 

--- a/src/autocast/scripts/workflow/commands.py
+++ b/src/autocast/scripts/workflow/commands.py
@@ -1023,7 +1023,7 @@ def _print_timing_results(
     print(f"{'=' * 60}")
     print("\nRecommended overrides:")
     print(
-        f"  trainer.max_epochs={result['max_epochs']} "
+        f"  +trainer.max_epochs={result['max_epochs']} "
         f"trainer.max_time={max_time_str} "
         f"optimizer=adamw_half"
     )


### PR DESCRIPTION
Since I had a run fail because `trainer.max_epochs` wasn't already a key, I figured I'd just update these suggested overrides to use `++` which ensures that regardless of whether it already exists as part of the config its value will be used. Probably useful for new users and/or LLMs (or maybe the venn diagram of that is a circle, idk).