### PR TITLE
Fix post-fit NCCL watchdog hang on multi-GPU DDP runs (#381)

### DIFF
--- a/src/autocast/scripts/training.py
+++ b/src/autocast/scripts/training.py
@@ -126,9 +126,20 @@ def _link_checkpoint_target_to_latest(trainer: L.Trainer, target_path: Path) -> 
 
 
 def _save_or_link_checkpoint_target(trainer: L.Trainer, target_path: Path) -> None:
-    if not _link_checkpoint_target_to_latest(trainer, target_path):
+    # Linking the alias to the latest callback checkpoint is a rank-0-only
+    # filesystem op, but the fallback ``trainer.save_checkpoint`` is collective
+    # (it ends in a strategy barrier) and must run on every rank. Decide on
+    # rank 0 and broadcast, so all ranks agree whether to take the collective
+    # save path (otherwise non-zero ranks miss the barrier; see #381).
+    linked = trainer.is_global_zero and _link_checkpoint_target_to_latest(
+        trainer, target_path
+    )
+    if trainer.strategy.broadcast(linked):
+        return
+    if trainer.is_global_zero:
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        trainer.save_checkpoint(target_path)
+    trainer.save_checkpoint(target_path)
+    if trainer.is_global_zero:
         log.info("Saved checkpoint to %s", target_path.resolve())
 
 
@@ -505,13 +516,24 @@ def run_training(
 
     # Save stable checkpoint target (prefer callback checkpoint) immediately
     # after fit so a checkpoint exists even if optional test later fails.
-    if trainer.is_global_zero:
-        _save_or_link_checkpoint_target(trainer, checkpoint_path)
+    #
+    # ``trainer.save_checkpoint`` is a collective operation: it ends in a
+    # ``strategy.barrier()``, so it must be invoked on *every* rank. Only the
+    # alias bookkeeping (symlink/unlink) is rank-0-only.
+    # Calling it under ``if trainer.is_global_zero`` left non-zero ranks out of
+    # that barrier and hung large DDP runs at the NCCL watchdog timeout (#381).
+    _save_or_link_checkpoint_target(trainer, checkpoint_path)
 
-        # If the stable target is a symlink, replace with a final concrete checkpoint.
-        if checkpoint_path.is_symlink():
+    # If the stable target is a symlink, replace it with a final concrete
+    # checkpoint. The symlink check + unlink are rank-0 filesystem ops; broadcast
+    # the decision so the collective save runs on all ranks together.
+    replace_symlink = trainer.strategy.broadcast(
+        trainer.is_global_zero and checkpoint_path.is_symlink()
+    )
+    if replace_symlink:
+        if trainer.is_global_zero:
             checkpoint_path.unlink()
-            trainer.save_checkpoint(checkpoint_path)
+        trainer.save_checkpoint(checkpoint_path)
 
     # Ensure non-zero ranks observe the finalized checkpoint before test.
     trainer.strategy.barrier("checkpoint-alias-finalize")
@@ -672,10 +694,13 @@ def train_autoencoder(
         output_cfg.get("checkpoint_path"),
         default_name="autoencoder.ckpt",
     )
+    # ``trainer.save_checkpoint`` is collective (it ends in a strategy barrier)
+    # and must run on every rank; the log line and reconstruction plots are
+    # rank-0-only. Guarding the save under ``is_global_zero`` left non-zero ranks
+    # out of that barrier and hung DDP runs at the NCCL watchdog timeout (#381).
+    trainer.save_checkpoint(checkpoint_path)
     if trainer.is_global_zero:
-        trainer.save_checkpoint(checkpoint_path)
         log.info("Saved checkpoint to %s", checkpoint_path.resolve())
-
         _save_reconstructions(model, datamodule, work_dir)
 
     trainer.strategy.barrier("autoencoder-post-training-finalize")


### PR DESCRIPTION
Closes #381.

## Symptom

On multi-GPU (`strategy=ddp`, ≥2 GPUs) training runs, training completes
normally (`max_epochs`/`max_time` reached, checkpoints written), then the job
is killed at the NCCL watchdog timeout (~30 min later) with a single-element
`ALLREDUCE` collective timeout on rank 0. All in-fit checkpoints are saved
before the hang, so results survive, but the job exits `FAILED`, burns the
watchdog window, and drops a large core file. Observed on independent runs
across several datasets.

## Root cause

`trainer.save_checkpoint()` is a **collective** operation — it ends in a
`strategy.barrier()`, which every rank must enter. In `run_training` (and
`train_autoencoder`) it was called inside an `if trainer.is_global_zero:`
block, so **only rank 0 entered that barrier**.

That desynchronises the post-`fit()` collective stream:

- rank 0: `save_checkpoint` barrier → `checkpoint-alias-finalize` barrier
- other ranks: `checkpoint-alias-finalize` barrier only

NCCL matches collectives by sequence number, not by name, so rank 0's
`save_checkpoint` barrier pairs with the other ranks' `checkpoint-alias-finalize`
barrier and completes; rank 0 then posts its own `checkpoint-alias-finalize`
barrier with no partner and hangs until the watchdog fires. Because the block
runs once, at the end of `fit()`, the run trains cleanly for hundreds of epochs
and only hangs at teardown.

## Fix

Move the collective `trainer.save_checkpoint()` calls out of the
`is_global_zero` guards so every rank participates in the internal barrier.
Keep the genuinely rank-0-only work (alias symlink/unlink, log lines,
reconstruction plots) guarded, and broadcast the save/skip decision from rank 0
so all ranks agree — mirroring `ModelCheckpoint`, which broadcasts its
checkpoint decision "to avoid possible hangs".

Three call sites in `src/autocast/scripts/training.py`:

- `_save_or_link_checkpoint_target` — link on rank 0, broadcast the result, run the fallback save on all ranks.
- `run_training` — `_save_or_link_checkpoint_target` and the symlink-replacement save now run on all ranks (decision broadcast); symlink/unlink stay rank-0.
- `train_autoencoder` — `save_checkpoint` on all ranks; log + reconstructions stay rank-0.

No behaviour change on single-device runs (`strategy.barrier`/`broadcast` are
no-ops there); checkpoint contents and alias semantics are unchanged.

## Validation

- Root-caused from the watchdog signature plus the fact that a failing run with
  `val_metrics=[]` and W&B disabled still hung — ruling out metric/logger/
  callback collectives and pointing at the checkpoint barrier.
- Confirmed with a minimal 2-GPU DDP repro (AD16, `max_epochs=1`, short
  process-group timeout). On **unfixed** code, training reaches `fit()` end
  cleanly, then the job fails at the post-fit barrier:

  ```
  ... TrainingTimerCallback: epochs=1 ...        # training finished
  trainer.strategy.barrier("checkpoint-alias-finalize")
  RuntimeError: [Rank 0]: Ranks 1 failed to pass monitoredBarrier in 120000 ms
  ```

  i.e. rank 0 advanced one barrier ahead (the rank-0-only `save_checkpoint`
  barrier) and rank 1 never reached `checkpoint-alias-finalize` — exactly the
  off-by-one above. Reproduced with `val_metrics=[]` and W&B disabled,
  confirming it is independent of metrics/logging.
- **Draft pending** the equivalent fixed-code run on the same config (expected
  to reach `fit()` end cleanly); will mark ready for review once attached.

## Testing

The repo has no multi-process DDP test harness (all `tests/` run single-process
`cpu/devices=1`), and the bug is in a multi-rank barrier path, so it can't be
reproduced single-process. Validated manually on 2 GPUs (above). Happy to add a
CPU/gloo 2-rank regression test (asserting `run_training` reaches `fit()` end
without a collective desync) if maintainers want one — flagging it since it
would be the first DDP test in the suite.
