### PR TITLE
Surface + document optimizer/trainer defaults (opt-in) + fractional warmup

### DIFF
--- a/src/autocast/configs/optimizer/adam.yaml
+++ b/src/autocast/configs/optimizer/adam.yaml
@@ -4,4 +4,3 @@ betas: [0.9, 0.999]
 learning_rate: 1e-4
 weight_decay: 0.0
 scheduler: null
-grad_clip: null

--- a/src/autocast/configs/optimizer/adamw.yaml
+++ b/src/autocast/configs/optimizer/adamw.yaml
@@ -2,13 +2,14 @@ name: "${.optimizer}_${.learning_rate}_${.scheduler}"
 optimizer: "adamw"
 betas: [0.9, 0.99]
 learning_rate: 1e-4
-# 0.01 is a conservative default for the field-regression regime here; the
-# textbook ViT-classification value (0.05) tends to over-regularise. Tune per
-# experiment. NB: applied uniformly (no no-decay groups for biases/norms yet).
-weight_decay: 0.01
+# Default 0.0 for reproducibility with existing runs. Recommended starting
+# point for this field-regression regime is 0.01 (the textbook ViT-classification
+# 0.05 tends to over-regularise); set per experiment. NB: when enabled it is
+# applied uniformly (no no-decay groups for biases/norms yet).
+weight_decay: 0.0
 # Warmup: integer = absolute steps/epochs; float in (0, 1) = fraction of the
-# cosine horizon. 0.05 = 5% of total horizon.
-warmup: 0.05
+# cosine horizon. Default 0 for reproducibility; recommended 0.05 (5% of horizon).
+warmup: 0
 scheduler: "cosine"
 # Optional scheduler controls:
 # scheduler_interval: "epoch"     # "epoch" or "step"

--- a/src/autocast/configs/optimizer/adamw.yaml
+++ b/src/autocast/configs/optimizer/adamw.yaml
@@ -2,13 +2,11 @@ name: "${.optimizer}_${.learning_rate}_${.scheduler}"
 optimizer: "adamw"
 betas: [0.9, 0.99]
 learning_rate: 1e-4
-# Default 0.0 for reproducibility with existing runs. Recommended starting
-# point for this field-regression regime is 0.01 (the textbook ViT-classification
-# 0.05 tends to over-regularise); set per experiment. NB: when enabled it is
-# applied uniformly (no no-decay groups for biases/norms yet).
+# Defaults preserve reproducibility with existing runs. For tuned starting
+# points (weight_decay, warmup) opt in with optimizer=updated_defaults/adamw.
 weight_decay: 0.0
 # Warmup: integer = absolute steps/epochs; float in (0, 1) = fraction of the
-# cosine horizon. Default 0 for reproducibility; recommended 0.05 (5% of horizon).
+# cosine horizon.
 warmup: 0
 scheduler: "cosine"
 # Optional scheduler controls:

--- a/src/autocast/configs/optimizer/adamw.yaml
+++ b/src/autocast/configs/optimizer/adamw.yaml
@@ -2,8 +2,13 @@ name: "${.optimizer}_${.learning_rate}_${.scheduler}"
 optimizer: "adamw"
 betas: [0.9, 0.99]
 learning_rate: 1e-4
-weight_decay: 0.0
-warmup: 0
+# 0.01 is a conservative default for the field-regression regime here; the
+# textbook ViT-classification value (0.05) tends to over-regularise. Tune per
+# experiment. NB: applied uniformly (no no-decay groups for biases/norms yet).
+weight_decay: 0.01
+# Warmup: integer = absolute steps/epochs; float in (0, 1) = fraction of the
+# cosine horizon. 0.05 = 5% of total horizon.
+warmup: 0.05
 scheduler: "cosine"
 # Optional scheduler controls:
 # scheduler_interval: "epoch"     # "epoch" or "step"
@@ -16,4 +21,3 @@ scheduler: "cosine"
 # 3) cosine_t_max
 # min_lr_ratio: 0.0                # Final LR ratio in [0, 1]
 # scheduler: "cosine_with_restarts"
-grad_clip: 1

--- a/src/autocast/configs/optimizer/adamw_half.yaml
+++ b/src/autocast/configs/optimizer/adamw_half.yaml
@@ -3,6 +3,8 @@ name: "${.optimizer}_${.learning_rate}_${.scheduler}_half"
 optimizer: "adamw"
 betas: [0.9, 0.99]
 learning_rate: 1e-4
+# LOLA-faithful: 0.0 weight decay, no warmup (see header). Gradient clipping
+# matching LOLA's grad_clip=1 comes from trainer.gradient_clip_val=1.0.
 weight_decay: 0.0
 scheduler: "cosine"
 
@@ -19,6 +21,8 @@ cosine_epochs: ${trainer.max_epochs}
 # interpolation is unavailable.
 cosine_t_max: 130
 
+# Warmup: integer = absolute steps/epochs; float in (0, 1) = fraction of the
+# cosine horizon. LOLA-faithful default is 0 (no warmup); use cold_lr_lambda
+# semantics above by overriding to a positive value when a cold start is wanted.
 warmup: 0
 min_lr_ratio: 0.0
-grad_clip: 1

--- a/src/autocast/configs/optimizer/psgd.yaml
+++ b/src/autocast/configs/optimizer/psgd.yaml
@@ -9,4 +9,3 @@ learning_rate: 1e-4
 weight_decay: 0.0
 warmup: 0
 scheduler: "cosine"
-grad_clip: 1.0

--- a/src/autocast/configs/optimizer/updated_defaults/adamw.yaml
+++ b/src/autocast/configs/optimizer/updated_defaults/adamw.yaml
@@ -7,16 +7,21 @@ name: "${.optimizer}_${.learning_rate}_${.scheduler}"
 optimizer: "adamw"
 betas: [0.9, 0.99]
 learning_rate: 1e-4
-# Decoupled weight decay for AdamW (Loshchilov & Hutter, ICLR 2019,
-# arXiv:1711.05101). 0.01 is conservative for this field-regression regime; the
-# textbook ViT-classification value (0.05) tends to over-regularise. Applied
-# uniformly (no no-decay groups for biases/norm scales yet).
+# Decoupled weight decay (AdamW): Loshchilov & Hutter, ICLR 2019
+# (arXiv:1711.05101). In modern training WD acts on optimisation dynamics more
+# than as a regulariser (D'Angelo et al., NeurIPS 2024, arXiv:2310.04415). 0.01
+# is the PyTorch AdamW default; the ViT-classification value 0.05 tends to
+# over-regularise this field-regression regime. Applied uniformly (no no-decay
+# groups for biases/norm scales yet).
 weight_decay: 0.01
-# Linear warmup as a fraction of the cosine horizon (5%). Warmup: Goyal et al.
-# (2017, arXiv:1706.02677); cosine annealing: Loshchilov & Hutter, SGDR (ICLR
-# 2017, arXiv:1608.03983). Integer = absolute steps/epochs; float in (0, 1) =
-# fraction of the horizon.
+# Linear warmup as a fraction of the cosine horizon (5%). Why warmup helps:
+# Kalra & Barkeshli, NeurIPS 2024 (arXiv:2406.09405); Adam-specific variance
+# argument: Liu et al. (RAdam), ICLR 2020 (arXiv:1908.03265). Integer = absolute
+# steps/epochs; float in (0, 1) = fraction of the horizon.
 warmup: 0.05
+# Cosine annealing: Loshchilov & Hutter, SGDR, ICLR 2017 (arXiv:1608.03983);
+# set the cycle length to match the run (Hoffmann et al., Chinchilla, 2022,
+# arXiv:2203.15556).
 scheduler: "cosine"
 # Optional scheduler controls:
 # scheduler_interval: "epoch"     # "epoch" or "step"

--- a/src/autocast/configs/optimizer/updated_defaults/adamw.yaml
+++ b/src/autocast/configs/optimizer/updated_defaults/adamw.yaml
@@ -1,0 +1,31 @@
+# Recommended tuned AdamW defaults (opt-in). Select with:
+#   optimizer=updated_defaults/adamw
+# Live defaults in optimizer/adamw.yaml are left unchanged for reproducibility;
+# this config carries the values we'd otherwise move to defaults (see the
+# follow-up issue to replace the in-place defaults).
+name: "${.optimizer}_${.learning_rate}_${.scheduler}"
+optimizer: "adamw"
+betas: [0.9, 0.99]
+learning_rate: 1e-4
+# Decoupled weight decay for AdamW (Loshchilov & Hutter, ICLR 2019,
+# arXiv:1711.05101). 0.01 is conservative for this field-regression regime; the
+# textbook ViT-classification value (0.05) tends to over-regularise. Applied
+# uniformly (no no-decay groups for biases/norm scales yet).
+weight_decay: 0.01
+# Linear warmup as a fraction of the cosine horizon (5%). Warmup: Goyal et al.
+# (2017, arXiv:1706.02677); cosine annealing: Loshchilov & Hutter, SGDR (ICLR
+# 2017, arXiv:1608.03983). Integer = absolute steps/epochs; float in (0, 1) =
+# fraction of the horizon.
+warmup: 0.05
+scheduler: "cosine"
+# Optional scheduler controls:
+# scheduler_interval: "epoch"     # "epoch" or "step"
+# cosine_epochs: null              # Used when scheduler_interval="epoch"
+# cosine_steps: null               # Used when scheduler_interval="step"
+# cosine_t_max: 1                  # Fallback horizon if trainer values are unavailable
+# Horizon precedence (highest to lowest):
+# 1) cosine_epochs/cosine_steps (based on scheduler_interval)
+# 2) trainer max value (max_epochs or estimated_stepping_batches)
+# 3) cosine_t_max
+# min_lr_ratio: 0.0                # Final LR ratio in [0, 1]
+# scheduler: "cosine_with_restarts"

--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -8,12 +8,9 @@ log_every_n_steps: 10
 enable_checkpointing: true
 detect_anomaly: false
 default_root_dir: null
-# Default null (no clipping) for reproducibility with existing runs; recommended
-# starting point is 1.0 (set per experiment).
+# Default null (no clipping) preserves reproducibility with existing runs. To
+# enable gradient clipping (1.0) opt in with trainer=updated_defaults.
 gradient_clip_val: null
-# precision: defaults to Lightning's 32-true. Recommended bf16-mixed for ~1.5-2x
-# A100 throughput, but first validate a bf16-vs-fp32 rollout matches within
-# tolerance (long autoregressive rollouts / spectral ops are precision-sensitive).
 
 # Save snapshots throughout training based on optimizer-step progress.
 # Override at runtime, e.g.:

--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -8,7 +8,8 @@ log_every_n_steps: 10
 enable_checkpointing: true
 detect_anomaly: false
 default_root_dir: null
-gradient_clip_val: null
+gradient_clip_val: 1.0
+precision: bf16-mixed
 
 # Save snapshots throughout training based on optimizer-step progress.
 # Override at runtime, e.g.:

--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -8,8 +8,12 @@ log_every_n_steps: 10
 enable_checkpointing: true
 detect_anomaly: false
 default_root_dir: null
-gradient_clip_val: 1.0
-precision: bf16-mixed
+# Default null (no clipping) for reproducibility with existing runs; recommended
+# starting point is 1.0 (set per experiment).
+gradient_clip_val: null
+# precision: defaults to Lightning's 32-true. Recommended bf16-mixed for ~1.5-2x
+# A100 throughput, but first validate a bf16-vs-fp32 rollout matches within
+# tolerance (long autoregressive rollouts / spectral ops are precision-sensitive).
 
 # Save snapshots throughout training based on optimizer-step progress.
 # Override at runtime, e.g.:

--- a/src/autocast/configs/trainer/updated_defaults.yaml
+++ b/src/autocast/configs/trainer/updated_defaults.yaml
@@ -1,0 +1,9 @@
+# Recommended trainer defaults (opt-in). Select with: trainer=updated_defaults
+# Inherits trainer/default.yaml and enables gradient clipping (1.0). bf16-mixed
+# is deliberately NOT enabled here: fp32-vs-bf16 showed performance degradation
+# in earlier experiments, so precision is left at Lightning's 32-true.
+defaults:
+  - default
+  - _self_
+
+gradient_clip_val: 1.0

--- a/src/autocast/configs/trainer/updated_defaults.yaml
+++ b/src/autocast/configs/trainer/updated_defaults.yaml
@@ -1,7 +1,9 @@
 # Recommended trainer defaults (opt-in). Select with: trainer=updated_defaults
-# Inherits trainer/default.yaml and enables gradient clipping (1.0). bf16-mixed
-# is deliberately NOT enabled here: fp32-vs-bf16 showed performance degradation
-# in earlier experiments, so precision is left at Lightning's 32-true.
+# Inherits trainer/default.yaml and enables gradient clipping (1.0, the GPT-style
+# global-norm default; matches LOLA). Why clipping helps: Zhang et al., ICLR 2020
+# (arXiv:1905.11881); origin: Pascanu et al., ICML 2013 (arXiv:1211.5063).
+# bf16-mixed is deliberately NOT enabled here: fp32-vs-bf16 showed performance
+# degradation in earlier experiments, so precision is left at Lightning's 32-true.
 defaults:
   - default
   - _self_

--- a/src/autocast/models/optimizer_mixin.py
+++ b/src/autocast/models/optimizer_mixin.py
@@ -91,6 +91,13 @@ class OptimizerMixin(nn.Module):
         if cfg.get("learning_rate") is None:
             msg = "learning_rate is required in optimizer_config."
             raise ValueError(msg)
+        if cfg.get("grad_clip") is not None:
+            msg = (
+                "optimizer.grad_clip is no longer read; gradient clipping is "
+                "wired through trainer.gradient_clip_val. Move the value to "
+                "trainer.gradient_clip_val (or set it to null to disable)."
+            )
+            raise ValueError(msg)
         optimizer_name = str(cfg.get("optimizer")).lower()
         lr = cfg.get("learning_rate")
         if not isinstance(lr, (float, int)):
@@ -151,6 +158,23 @@ class OptimizerMixin(nn.Module):
             merge_dims=merge_dims,
         )
 
+    def _resolve_warmup(self, cfg: dict[str, Any], horizon: int) -> int:
+        """Resolve warmup steps/epochs from config.
+
+        A float in (0, 1) is treated as a fraction of the cosine horizon
+        (e.g. 0.05 -> 5% of horizon). Anything else is interpreted as an
+        absolute count. Negative values clamp to 0. NaN / inf are rejected.
+        """
+        warmup_raw = cfg.get("warmup", 0)
+        if isinstance(warmup_raw, float) and not math.isfinite(warmup_raw):
+            msg = f"warmup must be finite. Got: {warmup_raw}"
+            raise ValueError(msg)
+        if isinstance(warmup_raw, float) and 0.0 < warmup_raw < 1.0:
+            warmup = int(warmup_raw * horizon)
+        else:
+            warmup = int(warmup_raw)
+        return max(warmup, 0)
+
     def _create_scheduler(
         self, optimizer: torch.optim.Optimizer, cfg: dict[str, Any]
     ) -> torch.optim.lr_scheduler.LRScheduler:
@@ -158,8 +182,6 @@ class OptimizerMixin(nn.Module):
         scheduler_name = str(cfg.get("scheduler", "")).lower()
         scheduler_interval = self._get_scheduler_interval(cfg)
 
-        warmup = int(cfg.get("warmup", 0))
-        warmup = max(warmup, 0)
         min_lr_ratio = float(cfg.get("min_lr_ratio", 0.0))
         if not 0.0 <= min_lr_ratio <= 1.0:
             msg = f"min_lr_ratio must be in [0, 1]. Got: {min_lr_ratio}"
@@ -167,6 +189,7 @@ class OptimizerMixin(nn.Module):
 
         if scheduler_name in {"cosine", "cosine_with_restarts"}:
             horizon = self._resolve_cosine_horizon(cfg, scheduler_interval)
+            warmup = self._resolve_warmup(cfg, horizon)
             use_restarts = scheduler_name == "cosine_with_restarts"
 
             def cosine_lambda(t: int) -> float:

--- a/tests/models/test_optimizer_mixin.py
+++ b/tests/models/test_optimizer_mixin.py
@@ -1,0 +1,165 @@
+"""Unit tests for OptimizerMixin warmup resolution."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+import torch
+from torch import nn
+
+from autocast.models.optimizer_mixin import OptimizerMixin
+
+
+class _ToyMixinUser(OptimizerMixin):
+    """Minimal nn.Module that exposes OptimizerMixin helpers for testing."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 2)
+        self.optimizer_config = None
+
+
+@pytest.fixture
+def mixin() -> _ToyMixinUser:
+    return _ToyMixinUser()
+
+
+class TestResolveWarmup:
+    """Tests for _resolve_warmup: fractional vs absolute warmup parsing."""
+
+    def test_zero_returns_zero(self, mixin: _ToyMixinUser) -> None:
+        assert mixin._resolve_warmup({"warmup": 0}, horizon=1000) == 0
+
+    def test_fractional_within_unit_interval_uses_horizon(
+        self, mixin: _ToyMixinUser
+    ) -> None:
+        # 0.05 * 1000 = 50
+        assert mixin._resolve_warmup({"warmup": 0.05}, horizon=1000) == 50
+
+    def test_fractional_rounds_down(self, mixin: _ToyMixinUser) -> None:
+        # 0.05 * 137 = 6.85 -> int() -> 6
+        assert mixin._resolve_warmup({"warmup": 0.05}, horizon=137) == 6
+
+    def test_absolute_int_passes_through(self, mixin: _ToyMixinUser) -> None:
+        assert mixin._resolve_warmup({"warmup": 500}, horizon=1000) == 500
+
+    def test_float_equal_to_one_is_absolute(self, mixin: _ToyMixinUser) -> None:
+        # 1.0 is excluded from the fractional range so int(1.0) = 1 step.
+        assert mixin._resolve_warmup({"warmup": 1.0}, horizon=1000) == 1
+
+    def test_float_above_one_is_absolute(self, mixin: _ToyMixinUser) -> None:
+        # 100.7 -> int(100.7) = 100 absolute steps (not 100 * horizon).
+        assert mixin._resolve_warmup({"warmup": 100.7}, horizon=1000) == 100
+
+    def test_float_at_zero_is_zero(self, mixin: _ToyMixinUser) -> None:
+        assert mixin._resolve_warmup({"warmup": 0.0}, horizon=1000) == 0
+
+    def test_negative_clamps_to_zero(self, mixin: _ToyMixinUser) -> None:
+        assert mixin._resolve_warmup({"warmup": -5}, horizon=1000) == 0
+        assert mixin._resolve_warmup({"warmup": -0.5}, horizon=1000) == 0
+
+    def test_missing_key_defaults_to_zero(self, mixin: _ToyMixinUser) -> None:
+        assert mixin._resolve_warmup({}, horizon=1000) == 0
+
+    def test_nan_warmup_raises(self, mixin: _ToyMixinUser) -> None:
+        with pytest.raises(ValueError, match="warmup must be finite"):
+            mixin._resolve_warmup({"warmup": float("nan")}, horizon=1000)
+
+    def test_positive_inf_warmup_raises(self, mixin: _ToyMixinUser) -> None:
+        with pytest.raises(ValueError, match="warmup must be finite"):
+            mixin._resolve_warmup({"warmup": float("inf")}, horizon=1000)
+
+    def test_negative_inf_warmup_raises(self, mixin: _ToyMixinUser) -> None:
+        with pytest.raises(ValueError, match="warmup must be finite"):
+            mixin._resolve_warmup({"warmup": float("-inf")}, horizon=1000)
+
+
+class TestGradClipGuard:
+    """_create_optimizer rejects the removed optimizer.grad_clip field."""
+
+    def test_grad_clip_value_raises(self, mixin: _ToyMixinUser) -> None:
+        # A real value would be silently ignored (clipping is now wired through
+        # trainer.gradient_clip_val), so fail loud and tell the caller to migrate.
+        cfg = cast(
+            "Any",
+            {"optimizer": "adamw", "learning_rate": 1e-4, "grad_clip": 2.0},
+        )
+        with pytest.raises(ValueError, match="grad_clip"):
+            mixin._create_optimizer(cfg)
+
+    def test_grad_clip_null_is_allowed(self, mixin: _ToyMixinUser) -> None:
+        # null meant "no clip"; it is benign, so it must not raise.
+        cfg = cast(
+            "Any",
+            {"optimizer": "adamw", "learning_rate": 1e-4, "grad_clip": None},
+        )
+        assert isinstance(mixin._create_optimizer(cfg), torch.optim.AdamW)
+
+    def test_absent_grad_clip_is_allowed(self, mixin: _ToyMixinUser) -> None:
+        cfg = cast("Any", {"optimizer": "adamw", "learning_rate": 1e-4})
+        assert isinstance(mixin._create_optimizer(cfg), torch.optim.AdamW)
+
+
+class TestCosineSchedulerWithWarmup:
+    """Integration: cosine scheduler uses the resolved warmup correctly."""
+
+    def _build_scheduler(
+        self, *, warmup: float | int
+    ) -> torch.optim.lr_scheduler.LambdaLR:
+        m = _ToyMixinUser()
+        m.optimizer_config = cast(
+            "Any",
+            {
+                "optimizer": "adamw",
+                "learning_rate": 1.0,  # get_last_lr surfaces the lambda value
+                "weight_decay": 0.0,
+                "warmup": warmup,
+                "scheduler": "cosine",
+                "scheduler_interval": "step",
+                "cosine_steps": 1000,
+            },
+        )
+        result = m.configure_optimizers()
+        assert isinstance(result, dict)
+        result_any = cast("dict[str, Any]", result)
+        sched = result_any["lr_scheduler"]["scheduler"]
+        assert isinstance(sched, torch.optim.lr_scheduler.LambdaLR)
+        return sched
+
+    def test_zero_warmup_starts_at_one(self) -> None:
+        # cosine(0) = (1 + cos(0))/2 = 1.0; no warmup factor.
+        sched = self._build_scheduler(warmup=0)
+        assert sched.get_last_lr()[0] == pytest.approx(1.0)
+
+    def test_fractional_warmup_50_steps_starts_at_1_over_51(self) -> None:
+        # warmup=0.05 with horizon=1000 -> 50 warmup steps.
+        # At step 0: warm = min(1, 1/51), cosine = 1.0 -> lr = 1/51.
+        sched = self._build_scheduler(warmup=0.05)
+        assert sched.get_last_lr()[0] == pytest.approx(1.0 / 51.0, rel=1e-4)
+
+    def test_absolute_warmup_matches_fractional_equivalent(self) -> None:
+        # warmup=50 (absolute) and warmup=0.05 (50/1000) yield identical schedules.
+        sched_abs = self._build_scheduler(warmup=50)
+        sched_frac = self._build_scheduler(warmup=0.05)
+        for _ in range(75):
+            sched_abs.optimizer.step()
+            sched_abs.step()
+            sched_frac.optimizer.step()
+            sched_frac.step()
+        assert sched_abs.get_last_lr()[0] == pytest.approx(
+            sched_frac.get_last_lr()[0], rel=1e-6
+        )
+
+    def test_lr_climbs_through_warmup_and_peaks_after(self) -> None:
+        # warmup=50, horizon=1000. lr should grow ~linearly through step 50 then
+        # follow cosine decay (still ~1.0 at step 50, before significant decay).
+        sched = self._build_scheduler(warmup=50)
+        lrs = [sched.get_last_lr()[0]]
+        for _ in range(60):
+            sched.optimizer.step()
+            sched.step()
+            lrs.append(sched.get_last_lr()[0])
+        # Step 0: ~1/51. Step 50: ~51/51 * cos(50/1000 * pi) ~ 0.997. Strict climb.
+        assert lrs[0] < lrs[25] < lrs[50]
+        assert lrs[50] == pytest.approx(0.997, rel=1e-2)

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -108,10 +108,10 @@ def test_autoencoder_trainer_fit_bf16_mixed_smoke(
 ):
     """Verify bf16-mixed + gradient_clip_val=1.0 don't produce NaN/Inf.
 
-    These are the recommended (opt-in) precision/clipping settings documented in
-    trainer/default.yaml. Running a smoke fit with both enabled catches
-    regressions where mixed precision introduces NaN/Inf in our model paths or
-    where clipping interferes with the optimizer step.
+    bf16-mixed is a supported but non-default option (not recommended — earlier
+    experiments showed fp32-vs-bf16 degradation). This smoke fit with both
+    enabled catches regressions where mixed precision introduces NaN/Inf in our
+    model paths or where clipping interferes with the optimizer step.
     """
     model_cfg = _load_config(config_dir, "model/autoencoder")
     cfg = _wrap_model_config(model_cfg)
@@ -147,14 +147,38 @@ def test_default_trainer_config_omits_clip_and_precision(config_dir: str):
     """Pin trainer/default.yaml to the reproducibility-preserving defaults.
 
     gradient_clip_val stays null (no clipping) and precision is left unset
-    (Lightning's 32-true) so existing runs reproduce unchanged; bf16-mixed and
-    clipping are opt-in recommendations documented in the config. Fails loudly if
-    a refactor silently re-introduces a behaviour-changing default.
+    (Lightning's 32-true) so existing runs reproduce unchanged; the tuned values
+    live in the opt-in ``updated_defaults`` configs. Fails loudly if a refactor
+    silently re-introduces a behaviour-changing default.
     """
     trainer_cfg = OmegaConf.load(Path(config_dir) / "trainer" / "default.yaml")
     assert isinstance(trainer_cfg, DictConfig)
     assert trainer_cfg.get("gradient_clip_val") is None
     assert trainer_cfg.get("precision") is None
+
+
+def test_updated_defaults_configs_opt_in(config_dir: str):
+    """The opt-in recommended configs select cleanly and carry the tuned values.
+
+    Per review: live defaults stay untouched and the tuned values ship as
+    selectable configs (``optimizer=updated_defaults/adamw``,
+    ``trainer=updated_defaults``) rather than changing the defaults in place.
+    """
+    cfg = _load_config(
+        config_dir,
+        "autoencoder",
+        overrides=[
+            "optimizer=updated_defaults/adamw",
+            "trainer=updated_defaults",
+        ],
+    )
+    assert cfg.optimizer.weight_decay == 0.01
+    assert cfg.optimizer.warmup == 0.05
+    assert cfg.trainer.gradient_clip_val == 1.0
+    # bf16 deliberately not recommended (see review); precision stays unset.
+    assert cfg.trainer.get("precision") is None
+    # Inheritance from trainer/default.yaml preserved the callbacks.
+    assert len(cfg.trainer.callbacks) > 0
 
 
 def test_processor_config_training_step_smoke(config_dir: str, dummy_datamodule):

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -103,6 +103,57 @@ def test_autoencoder_config_trainer_fit_smoke(
     trainer.fit(model, train_dataloaders=dummy_loader, val_dataloaders=dummy_loader)
 
 
+def test_autoencoder_trainer_fit_bf16_mixed_smoke(
+    config_dir: str, toy_batch: Batch, dummy_loader, dummy_datamodule
+):
+    """Verify bf16-mixed + gradient_clip_val=1.0 defaults don't produce NaN/Inf.
+
+    These two settings are the behaviour-changing defaults in trainer/default.yaml.
+    Running a smoke fit with both enabled catches regressions where mixed precision
+    introduces NaN/Inf in our model paths or where clipping interferes with the
+    optimizer step.
+    """
+    model_cfg = _load_config(config_dir, "model/autoencoder")
+    cfg = _wrap_model_config(model_cfg)
+    with open_dict(cfg):
+        cfg.optimizer = get_optimizer_config()
+        cfg.datamodule = {
+            "n_steps_input": toy_batch.input_fields.shape[1],
+            "n_steps_output": toy_batch.output_fields.shape[1],
+        }
+    stats = _stats_from_batch(toy_batch)
+    model = setup_autoencoder_model(cfg, stats, dummy_datamodule)
+
+    trainer = L.Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_epochs=1,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        precision="bf16-mixed",
+        gradient_clip_val=1.0,
+    )
+    trainer.fit(model, train_dataloaders=dummy_loader, val_dataloaders=dummy_loader)
+
+    for name, p in model.named_parameters():
+        assert torch.isfinite(p).all(), f"param {name} has NaN/Inf after bf16-mixed fit"
+
+
+def test_default_trainer_config_has_expected_precision_and_clip(config_dir: str):
+    """Pin trainer/default.yaml's bf16-mixed + gradient_clip_val=1.0 defaults.
+
+    These are explicitly project-wide defaults; this test fails loudly if they
+    are silently changed (e.g. by a future refactor that lowers WD or precision).
+    """
+    trainer_cfg = OmegaConf.load(Path(config_dir) / "trainer" / "default.yaml")
+    assert trainer_cfg.precision == "bf16-mixed"
+    assert trainer_cfg.gradient_clip_val == 1.0
+
+
 def test_processor_config_training_step_smoke(config_dir: str, dummy_datamodule):
     processor_cfg = _load_config(config_dir, "processor/flow_matching").processor
     with open_dict(processor_cfg):

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -106,12 +106,12 @@ def test_autoencoder_config_trainer_fit_smoke(
 def test_autoencoder_trainer_fit_bf16_mixed_smoke(
     config_dir: str, toy_batch: Batch, dummy_loader, dummy_datamodule
 ):
-    """Verify bf16-mixed + gradient_clip_val=1.0 defaults don't produce NaN/Inf.
+    """Verify bf16-mixed + gradient_clip_val=1.0 don't produce NaN/Inf.
 
-    These two settings are the behaviour-changing defaults in trainer/default.yaml.
-    Running a smoke fit with both enabled catches regressions where mixed precision
-    introduces NaN/Inf in our model paths or where clipping interferes with the
-    optimizer step.
+    These are the recommended (opt-in) precision/clipping settings documented in
+    trainer/default.yaml. Running a smoke fit with both enabled catches
+    regressions where mixed precision introduces NaN/Inf in our model paths or
+    where clipping interferes with the optimizer step.
     """
     model_cfg = _load_config(config_dir, "model/autoencoder")
     cfg = _wrap_model_config(model_cfg)
@@ -143,15 +143,18 @@ def test_autoencoder_trainer_fit_bf16_mixed_smoke(
         assert torch.isfinite(p).all(), f"param {name} has NaN/Inf after bf16-mixed fit"
 
 
-def test_default_trainer_config_has_expected_precision_and_clip(config_dir: str):
-    """Pin trainer/default.yaml's bf16-mixed + gradient_clip_val=1.0 defaults.
+def test_default_trainer_config_omits_clip_and_precision(config_dir: str):
+    """Pin trainer/default.yaml to the reproducibility-preserving defaults.
 
-    These are explicitly project-wide defaults; this test fails loudly if they
-    are silently changed (e.g. by a future refactor that lowers WD or precision).
+    gradient_clip_val stays null (no clipping) and precision is left unset
+    (Lightning's 32-true) so existing runs reproduce unchanged; bf16-mixed and
+    clipping are opt-in recommendations documented in the config. Fails loudly if
+    a refactor silently re-introduces a behaviour-changing default.
     """
     trainer_cfg = OmegaConf.load(Path(config_dir) / "trainer" / "default.yaml")
-    assert trainer_cfg.precision == "bf16-mixed"
-    assert trainer_cfg.gradient_clip_val == 1.0
+    assert isinstance(trainer_cfg, DictConfig)
+    assert trainer_cfg.get("gradient_clip_val") is None
+    assert trainer_cfg.get("precision") is None
 
 
 def test_processor_config_training_step_smoke(config_dir: str, dummy_datamodule):


### PR DESCRIPTION
## Summary

Surfaces four training-config knobs that were previously absent or latent, and ships the tuned values as **opt-in selectable configs** — the live defaults are left unchanged, so existing runs reproduce from config alone and old W&B baselines stay comparable.

Opt in with:

```
optimizer=updated_defaults/adamw   # weight_decay 0.01, warmup 0.05
trainer=updated_defaults           # gradient_clip_val 1.0 (inherits trainer/default)
```

| Setting | Live default (unchanged) | `updated_defaults` (opt-in) |
|---|---|---|
| `adamw.yaml` `weight_decay` | `0.0` | `0.01` |
| `adamw.yaml` `warmup` | `0` | `0.05` (fraction of cosine horizon) |
| `trainer.gradient_clip_val` | `null` (no clipping) | `1.0` |
| `trainer.precision` | unset → `32-true` | unchanged — bf16 dropped (see below) |

Plus fractional-warmup support in `OptimizerMixin._resolve_warmup`: a float in `(0, 1)` is a fraction of the cosine horizon; integers and floats `>= 1` stay absolute counts; `NaN`/`inf` rejected.

## Approach (per review)

Following @sgreenbury's review: rather than changing defaults in place, the tuned values live in selectable `updated_defaults` configs, so nothing changes for existing runs. #394 tracks promoting them to the in-place defaults once validated.

## bf16-mixed dropped

Not recommended — earlier fp32-vs-bf16 experiments showed degradation ([report](https://wandb.ai/turing-core/autocast/reports/Comparison-of-fp32-and-bf16-mixed--VmlldzoxNjUzNTc0Nw)). Precision stays at Lightning's `32-true`. bf16 is still usable as a manual override, and a smoke test keeps it numerically exercised (no NaN/Inf), but it is not part of the recommended set.

## Migration: `optimizer.grad_clip` removed

The orphaned `grad_clip` field is dropped from all optimizer configs, and `_create_optimizer` now **raises** if `optimizer.grad_clip` is set, pointing callers to `trainer.gradient_clip_val`. This is deliberate: any config that set `optimizer.grad_clip: <value>` was silently *not* clipping (no code path read it). Such configs must move the value to `trainer.gradient_clip_val` — or drop it, since it was a no-op. No config in this repo sets it; only downstream/experiment configs need the one-line move.

## References

The values are framework/community defaults aligned to the LOLA reference, not paper-derived constants; the citations justify the techniques and explain why they help (validation before promotion is tracked in #394).

- **Weight decay (0.01)** — decoupled WD: Loshchilov & Hutter, ICLR 2019 (arXiv:1711.05101); modern role (optimisation dynamics, not classical regularisation): D'Angelo et al., NeurIPS 2024 (arXiv:2310.04415). 0.01 is the PyTorch AdamW default.
- **Warmup (5%)** — mechanism: Kalra & Barkeshli, NeurIPS 2024 (arXiv:2406.09405); Adam-specific variance argument: Liu et al. (RAdam), ICLR 2020 (arXiv:1908.03265); linear-warmup origin: Goyal et al., 2017 (arXiv:1706.02677).
- **Cosine schedule** — Loshchilov & Hutter, SGDR, ICLR 2017 (arXiv:1608.03983); match the cycle length to the run: Hoffmann et al. (Chinchilla), 2022 (arXiv:2203.15556).
- **Gradient clipping (1.0)** — why it accelerates: Zhang et al., ICLR 2020 (arXiv:1905.11881); origin: Pascanu et al., ICML 2013 (arXiv:1211.5063). 1.0 is the GPT-style global-norm default and matches LOLA.

## Notes

- **WD `0.01` is a starting point.** `0.05` is the ViT-*classification* recipe; this is field regression where it tends to over-regularise. When enabled it is applied uniformly — no no-decay param groups for biases/norm scales yet (tracked in #394).
- **`adamw_half.yaml` stays LOLA-faithful** (`weight_decay: 0.0`, `warmup: 0`).
- Relates to #322 (optimizer/trainer param alignment).

## Testing

- 16 unit tests for `_resolve_warmup`; 3 for the `grad_clip` migration guard; a bf16-mixed + `gradient_clip_val=1.0` autoencoder fit smoke; a config pin asserting the reproducibility-preserving live defaults; a compose test asserting the `updated_defaults` configs select cleanly, carry the tuned values, and preserve inherited trainer callbacks.
- `uv run pytest tests/models/test_optimizer_mixin.py tests/scripts/test_training.py` → 56 passed. Ruff + pyright clean.
