### PR TITLE
Add plotting CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "torch>=2.9.1",
     "wandb>=0.18.7",
     "nvidia-ml-py>=13.595.45",
+    "openpyxl>=3.1.5",
+    "tabulate>=0.10.0",
 ]
 
 [project.optional-dependencies]
@@ -41,6 +43,7 @@ train_encoder_processor_decoder = "autocast.scripts.train.encoder_processor_deco
 train_autoencoder = "autocast.scripts.train.autoencoder:main"
 evaluate_encoder_processor_decoder = "autocast.scripts.eval.encoder_processor_decoder:main"
 cache_latents = "autocast.scripts.cache_latents:main"
+autocast-plots = "autocast.scripts.plot_dataset_comparisons:main"
 
 [build-system]
 requires = ["uv_build>=0.8.15,<0.9.0"]

--- a/scripts/plots.sh
+++ b/scripts/plots.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 PLOTS_PATH=2026-04-20_plots_m16_complete
 
@@ -6,7 +7,7 @@ PLOTS_PATH=2026-04-20_plots_m16_complete
 # Comparison with previous CNS results
 # m=8 
 # --run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (24hrs, update, n=1024, afCRPS, h=568, layers=12)" 0 \
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run crps_cns64_vit_azula_large_1ed9013_ab31602 "CRPS (24hrs, prelim, n=1024, afCRPS, h=632, layers=10)" 0 \
 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (24hrs, update, n=1024, afCRPS, h=568, layers=12, m=16)" 0 \
 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs, prelim)" 2 \
@@ -26,7 +27,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 # Main comparison: CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
 # --run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient)" 0 \
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run crps_ad64_vit_azula_large_0f89f06_4667606 "CRPS (ambient)" 0 \
 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient m=16)" 0 \
 	--run crps_gpe64_vit_azula_large_0f89f06_d337bd8 "CRPS (ambient)" 0 \
@@ -54,7 +55,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 
 # Main comparison (with m=16 runs 100^ complete): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 \
 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 \
 	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 \
@@ -67,7 +68,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
-	--dataset-order AD CNS GS GPE\
+	--dataset-order AD CNS GS GPE \
 	--error-ylim 1e-5 1 \
 	--lead-time-error-metrics vrmse rmse \
 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -81,7 +82,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete
 
 # Main comparison (with m=16 runs 100^ complete): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 \
 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 \
 	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 \
@@ -90,7 +91,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
-	--dataset-order AD CNS GS GPE\
+	--dataset-order AD CNS GS GPE \
 	--error-ylim 1e-5 1 \
 	--lead-time-error-metrics vrmse rmse \
 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -110,7 +111,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # ../2026-04-24/crps_gs64_vit_azula_large_bed4611_828a161/
 
 # Main comparison (with m=8 runs 100^ complete): best winkler
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS (ambient, m=8)" 0 eval=eval_best_multiwinkler_from0p25 \
 	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (ambient, m=8)" 0 eval=eval_best_multiwinkler_from0p25 \
 	--run crps_gpe64_vit_azula_large_bed4611_e0a6df5 "CRPS (ambient, m=8)" 0 eval=eval_best_multiwinkler_from0p25 \
@@ -119,7 +120,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
-	--dataset-order AD CNS GS GPE\
+	--dataset-order AD CNS GS GPE \
 	--error-ylim 1e-5 1 \
 	--lead-time-error-metrics vrmse rmse \
 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -139,7 +140,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # ../2026-04-24/ensemble_size/crps_gs64_vit_azula_large_bed4611_4d04729/
 
 # Main comparison (with m=16 runs 100^ complete): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run crps_ad64_vit_azula_large_bed4611_69c99bf "CRPS (ambient, m=16)" 0 eval=eval_best_multiwinkler_from0p25 \
 	--run crps_cns64_vit_azula_large_bed4611_5758ebc "CRPS (ambient, m=16)" 0 eval=eval_best_multiwinkler_from0p25 \
 	--run crps_gpe64_vit_azula_large_bed4611_6b78265 "CRPS (ambient, m=16)" 0 eval=eval_best_multiwinkler_from0p25 \
@@ -148,7 +149,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
-	--dataset-order AD CNS GS GPE\
+	--dataset-order AD CNS GS GPE \
 	--error-ylim 1e-5 1 \
 	--lead-time-error-metrics vrmse rmse \
 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -165,7 +166,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 
 # # Main comparison (with m=16 runs at 75% checkpoint): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
-# autocast-plots --results-dir outputs/2026-04-20_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
 # 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
 # 	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
@@ -178,7 +179,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 # 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
 # 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
-# 	--dataset-order AD CNS GS GPE\
+# 	--dataset-order AD CNS GS GPE \
 # 	--error-ylim 1e-5 1 \
 # 	--lead-time-error-metrics vrmse rmse \
 # 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -192,16 +193,16 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_0p75
 
 # Main comparison (with m=16 runs at 75% checkpoint): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
 	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
 	--run crps_gs64_vit_azula_large_ac1bb06_639963f "CRPS (ambient, m=16) " 0 eval=eval_0p75 \
-	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 eval=eval_0p75\
-	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 eval=eval_0p75\
-	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 eval=eval_0p75\
-	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 eval=eval_0p75\
-	--dataset-order AD CNS GS GPE\
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 eval=eval_0p75 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 eval=eval_0p75 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 eval=eval_0p75 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 eval=eval_0p75 \
+	--dataset-order AD CNS GS GPE \
 	--error-ylim 1e-5 1 \
 	--lead-time-error-metrics vrmse rmse \
 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -215,7 +216,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_0p75_fm_too
 
 # # Main comparison (with m=16 runs at 50% checkpoint): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
-# autocast-plots --results-dir outputs/2026-04-20_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
 # 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
 # 	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
@@ -228,7 +229,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 # 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
 # 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
-# 	--dataset-order AD CNS GS GPE\
+# 	--dataset-order AD CNS GS GPE \
 # 	--error-ylim 1e-5 1 \
 # 	--lead-time-error-metrics vrmse rmse \
 # 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -242,16 +243,16 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_0p50
 
 # Main comparison (with m=16 runs at 50% checkpoint): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
 	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
 	--run crps_gs64_vit_azula_large_ac1bb06_639963f "CRPS (ambient, m=16) " 0 eval=eval_0p50 \
-	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 eval=eval_0p50\
-	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 eval=eval_0p50\
-	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 eval=eval_0p50\
-	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 eval=eval_0p50\
-	--dataset-order AD CNS GS GPE\
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 eval=eval_0p50 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 eval=eval_0p50 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 eval=eval_0p50 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 eval=eval_0p50 \
+	--dataset-order AD CNS GS GPE \
 	--error-ylim 1e-5 1 \
 	--lead-time-error-metrics vrmse rmse \
 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -267,7 +268,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 # Ablation with CRPS ViT using global cond instead of permute_concat and channels last
 # --run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient)" 0 \
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 	--run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient, m=8)" 0 \
@@ -288,7 +289,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 # Usign cached latents for evaluation instead of AE-ambient latents for CRPS latent variant
 # --run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient)" 0 \
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 	--run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient, m=8)" 0 \
@@ -311,7 +312,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 # Ablation with CRPS ensemble size
 # TODO: update with final runs
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
 	--run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient, m=8)" 0 \
@@ -331,7 +332,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/ablation_crps_ensemble_size_complete
 
 # Model size ablation
-autocast-plots --results-dir outputs/2026-04-20_collated \
+uv run autocast-plots --results-dir outputs/2026-04-20_collated \
 	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
 	--run diff_cns64_flow_matching_vit_896_3a69487_e894c55 "FM (ambient, 2x)" 1 \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
@@ -355,13 +356,13 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # PLOTS_PATH=2026-04-08_plots
 
 # # CRPS variants
-# autocast-plots --results-dir outputs/2026-04-01_collated \
-# 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (large)"\
-# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (large)"\
-# 	--run crps_sw2d64_vit_azula_large_60114bf_5d5c8e1 "ViT (1024)"\
-# 	--run crps_sw2d64_vit_azula_large_concat_60114bf_acf9189 "ViT (concat)"\
-# 	--run epd_sw2d64_vit_azula_large_8c5f696_c5f3ea9 "ViT (MAE loss)"\
-# 	--run crps_sw2d64_vit_azula_large_feb5e43_c630eda "ViT (afCRPS loss)"\
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (large)" \
+# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (large)" \
+# 	--run crps_sw2d64_vit_azula_large_60114bf_5d5c8e1 "ViT (1024)" \
+# 	--run crps_sw2d64_vit_azula_large_concat_60114bf_acf9189 "ViT (concat)" \
+# 	--run epd_sw2d64_vit_azula_large_8c5f696_c5f3ea9 "ViT (MAE loss)" \
+# 	--run crps_sw2d64_vit_azula_large_feb5e43_c630eda "ViT (afCRPS loss)" \
 # 	--error-ylim 1e-3 1 \
 # 	--lead-time-error-metrics vrmse rmse \
 # 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
@@ -372,7 +373,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/sw_crps_variants
 
 # # 23hrs
-# autocast-plots --results-dir outputs/2026-04-01_collated --sort Date --filter "Dataset=SW2D64 AND (Model=AzulaViTProcessor OR Model=FlowMatchingProcessor) AND Resolution=64x64 AND scale=large" \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated --sort Date --filter "Dataset=SW2D64 AND (Model=AzulaViTProcessor OR Model=FlowMatchingProcessor) AND Resolution=64x64 AND scale=large" \
 # 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (large)" \
 # 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (large)" \
 # 	--run crps_sw2d64_vit_azula_large_feb5e43_90e3465 "ViT (23hrs)" \
@@ -387,7 +388,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/sw_23hrs
 
 # # Comparison of 1:4, 1:1 and 2:1
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_55a4d1a_511e7b1 "FM (1:4)" \
 # 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (1:4)" \
 # 	--run crps_cns64_vit_azula_large_8fe25aa_d105b90 "ViT (1:4)" \
@@ -411,7 +412,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/1_4_vs_1_1_vs_2_1_no_cached_latents
 
 # # Comparison of 1:4 and 8x gradient steps
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_55a4d1a_511e7b1 "FM (1:4)" \
 # 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (1:4)" \
 # 	--run diff_cns64_flow_matching_vit_c3c9713_d2bcaa2 "FM (64, 24hrs)" \
@@ -427,7 +428,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/fm_8x
 
 # # Comparison with 128x128
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run crps_shallow_water2d_128_vit_azula_large_05cf9ff_29b49a6 "ViT 128x128" \
 # 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT 64x64" \
 # 	--color-by-label \
@@ -441,7 +442,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/128x128
 
 # # Comparison with ODE steps
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_c3c9713_d2bcaa2_25 "FM (25 steps)" \
 # 	--run diff_cns64_flow_matching_vit_c3c9713_d2bcaa2 "FM (50 steps)" \
 # 	--run diff_cns64_flow_matching_vit_c3c9713_d2bcaa2_100 "FM (100 steps)" \
@@ -461,7 +462,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 
 # # Comparison of 1:4, longer 1:4, smoother optimizer 1:4
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run crps_cns64_vit_azula_large_8fe25aa_d105b90 "ViT" \
 # 	--run diff_cns64_flow_matching_vit_55a4d1a_511e7b1 "FM" \
 # 	--run diff_cns64_flow_matching_vit_13eba33_82f423d "FM (36hrs)" \
@@ -478,7 +479,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 # # Compare SW, CNS, GPE
 # # TODO: update SW, CNS and GPE with same training schedule (GPE currently 2e-4)
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run crps_cns64_vit_azula_large_eb4a4f6_294dc78 "ViT" \
 # 	--run crps_sw2d64_vit_azula_large_eb4a4f6_682f33b "ViT" \
 # 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM" \
@@ -497,7 +498,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/sw_cns_gpe
 
 # # Compare DM, FM, ViT for SW, CNS
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run crps_cns64_vit_azula_large_eb4a4f6_294dc78 "ViT" \
 # 	--run crps_sw2d64_vit_azula_large_eb4a4f6_682f33b "ViT" \
 # 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM" \
@@ -516,7 +517,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/crps_fm_dm
 
 # # Compare ViT and FM for batch_size 32 and 128 trained over 12hrs 1GPU / 3hrs 4GPU
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM" \
 # 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM" \
 # 	--run crps_cns64_vit_azula_large_8fe25aa_d105b90 "ViT (n=256, CRPS, h=768, bs=32)" \
@@ -536,7 +537,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 
 # # Compare DM, FM, ViT for SW, CNS
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM" \
 # 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM" \
 # 	--run crps_cns64_vit_azula_large_eb4a4f6_294dc78 "ViT (n=256, CRPS, h=768)" \
@@ -558,7 +559,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 
 # # # Compare FM, ViT for SW, CNS with long 24hrs runs
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (3hrs)" \
 # 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs)" \
 # 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
@@ -579,7 +580,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 
 # # Compare FM, ViT for SW, CNS with long 24hrs runs
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (3hrs)" \
 # 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs)" \
 # 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
@@ -600,7 +601,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 	
 
 # # Compare FM, ViT for CNS with varying batch size, training time, precision and model size
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (3hrs)" \
 # 	--run crps_cns64_vit_azula_large_1ed9013_ab31602 "ViT (24hrs, n=1024, afCRPS, h=632)" \
 # 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
@@ -619,7 +620,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	# --color-by-label \
 
 # # Compare FM, ViT for SW, CNS with long 24hrs runs
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs)" \
 # 	--run diff_cns64_flow_matching_vit_1ed9013_893624d_ode_method "FM (24hrs, Adams-Bashforth)" \
 # 	--dataset-order CNS \
@@ -638,7 +639,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # # - between optimizer with cosine period of 2 epochs compared
 # # - 3hrs on 4GPU (or 12hrs on 1GPU) compared to 24hrs on 4GPU
 # # - updated 4x batch size, 4x hidden dimension, afCRPS vs CRPS for ViT
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run diff_cns64_flow_matching_vit_55a4d1a_511e7b1 "FM (12hrs, old optim)" \
 # 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (3hrs)" \
 # 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs)" \
@@ -651,7 +652,7 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (12hrs, 1GPU, n=256, CRPS, h=768, old optim)" \
 # 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
 # 	--run crps_sw2d64_vit_azula_large_1ed9013_6ab9fa2 "ViT (24hrs, n=1024, afCRPS, h=632)" \
-# 	--dataset-order SW, CNS\
+# 	--dataset-order SW, CNS \
 # 	--color-by-label \
 # 	--error-ylim 1e-3 1 \
 # 	--lead-time-error-metrics vrmse rmse \
@@ -664,11 +665,11 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 
 # # Revisit b16-mixed with lower batch size and updated optimizers:
 # # TODO: add once eval completed
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (12hrs, 1GPU, n=256, CRPS, h=768, old optim)" \
 # 	--run crps_sw2d64_vit_azula_large_1ed9013_6ab9fa2 "ViT (24hrs, n=1024, afCRPS, h=632)" \
 # 	--run crps_sw2d64_vit_azula_large_ed15816_085752e "ViT (6hrs, n=1024, afCRPS, h=632, b16-mixed, bs=32)" \
-# 	--dataset-order SW\
+# 	--dataset-order SW \
 # 	--color-by-label \
 # 	--error-ylim 1e-3 1 \
 # 	--lead-time-error-metrics vrmse rmse \
@@ -680,12 +681,12 @@ autocast-plots --results-dir outputs/2026-04-20_collated \
 # 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/b16-mixed_lower_bs_comparison
 
 # # SW in ambient compared to latent
-# autocast-plots --results-dir outputs/2026-04-01_collated \
+# uv run autocast-plots --results-dir outputs/2026-04-01_collated \
 # 	--run crps_sw2d64_vit_azula_large_1ed9013_6ab9fa2 "ViT (24hrs, n=1024, afCRPS, h=632)" \
 # 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM (3hrs)" \
 # 	--run diff_sw2d64_flow_matching_vit_53e8e0e_933bcfa "FM (3hrs ambient, new optim)" \
 # 	--run diff_sw2d64_flow_matching_vit_53e8e0e_933bcfa_ema "FM (3hrs ambient, new optim, EMA)" \
-# 	--dataset-order SW\
+# 	--dataset-order SW \
 # 	--color-by-label \
 # 	--error-ylim 1e-3 1 \
 # 	--lead-time-error-metrics vrmse rmse \

--- a/scripts/plots.sh
+++ b/scripts/plots.sh
@@ -1,0 +1,697 @@
+#!/bin/bash
+
+PLOTS_PATH=2026-04-20_plots_m16_complete
+
+
+# Comparison with previous CNS results
+# m=8 
+# --run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (24hrs, update, n=1024, afCRPS, h=568, layers=12)" 0 \
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run crps_cns64_vit_azula_large_1ed9013_ab31602 "CRPS (24hrs, prelim, n=1024, afCRPS, h=632, layers=10)" 0 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (24hrs, update, n=1024, afCRPS, h=568, layers=12, m=16)" 0 \
+	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs, prelim)" 2 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--dataset-order CNS \
+	--error-ylim 1e-3 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/cns_comparison_with_exploratory_results
+
+# Main comparison: CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
+# --run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient)" 0 \
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run crps_ad64_vit_azula_large_0f89f06_4667606 "CRPS (ambient)" 0 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient m=16)" 0 \
+	--run crps_gpe64_vit_azula_large_0f89f06_d337bd8 "CRPS (ambient)" 0 \
+	--run crps_gs64_vit_azula_large_0f89f06_779325a "CRPS (ambient) " 0 \
+	--run diff_ad64_flow_matching_vit_0f89f06_725d44a "FM (ambient)" 1 \
+	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
+	--run diff_gpe64_flow_matching_vit_0f89f06_3b3604d "FM (ambient)" 1 \
+	--run diff_gs64_flow_matching_vit_0f89f06_6e3a299 "FM (ambient)" 1 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
+	--dataset-order AD CNS GS GPE \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison
+
+
+# Main comparison (with m=16 runs 100^ complete): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 \
+	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 \
+	--run crps_gs64_vit_azula_large_ac1bb06_639963f "CRPS (ambient, m=16) " 0 \
+	--run diff_ad64_flow_matching_vit_0f89f06_725d44a "FM (ambient)" 1 \
+	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
+	--run diff_gpe64_flow_matching_vit_0f89f06_3b3604d "FM (ambient)" 1 \
+	--run diff_gs64_flow_matching_vit_0f89f06_6e3a299 "FM (ambient)" 1 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
+	--dataset-order AD CNS GS GPE\
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete
+
+# Main comparison (with m=16 runs 100^ complete): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 \
+	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 \
+	--run crps_gs64_vit_azula_large_ac1bb06_639963f "CRPS (ambient, m=16) " 0 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
+	--dataset-order AD CNS GS GPE\
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_no_fm_amb
+
+# m=8 
+# ../2026-04-24/crps_ad64_vit_azula_large_bed4611_da01a04/
+# ../2026-04-24/crps_cns64_vit_azula_large_bed4611_c99f534/
+# ../2026-04-24/crps_gpe64_vit_azula_large_bed4611_e0a6df5/
+# ../2026-04-24/crps_gs64_vit_azula_large_bed4611_828a161/
+
+# Main comparison (with m=8 runs 100^ complete): best winkler
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS (ambient, m=8)" 0 eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (ambient, m=8)" 0 eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_bed4611_e0a6df5 "CRPS (ambient, m=8)" 0 eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_bed4611_828a161 "CRPS (ambient, m=8)" 0 eval=eval_best_multiwinkler_from0p25 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
+	--dataset-order AD CNS GS GPE\
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m8_complete_no_fm_amb_best_winkler
+
+# m=16
+# ../2026-04-24/ensemble_size/crps_ad64_vit_azula_large_bed4611_69c99bf/
+# ../2026-04-24/ensemble_size/crps_cns64_vit_azula_large_bed4611_5758ebc/
+# ../2026-04-24/ensemble_size/crps_gpe64_vit_azula_large_bed4611_6b78265/
+# ../2026-04-24/ensemble_size/crps_gs64_vit_azula_large_bed4611_4d04729/
+
+# Main comparison (with m=16 runs 100^ complete): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run crps_ad64_vit_azula_large_bed4611_69c99bf "CRPS (ambient, m=16)" 0 eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_bed4611_5758ebc "CRPS (ambient, m=16)" 0 eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_bed4611_6b78265 "CRPS (ambient, m=16)" 0 eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_bed4611_4d04729 "CRPS (ambient, m=16)" 0 eval=eval_best_multiwinkler_from0p25 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
+	--dataset-order AD CNS GS GPE\
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_no_fm_amb_best_winkler
+
+
+
+
+# # Main comparison (with m=16 runs at 75% checkpoint): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
+# autocast-plots --results-dir outputs/2026-04-20_collated \
+# 	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
+# 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
+# 	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
+# 	--run crps_gs64_vit_azula_large_ac1bb06_639963f "CRPS (ambient, m=16) " 0 eval=eval_0p75 \
+# 	--run diff_ad64_flow_matching_vit_0f89f06_725d44a "FM (ambient)" 1 \
+# 	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
+# 	--run diff_gpe64_flow_matching_vit_0f89f06_3b3604d "FM (ambient)" 1 \
+# 	--run diff_gs64_flow_matching_vit_0f89f06_6e3a299 "FM (ambient)" 1 \
+# 	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 \
+# 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+# 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
+# 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
+# 	--dataset-order AD CNS GS GPE\
+# 	--error-ylim 1e-5 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--lead-time-coverage-delta \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--panel-figure-no-training \
+# 	--coverage-panel-overall-rollout-windows \
+# 	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_0p75
+
+# Main comparison (with m=16 runs at 75% checkpoint): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
+	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 eval=eval_0p75 \
+	--run crps_gs64_vit_azula_large_ac1bb06_639963f "CRPS (ambient, m=16) " 0 eval=eval_0p75 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 eval=eval_0p75\
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 eval=eval_0p75\
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 eval=eval_0p75\
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 eval=eval_0p75\
+	--dataset-order AD CNS GS GPE\
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_0p75_fm_too
+
+# # Main comparison (with m=16 runs at 50% checkpoint): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
+# autocast-plots --results-dir outputs/2026-04-20_collated \
+# 	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
+# 	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
+# 	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
+# 	--run crps_gs64_vit_azula_large_ac1bb06_639963f "CRPS (ambient, m=16) " 0 eval=eval_0p50 \
+# 	--run diff_ad64_flow_matching_vit_0f89f06_725d44a "FM (ambient)" 1 \
+# 	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
+# 	--run diff_gpe64_flow_matching_vit_0f89f06_3b3604d "FM (ambient)" 1 \
+# 	--run diff_gs64_flow_matching_vit_0f89f06_6e3a299 "FM (ambient)" 1 \
+# 	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 \
+# 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+# 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 \
+# 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 \
+# 	--dataset-order AD CNS GS GPE\
+# 	--error-ylim 1e-5 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--lead-time-coverage-delta \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--panel-figure-no-training \
+# 	--coverage-panel-overall-rollout-windows \
+# 	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_0p50
+
+# Main comparison (with m=16 runs at 50% checkpoint): CRPS ambient variants, CRPS processor-on-latents, FM ambient (EPD)
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run crps_ad64_vit_azula_large_ac1bb06_ef6368d "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
+	--run crps_gpe64_vit_azula_large_ac1bb06_638585e "CRPS (ambient, m=16)" 0 eval=eval_0p50 \
+	--run crps_gs64_vit_azula_large_ac1bb06_639963f "CRPS (ambient, m=16) " 0 eval=eval_0p50 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" 2 eval=eval_0p50\
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 eval=eval_0p50\
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" 2 eval=eval_0p50\
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" 2 eval=eval_0p50\
+	--dataset-order AD CNS GS GPE\
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/main_comparison_m16_complete_0p50_fm_too
+
+
+# Ablation with CRPS ViT using global cond instead of permute_concat and channels last
+# --run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient)" 0 \
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient, m=8)" 0 \
+	--run crps_cns64_vit_azula_large_0f89f06_cf53b48 "CRPS (ambient, identity+global-cond, m=8)" 0 \
+	--dataset-order CNS \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/ablation_crps_vit_global_cond
+
+
+# Usign cached latents for evaluation instead of AE-ambient latents for CRPS latent variant
+# --run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient)" 0 \
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient, m=8)" 0 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient m=16)" 3 \
+	--run crps_cns64_vit_azula_large_0f89f06_e7e60d9 "CRPS (latent, CRPS in ambient, m=8)" 0 \
+	--run crps_cns64_vit_azula_large_09490da_8b7573d "CRPS (latent, CRPS in latent, m=8)" 0 \
+	--dataset-order CNS \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/ablation_crps_vit_latent
+
+
+# Ablation with CRPS ensemble size
+# TODO: update with final runs
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (ambient, m=8)" 0 \
+	--run crps_cns64_vit_azula_large_0db40e1_5e157a5 "CRPS (ambient, m=16, bs=32)" 0 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16, eff_bs=1024)" 0 \
+	--dataset-order CNS \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/ablation_crps_ensemble_size_complete
+
+# Model size ablation
+autocast-plots --results-dir outputs/2026-04-20_collated \
+	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" 1 \
+	--run diff_cns64_flow_matching_vit_896_3a69487_e894c55 "FM (ambient, 2x)" 1 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" 2 \
+	--run crps_cns64_vit_azula_large_0db40e1_dcd79e4 "CRPS (ambient, m=16)" 0 \
+	--run crps_cns64_vit_azula_large_768_3a69487_1d7da5f "CRPS (ambient, m=16, 2x)" 0 \
+	--dataset-order CNS \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse rmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--output-dir outputs/2026-04-20_collated/$PLOTS_PATH/ablation_crps_model_size
+
+# ---
+
+# PLOTS_PATH=2026-04-08_plots
+
+# # CRPS variants
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (large)"\
+# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (large)"\
+# 	--run crps_sw2d64_vit_azula_large_60114bf_5d5c8e1 "ViT (1024)"\
+# 	--run crps_sw2d64_vit_azula_large_concat_60114bf_acf9189 "ViT (concat)"\
+# 	--run epd_sw2d64_vit_azula_large_8c5f696_c5f3ea9 "ViT (MAE loss)"\
+# 	--run crps_sw2d64_vit_azula_large_feb5e43_c630eda "ViT (afCRPS loss)"\
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/sw_crps_variants
+
+# # 23hrs
+# autocast-plots --results-dir outputs/2026-04-01_collated --sort Date --filter "Dataset=SW2D64 AND (Model=AzulaViTProcessor OR Model=FlowMatchingProcessor) AND Resolution=64x64 AND scale=large" \
+# 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (large)" \
+# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (large)" \
+# 	--run crps_sw2d64_vit_azula_large_feb5e43_90e3465 "ViT (23hrs)" \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--color-by-label \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/sw_23hrs
+
+# # Comparison of 1:4, 1:1 and 2:1
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_55a4d1a_511e7b1 "FM (1:4)" \
+# 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (1:4)" \
+# 	--run crps_cns64_vit_azula_large_8fe25aa_d105b90 "ViT (1:4)" \
+# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (1:4)" \
+# 	--run diff_cns64_flow_matching_vit_13eba33_1f075ac "FM (1:1)" \
+# 	--run diff_sw2d64_flow_matching_vit_13eba33_0bc663c "FM (1:1)" \
+# 	--run crps_cns64_vit_azula_large_feb5e43_91c22c0 "ViT (1:1)" \
+# 	--run crps_sw2d64_vit_azula_large_feb5e43_bb3bf07 "ViT (1:1)" \
+# 	--run diff_cns64_flow_matching_vit_13eba33_9305e6a "FM (2:1)" \
+# 	--run diff_sw2d64_flow_matching_vit_13eba33_02cb549 "FM (2:1)" \
+# 	--run crps_cns64_vit_azula_large_feb5e43_b8f68ac "ViT (2:1)" \
+# 	--run crps_sw2d64_vit_azula_large_feb5e43_ffb68ce "ViT (2:1)" \
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/1_4_vs_1_1_vs_2_1_no_cached_latents
+
+# # Comparison of 1:4 and 8x gradient steps
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_55a4d1a_511e7b1 "FM (1:4)" \
+# 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (1:4)" \
+# 	--run diff_cns64_flow_matching_vit_c3c9713_d2bcaa2 "FM (64, 24hrs)" \
+# 	--run diff_sw2d64_flow_matching_vit_c3c9713_e4e3ba5 "FM (64, 24hrs)" \
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/fm_8x
+
+# # Comparison with 128x128
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run crps_shallow_water2d_128_vit_azula_large_05cf9ff_29b49a6 "ViT 128x128" \
+# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT 64x64" \
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/128x128
+
+# # Comparison with ODE steps
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_c3c9713_d2bcaa2_25 "FM (25 steps)" \
+# 	--run diff_cns64_flow_matching_vit_c3c9713_d2bcaa2 "FM (50 steps)" \
+# 	--run diff_cns64_flow_matching_vit_c3c9713_d2bcaa2_100 "FM (100 steps)" \
+# 	--run diff_sw2d64_flow_matching_vit_c3c9713_e4e3ba5_25 "FM (25 steps)" \
+# 	--run diff_sw2d64_flow_matching_vit_c3c9713_e4e3ba5 "FM (50 steps)" \
+# 	--run diff_sw2d64_flow_matching_vit_c3c9713_e4e3ba5_100 "FM (100 steps)" \
+# 	--color-by-label \
+# 	--group-hues 0 0 0 0 0 0 \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/ode_steps
+
+
+# # Comparison of 1:4, longer 1:4, smoother optimizer 1:4
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run crps_cns64_vit_azula_large_8fe25aa_d105b90 "ViT" \
+# 	--run diff_cns64_flow_matching_vit_55a4d1a_511e7b1 "FM" \
+# 	--run diff_cns64_flow_matching_vit_13eba33_82f423d "FM (36hrs)" \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (lr=1e-4)" \
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/longer_training_and_smoother_optimizer
+
+# # Compare SW, CNS, GPE
+# # TODO: update SW, CNS and GPE with same training schedule (GPE currently 2e-4)
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run crps_cns64_vit_azula_large_eb4a4f6_294dc78 "ViT" \
+# 	--run crps_sw2d64_vit_azula_large_eb4a4f6_682f33b "ViT" \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM" \
+# 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM" \
+# 	--run crps_gpe_laser_only_wake_vit_azula_large_feb5e43_699855c "ViT" \
+# 	--run diff_gpe_laser_only_wake_flow_matching_vit_2007857_7ee7dea "FM" \
+# 	--color-by-label \
+# 	--dataset-order SW CNS GPE \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/sw_cns_gpe
+
+# # Compare DM, FM, ViT for SW, CNS
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run crps_cns64_vit_azula_large_eb4a4f6_294dc78 "ViT" \
+# 	--run crps_sw2d64_vit_azula_large_eb4a4f6_682f33b "ViT" \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM" \
+# 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM" \
+# 	--run diff_cns64_diffusion_vit_fc5b63a_3c040a7 "DM" \
+# 	--run diff_sw2d64_diffusion_vit_3dd3cf5_e849015 "DM" \
+# 	--color-by-label \
+# 	--dataset-order SW CNS \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/crps_fm_dm
+
+# # Compare ViT and FM for batch_size 32 and 128 trained over 12hrs 1GPU / 3hrs 4GPU
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM" \
+# 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM" \
+# 	--run crps_cns64_vit_azula_large_8fe25aa_d105b90 "ViT (n=256, CRPS, h=768, bs=32)" \
+# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (n=256, CRPS, h=768, bs=32)" \
+# 	--run crps_cns64_vit_azula_large_eb4a4f6_294dc78 "ViT (n=256, CRPS, h=768, bs=128)" \
+# 	--run crps_sw2d64_vit_azula_large_eb4a4f6_682f33b "ViT (n=256, CRPS, h=768, bs=128)" \
+# 	--color-by-label \
+# 	--dataset-order SW CNS \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/crps_fm_vits_bs_32_vs_128
+
+
+# # Compare DM, FM, ViT for SW, CNS
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM" \
+# 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM" \
+# 	--run crps_cns64_vit_azula_large_eb4a4f6_294dc78 "ViT (n=256, CRPS, h=768)" \
+# 	--run crps_sw2d64_vit_azula_large_eb4a4f6_682f33b "ViT (n=256, CRPS, h=768)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (n=1024, afCRPS, h=632)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_4268ef8 "ViT (n=1024, afCRPS, h=768)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_4268ef8 "ViT (n=1024, afCRPS, h=768)" \
+# 	--run crps_sw2d64_vit_azula_large_468b553_0bdf23f "ViT (n=256, CRPS, h=768, bs=256, bf16)" \
+# 	--color-by-label \
+# 	--dataset-order SW CNS \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/crps_fm_vits_comparison_before_24hrs
+
+
+# # # Compare FM, ViT for SW, CNS with long 24hrs runs
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (3hrs)" \
+# 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_ab31602 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM (3hrs)" \
+# 	--run diff_sw2d64_flow_matching_vit_1ed9013_5529d56 "FM (24hrs)" \
+# 	--run crps_sw2d64_vit_azula_large_1ed9013_6ab9fa2 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--dataset-order SW CNS \
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/crps_fm_vits_comparison_24hrs
+
+
+# # Compare FM, ViT for SW, CNS with long 24hrs runs
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (3hrs)" \
+# 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_ab31602 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM (3hrs)" \
+# 	--run diff_sw2d64_flow_matching_vit_1ed9013_5529d56 "FM (24hrs)" \
+# 	--run crps_sw2d64_vit_azula_large_1ed9013_6ab9fa2 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--dataset-order SW CNS \
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/crps_fm_vits_comparison_24hrs_v
+	
+
+# # Compare FM, ViT for CNS with varying batch size, training time, precision and model size
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (3hrs)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_ab31602 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
+# 	--run crps_cns64_vit_azula_large_6bb8774_bb210b3 "ViT (3hrs, n=1024, afCRPS, h=632, bf16)" \
+# 	--run crps_cns64_vit_azula_large_52e1abc_1ca7096 "ViT (3hrs, n=4096, afCRPS, h=608, bf16, bs=32)" \
+# 	--run crps_cns64_vit_azula_large_concat_c8ff6c2_e36b786 "ViT (3hrs, n=1024, afCRPS, h=632, concat, bf16)" \
+# 	--dataset-order CNS \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/crps_vits_bf16_4096_vs_1024
+# 	# --color-by-label \
+
+# # Compare FM, ViT for SW, CNS with long 24hrs runs
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs)" \
+# 	--run diff_cns64_flow_matching_vit_1ed9013_893624d_ode_method "FM (24hrs, Adams-Bashforth)" \
+# 	--dataset-order CNS \
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/fm_24hrs_adams_bashforth
+	
+
+# # Revisit recents runs including comparison:
+# # - between optimizer with cosine period of 2 epochs compared
+# # - 3hrs on 4GPU (or 12hrs on 1GPU) compared to 24hrs on 4GPU
+# # - updated 4x batch size, 4x hidden dimension, afCRPS vs CRPS for ViT
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run diff_cns64_flow_matching_vit_55a4d1a_511e7b1 "FM (12hrs, old optim)" \
+# 	--run diff_cns64_flow_matching_vit_2007857_2cfb01f "FM (3hrs)" \
+# 	--run diff_cns64_flow_matching_vit_1ed9013_893624d "FM (24hrs)" \
+# 	--run crps_cns64_vit_azula_large_8fe25aa_d105b90 "ViT (12hrs, 1GPU, n=256, CRPS, h=768, old optim)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_ab31602 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--run diff_sw2d64_flow_matching_vit_4d5fcbd_067529b "FM (12hrs, old optim)" \
+# 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM (3hrs)" \
+# 	--run diff_sw2d64_flow_matching_vit_1ed9013_5529d56 "FM (24hrs)" \
+# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (12hrs, 1GPU, n=256, CRPS, h=768, old optim)" \
+# 	--run crps_cns64_vit_azula_large_1ed9013_babdaa8 "ViT (3hrs, n=1024, afCRPS, h=632)" \
+# 	--run crps_sw2d64_vit_azula_large_1ed9013_6ab9fa2 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--dataset-order SW, CNS\
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/optimizer_24hrs_crps-changes_comparison
+
+# # Revisit b16-mixed with lower batch size and updated optimizers:
+# # TODO: add once eval completed
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run crps_sw2d64_vit_azula_large_8fe25aa_74f91d8 "ViT (12hrs, 1GPU, n=256, CRPS, h=768, old optim)" \
+# 	--run crps_sw2d64_vit_azula_large_1ed9013_6ab9fa2 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--run crps_sw2d64_vit_azula_large_ed15816_085752e "ViT (6hrs, n=1024, afCRPS, h=632, b16-mixed, bs=32)" \
+# 	--dataset-order SW\
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/b16-mixed_lower_bs_comparison
+
+# # SW in ambient compared to latent
+# autocast-plots --results-dir outputs/2026-04-01_collated \
+# 	--run crps_sw2d64_vit_azula_large_1ed9013_6ab9fa2 "ViT (24hrs, n=1024, afCRPS, h=632)" \
+# 	--run diff_sw2d64_flow_matching_vit_cb09424_7566c5e "FM (3hrs)" \
+# 	--run diff_sw2d64_flow_matching_vit_53e8e0e_933bcfa "FM (3hrs ambient, new optim)" \
+# 	--run diff_sw2d64_flow_matching_vit_53e8e0e_933bcfa_ema "FM (3hrs ambient, new optim, EMA)" \
+# 	--dataset-order SW\
+# 	--color-by-label \
+# 	--error-ylim 1e-3 1 \
+# 	--lead-time-error-metrics vrmse rmse \
+# 	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+# 	--combined-lead-time \
+# 	--training-metrics val_loss train_loss \
+# 	--training-yscale log \
+# 	--panel-figure \
+# 	--output-dir outputs/2026-04-01_collated/$PLOTS_PATH/sw_ambient_vs_latent

--- a/scripts/plots_final_results.sh
+++ b/scripts/plots_final_results.sh
@@ -1,0 +1,499 @@
+#!/bin/bash
+set -euo pipefail
+
+PLOTS_PATH=${PLOTS_PATH:-2026-05-19_final_plots}
+RESULTS_DIR=${RESULTS_DIR:-outputs/2026-05-15_collated}
+OUTPUT_DIR=${OUTPUT_DIR:-$RESULTS_DIR/$PLOTS_PATH/main_comparison_m8_complete_no_fm_amb_best_winkler}
+FIGURE_FORMATS=${FIGURE_FORMATS:-png}
+PAPER_OUTPUT_DIR=${PAPER_OUTPUT_DIR:-$RESULTS_DIR/$PLOTS_PATH/paper_figures}
+PAPER_USE_TEX=${PAPER_USE_TEX:-false}
+PAPER_PANEL_LABELS=${PAPER_PANEL_LABELS:-true}
+
+# Keep colours stable across all final plots. These are indices into matplotlib's
+# tab10 palette as used by the explicit hue argument.
+HUE_CRPS=0
+HUE_FM_LATENT=1
+HUE_CRPS_LATENT=2
+HUE_FM_AMBIENT=3
+HUE_DM=4
+HUE_ABLATION_ALT_1=1
+HUE_ABLATION_ALT_2=2
+HUE_ABLATION_ALT_3=3
+HUE_ODE_ABLATION_STEPS=5
+HUE_ODE_MAIN=$HUE_FM_LATENT
+
+PAPER_MAIN_FIGURES=false
+FOUR_DS_ABLATION=false
+ONE_DS_ABLATION=false
+PAPER_ONLY=false
+
+usage() {
+	cat <<'EOF'
+Usage: scripts/plots_final_results.sh [OPTIONS]
+
+Options:
+  --paper-main-figures  Add paper-width main-result figures to OUTPUT_DIR,
+                        including the multi-metric lead-time summary.
+  --four-ds-ablation    Add four-dataset ablation figures to multi-dataset ablations.
+  --one-ds-ablation     Add the one-dataset ablation paper figure.
+  --paper-figures       Add all optional paper-width figures above.
+  --paper-only          Only run/copy paper figures, writing PNG and PDF.
+  --paper-output-dir DIR
+                        Copy all paper_*.png/pdf figures into DIR.
+                        Default: <results-dir>/<plots-path>/paper_figures.
+  --paper-use-tex       Render text/math with external LaTeX.
+  --no-paper-panel-labels
+                        Disable a), b), c) labels on combined paper figures.
+  --pdf                 Write both PNG and PDF figures.
+  --figure-formats FMT  Write selected formats, comma-separated or quoted.
+                        Example: --figure-formats png,pdf
+  -h, --help            Show this help.
+
+By default the script preserves the standard output set and does not write
+paper_*.png files. Pass --paper-figures to generate the paper-ready variants.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--paper-main-figures)
+			PAPER_MAIN_FIGURES=true
+			;;
+		--four-ds-ablation)
+			FOUR_DS_ABLATION=true
+			;;
+		--one-ds-ablation)
+			ONE_DS_ABLATION=true
+			;;
+		--paper-figures)
+			PAPER_MAIN_FIGURES=true
+			FOUR_DS_ABLATION=true
+			ONE_DS_ABLATION=true
+			;;
+		--paper-only)
+			PAPER_MAIN_FIGURES=true
+			FOUR_DS_ABLATION=true
+			ONE_DS_ABLATION=true
+			PAPER_ONLY=true
+			;;
+		--paper-output-dir)
+			if [[ $# -lt 2 ]]; then
+				echo "--paper-output-dir requires a value" >&2
+				exit 2
+			fi
+			PAPER_OUTPUT_DIR=$2
+			shift
+			;;
+		--paper-use-tex)
+			PAPER_USE_TEX=true
+			;;
+		--no-paper-panel-labels)
+			PAPER_PANEL_LABELS=false
+			;;
+		--pdf)
+			FIGURE_FORMATS="png pdf"
+			;;
+		--figure-formats)
+			if [[ $# -lt 2 ]]; then
+				echo "--figure-formats requires a value" >&2
+				exit 2
+			fi
+			FIGURE_FORMATS=${2//,/ }
+			shift
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown option: $1" >&2
+			usage >&2
+			exit 2
+			;;
+	esac
+	shift
+done
+
+FIGURE_FORMAT_ARRAY=()
+read -r -a FIGURE_FORMAT_ARRAY <<< "$FIGURE_FORMATS"
+if [[ "$PAPER_MAIN_FIGURES" == true || "$FOUR_DS_ABLATION" == true || "$ONE_DS_ABLATION" == true ]]; then
+	case " ${FIGURE_FORMAT_ARRAY[*]} " in
+		*" png "*) ;;
+		*) FIGURE_FORMAT_ARRAY+=(png) ;;
+	esac
+	case " ${FIGURE_FORMAT_ARRAY[*]} " in
+		*" pdf "*) ;;
+		*) FIGURE_FORMAT_ARRAY+=(pdf) ;;
+	esac
+fi
+FIGURE_FORMAT_ARGS=(--figure-formats "${FIGURE_FORMAT_ARRAY[@]}")
+BASE_PLOT_ARGS=("${FIGURE_FORMAT_ARGS[@]}")
+if [[ "$PAPER_USE_TEX" == true ]]; then
+	BASE_PLOT_ARGS+=(--paper-use-tex)
+fi
+if [[ "$PAPER_ONLY" == true ]]; then
+	BASE_PLOT_ARGS+=(--paper-only)
+fi
+if [[ "$PAPER_PANEL_LABELS" != true ]]; then
+	BASE_PLOT_ARGS+=(--no-paper-panel-labels)
+fi
+
+
+COMMON_ARGS=(
+	"${BASE_PLOT_ARGS[@]}"
+	--dataset-order CNS
+	--error-ylim 1e-5 1
+	--lead-time-error-metrics vrmse
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1
+	--lead-time-coverage-delta
+	--combined-lead-time
+	--training-metrics val_loss train_loss
+	--training-yscale log
+	--panel-figure
+	--panel-figure-no-training
+	--coverage-panel-overall-rollout-windows
+	--uniform-run-hue-color
+	--tick-label-scale 1.5
+	--axis-label-scale 1.3
+	--legend-font-scale 1.5
+	--short-axis-labels
+	--shared-axis-labels
+	--coverage-panel-height-scale 1.5
+)
+
+if [[ "$ONE_DS_ABLATION" == true ]]; then
+	COMMON_ARGS+=(--one-ds-ablation)
+fi
+
+PAPER_MAIN_ARG=
+if [[ "$PAPER_MAIN_FIGURES" == true ]]; then
+	PAPER_MAIN_ARG=--paper-main-figures
+fi
+
+FOUR_DS_ABLATION_ARG=
+if [[ "$FOUR_DS_ABLATION" == true ]]; then
+	FOUR_DS_ABLATION_ARG=--four-ds-ablation
+fi
+
+ALL_DATASET_COMMON_ARGS=(
+	"${BASE_PLOT_ARGS[@]}"
+	--dataset-order AD CNS GS GPE
+	--error-ylim 1e-5 1
+	--lead-time-error-metrics vrmse
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1
+	--lead-time-coverage-delta
+	--combined-lead-time
+	--training-metrics val_loss train_loss
+	--training-yscale log
+	--panel-figure
+	--panel-figure-no-training
+	--coverage-panel-overall-rollout-windows
+	--tick-label-scale 1.5
+	--axis-label-scale 1.3
+	--legend-font-scale 1.5
+	--short-axis-labels
+	--shared-axis-labels
+	--coverage-panel-height-scale 1.5
+)
+
+if [[ "$FOUR_DS_ABLATION" == true ]]; then
+	ALL_DATASET_COMMON_ARGS+=(--four-ds-ablation)
+fi
+
+echo "Writing plots under: $RESULTS_DIR/$PLOTS_PATH"
+echo "Writing figure formats: ${FIGURE_FORMAT_ARRAY[*]}"
+if [[ "$PAPER_MAIN_FIGURES" == true || "$FOUR_DS_ABLATION" == true || "$ONE_DS_ABLATION" == true ]]; then
+	echo "Collecting paper figures under: $PAPER_OUTPUT_DIR"
+fi
+if [[ "$PAPER_USE_TEX" == true ]]; then
+	echo "Rendering plot text with LaTeX."
+fi
+if [[ "$PAPER_ONLY" == true ]]; then
+	echo "Paper-only mode enabled."
+fi
+if [[ "$PAPER_MAIN_FIGURES" != true && "$FOUR_DS_ABLATION" != true && "$ONE_DS_ABLATION" != true ]]; then
+	echo "Paper-ready outputs are disabled. Run with --paper-figures to write paper_*.png files."
+fi
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	"${BASE_PLOT_ARGS[@]}" \
+	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_bed4611_e0a6df5 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_bed4611_828a161 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM" "$HUE_FM_LATENT" \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM" "$HUE_FM_LATENT" \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM" "$HUE_FM_LATENT" \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM" "$HUE_FM_LATENT" \
+	--dataset-order AD CNS GS GPE \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--uniform-run-hue-color \
+	--tick-label-scale 1.5 \
+	--axis-label-scale 1.3 \
+	--legend-font-scale 1.5 \
+	--short-axis-labels \
+	--shared-axis-labels \
+	--coverage-panel-height-scale 1.5 \
+	${PAPER_MAIN_ARG:+$PAPER_MAIN_ARG} \
+	--output-dir "$OUTPUT_DIR"
+
+if [[ "$PAPER_ONLY" != true ]]; then
+	# Same as above but rendered smaller so the two coverage panels read well when
+	# paired side-by-side in LaTeX (each at ~0.5\textwidth).
+	autocast-plots --results-dir "$RESULTS_DIR" \
+		"${BASE_PLOT_ARGS[@]}" \
+		--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+		--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+		--run crps_gpe64_vit_azula_large_bed4611_e0a6df5 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+		--run crps_gs64_vit_azula_large_bed4611_828a161 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+		--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM" "$HUE_FM_LATENT" \
+		--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM" "$HUE_FM_LATENT" \
+		--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM" "$HUE_FM_LATENT" \
+		--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM" "$HUE_FM_LATENT" \
+		--dataset-order AD CNS GS GPE \
+		--error-ylim 1e-5 1 \
+		--lead-time-error-metrics vrmse \
+		--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+		--lead-time-coverage-delta \
+		--combined-lead-time \
+		--training-metrics val_loss train_loss \
+		--training-yscale log \
+		--panel-figure \
+		--panel-figure-no-training \
+		--coverage-panel-overall-rollout-windows \
+		--uniform-run-hue-color \
+		--tick-label-scale 1.5 \
+		--axis-label-scale 1.3 \
+		--legend-font-scale 1.5 \
+		--short-axis-labels \
+		--shared-axis-labels \
+		--coverage-panel-height-scale 1.5 \
+		--figure-scale 0.6 \
+		--output-dir "${OUTPUT_DIR}_pairfig"
+fi
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	"${ALL_DATASET_COMMON_ARGS[@]}" \
+	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS (ambient)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (ambient)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_bed4611_e0a6df5 "CRPS (ambient)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_bed4611_828a161 "CRPS (ambient)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_ad64_vit_azula_large_3b47441_3ad3562 "CRPS (latent)" "$HUE_CRPS_LATENT" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_9c98db0_4b2a1a5 "CRPS (latent)" "$HUE_CRPS_LATENT" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_3b47441_1c8e446 "CRPS (latent)" "$HUE_CRPS_LATENT" eval=eval_best_multiwinkler_from0p25 \
+	--run diff_ad64_flow_matching_vit_0f89f06_725d44a "FM (ambient)" "$HUE_FM_AMBIENT" \
+	--run diff_cns64_flow_matching_vit_0f89f06_483bb70 "FM (ambient)" "$HUE_FM_AMBIENT" \
+	--run diff_gpe64_flow_matching_vit_0f89f06_3b3604d "FM (ambient)" "$HUE_FM_AMBIENT" \
+	--run diff_gs64_flow_matching_vit_0f89f06_6e3a299 "FM (ambient)" "$HUE_FM_AMBIENT" \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "FM (latent)" "$HUE_FM_LATENT" \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" "$HUE_FM_LATENT" \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "FM (latent)" "$HUE_FM_LATENT" \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" "$HUE_FM_LATENT" \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_ambient_fm_latent_crps_m8"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" "$HUE_FM_LATENT" \
+	--run diff_cns64_diffusion_vit_0c75022_80967c4 "DM (latent)" "$HUE_DM" eval=eval_encode_once \
+	"${COMMON_ARGS[@]}" \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_dm_latent"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "ODE=1" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode001 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "ODE=1" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode001 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "ODE=1" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode001 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "ODE=1" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode001 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "ODE=5" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode005 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "ODE=5" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode005 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "ODE=5" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode005 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "ODE=5" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode005 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "ODE=10" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode010 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "ODE=10" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode010 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "ODE=10" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode010 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "ODE=10" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode010 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "ODE=25" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode025 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "ODE=25" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode025 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "ODE=25" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode025 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "ODE=25" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode025 \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "ODE=50" "$HUE_ODE_MAIN" eval=eval \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "ODE=50" "$HUE_ODE_MAIN" eval=eval \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "ODE=50" "$HUE_ODE_MAIN" eval=eval \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "ODE=50" "$HUE_ODE_MAIN" eval=eval \
+	--run diff_ad64_flow_matching_vit_09490da_dae1382 "ODE=100" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode100 \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "ODE=100" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode100 \
+	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "ODE=100" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode100 \
+	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "ODE=100" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode100 \
+	"${ALL_DATASET_COMMON_ARGS[@]}" \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_fm_ode_steps"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	"${BASE_PLOT_ARGS[@]}" \
+	--run crps_ad64_vit_azula_large_0f89f06_4667606 "CRPS (best val loss)" "$HUE_ABLATION_ALT_2" eval=eval \
+	--run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (best val loss)" "$HUE_ABLATION_ALT_2" eval=eval \
+	--run crps_gpe64_vit_azula_large_0f89f06_d337bd8 "CRPS (best val loss)" "$HUE_ABLATION_ALT_2" eval=eval \
+	--run crps_gs64_vit_azula_large_0f89f06_779325a "CRPS (best val loss)" "$HUE_ABLATION_ALT_2" eval=eval \
+	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS (multiwinkler)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (multiwinkler)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_bed4611_e0a6df5 "CRPS (multiwinkler)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_bed4611_828a161 "CRPS (multiwinkler)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--dataset-order AD CNS GS GPE \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--uniform-run-hue-color \
+	--tick-label-scale 1.5 \
+	--axis-label-scale 1.3 \
+	--legend-font-scale 1.5 \
+	--short-axis-labels \
+	--shared-axis-labels \
+	--coverage-panel-height-scale 1.5 \
+	${FOUR_DS_ABLATION_ARG:+$FOUR_DS_ABLATION_ARG} \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_crps_multiwinkler_eval_m8"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (6x)" "$HUE_FM_LATENT" \
+	--run diff_cns64_flow_matching_vit_43cbdde_bb55197 "FM (24x)" "$HUE_ABLATION_ALT_2" eval=eval_encode_once \
+	"${COMMON_ARGS[@]}" \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_fm_autoencoder"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (channel concatenation)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_9c98db0_2fa67c5 "CRPS (backbone modulation)" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
+	"${COMMON_ARGS[@]}" \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_global_conditioning_m8"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "ViT" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_unet_azula_large_9c98db0_65f8f71 "U-Net" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
+	"${COMMON_ARGS[@]}" \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_vit_unet_m8"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	"${ALL_DATASET_COMMON_ARGS[@]}" \
+	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS (\$\alpha\$fCRPS loss)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (\$\alpha\$fCRPS loss)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_bed4611_e0a6df5 "CRPS (\$\alpha\$fCRPS loss)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_bed4611_828a161 "CRPS (\$\alpha\$fCRPS loss)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_9c98db0_6a91c49 "CRPS (CRPS loss)" "$HUE_ABLATION_ALT_1" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_ad64_vit_azula_large_5a8c216_9978d9b "CRPS (fCRPS loss)" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_9c98db0_d2a0496 "CRPS (fCRPS loss)" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_5a8c216_2b1460a "CRPS (fCRPS loss)" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_5a8c216_2ced703 "CRPS (fCRPS loss)" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_crps_variants"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	"${BASE_PLOT_ARGS[@]}" \
+	--run crps_cns64_vit_azula_large_9c98db0_957ff88 "M=4" "$HUE_ABLATION_ALT_1" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_ad64_vit_azula_large_189c141_bbb0bc8 "M=4" "$HUE_ABLATION_ALT_1" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_3b47441_4944cce "M=4" "$HUE_ABLATION_ALT_1" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_189c141_ce8db86 "M=4" "$HUE_ABLATION_ALT_1" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_ad64_vit_azula_large_bed4611_da01a04 "M=8" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "M=8" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_bed4611_e0a6df5 "M=8" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_bed4611_828a161 "M=8" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_ad64_vit_azula_large_bed4611_69c99bf "M=16" "$HUE_ABLATION_ALT_3" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_bed4611_5758ebc "M=16" "$HUE_ABLATION_ALT_3" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gpe64_vit_azula_large_bed4611_6b78265 "M=16" "$HUE_ABLATION_ALT_3" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_gs64_vit_azula_large_bed4611_4d04729 "M=16" "$HUE_ABLATION_ALT_3" eval=eval_best_multiwinkler_from0p25 \
+	--dataset-order AD CNS GS GPE \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--uniform-run-hue-color \
+	--tick-label-scale 1.5 \
+	--axis-label-scale 1.3 \
+	--legend-font-scale 1.5 \
+	--short-axis-labels \
+	--shared-axis-labels \
+	--coverage-panel-height-scale 1.5 \
+	${FOUR_DS_ABLATION_ARG:+$FOUR_DS_ABLATION_ARG} \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_ensemble_size"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	--run crps_cns64_vit_azula_large_bed4611_c99f534 "noise=1024, h=568" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
+	--run crps_cns64_vit_azula_large_9c98db0_86e355d "noise=256, h=704" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
+	"${COMMON_ARGS[@]}" \
+	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_noise_channels"
+
+if [[ "$PAPER_MAIN_FIGURES" == true || "$FOUR_DS_ABLATION" == true || "$ONE_DS_ABLATION" == true ]]; then
+	mkdir -p "$PAPER_OUTPUT_DIR/png" "$PAPER_OUTPUT_DIR/pdf" "$PAPER_OUTPUT_DIR/tables"
+	SKIPPED_PAPER_DIRS=(
+		ablation_cns_dm
+		ablation_fm_ema
+	)
+	for ext in png pdf; do
+		rm -f "$PAPER_OUTPUT_DIR/$ext/"*_paper_one_ds_ablation_b."$ext"
+		for skipped_dir in "${SKIPPED_PAPER_DIRS[@]}"; do
+			rm -f "$PAPER_OUTPUT_DIR/$ext/${skipped_dir}_"*."$ext"
+		done
+	done
+	rm -f "$PAPER_OUTPUT_DIR/tables/"*.csv "$PAPER_OUTPUT_DIR/tables/"*.tex
+	copied=0
+	while IFS= read -r fig; do
+		src_dir=$(basename "$(dirname "$fig")")
+		fig_name=$(basename "$fig")
+		case "$fig_name" in
+			paper_one_ds_ablation_b.*)
+				continue
+				;;
+		esac
+		case "$src_dir" in
+			ablation_cns_dm | ablation_fm_ema)
+				continue
+				;;
+		esac
+		ext=${fig##*.}
+		dest_name="${src_dir}_${fig_name}"
+		cp "$fig" "$PAPER_OUTPUT_DIR/$ext/$dest_name"
+		copied=$((copied + 1))
+	done < <(
+		find "$RESULTS_DIR/$PLOTS_PATH" \
+			-path "$PAPER_OUTPUT_DIR" -prune -o \
+			-path "$RESULTS_DIR/$PLOTS_PATH/ablation_fm_ema" -prune -o \
+			-path "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_dm" -prune -o \
+			-type f \( -name 'paper_*.png' -o -name 'paper_*.pdf' \) \
+			-print
+	)
+	echo "Copied $copied paper figure files to: $PAPER_OUTPUT_DIR/{png,pdf}"
+	copied_tables=0
+	while IFS= read -r table; do
+		src_dir=$(basename "$(dirname "$table")")
+		case "$src_dir" in
+			ablation_cns_dm | ablation_fm_ema)
+				continue
+				;;
+		esac
+		cp "$table" "$PAPER_OUTPUT_DIR/tables/${src_dir}_$(basename "$table")"
+		copied_tables=$((copied_tables + 1))
+	done < <(
+		find "$RESULTS_DIR/$PLOTS_PATH" \
+			-path "$PAPER_OUTPUT_DIR" -prune -o \
+			-path "$RESULTS_DIR/$PLOTS_PATH/ablation_fm_ema" -prune -o \
+			-path "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_dm" -prune -o \
+			-type f \( -name 'single_step_overall_results.csv' -o -name 'single_step_overall_results.tex' \) \
+			-print
+	)
+	echo "Copied $copied_tables table result files to: $PAPER_OUTPUT_DIR/tables"
+fi

--- a/scripts/plots_final_results.sh
+++ b/scripts/plots_final_results.sh
@@ -215,7 +215,7 @@ if [[ "$PAPER_MAIN_FIGURES" != true && "$FOUR_DS_ABLATION" != true && "$ONE_DS_A
 	echo "Paper-ready outputs are disabled. Run with --paper-figures to write paper_*.png files."
 fi
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	"${BASE_PLOT_ARGS[@]}" \
 	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
 	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
@@ -249,7 +249,7 @@ autocast-plots --results-dir "$RESULTS_DIR" \
 if [[ "$PAPER_ONLY" != true ]]; then
 	# Same as above but rendered smaller so the two coverage panels read well when
 	# paired side-by-side in LaTeX (each at ~0.5\textwidth).
-	autocast-plots --results-dir "$RESULTS_DIR" \
+	uv run autocast-plots --results-dir "$RESULTS_DIR" \
 		"${BASE_PLOT_ARGS[@]}" \
 		--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
 		--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
@@ -281,7 +281,7 @@ if [[ "$PAPER_ONLY" != true ]]; then
 		--output-dir "${OUTPUT_DIR}_pairfig"
 fi
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	"${ALL_DATASET_COMMON_ARGS[@]}" \
 	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS (ambient)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
 	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (ambient)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
@@ -300,13 +300,13 @@ autocast-plots --results-dir "$RESULTS_DIR" \
 	--run diff_gs64_flow_matching_vit_09490da_7e9e331 "FM (latent)" "$HUE_FM_LATENT" \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_ambient_fm_latent_crps_m8"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (latent)" "$HUE_FM_LATENT" \
 	--run diff_cns64_diffusion_vit_0c75022_80967c4 "DM (latent)" "$HUE_DM" eval=eval_encode_once \
 	"${COMMON_ARGS[@]}" \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_dm_latent"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	--run diff_ad64_flow_matching_vit_09490da_dae1382 "ODE=1" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode001 \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "ODE=1" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode001 \
 	--run diff_gpe64_flow_matching_vit_09490da_47bf39a "ODE=1" "$HUE_ODE_ABLATION_STEPS" eval=eval_encode_once_ode001 \
@@ -334,7 +334,7 @@ autocast-plots --results-dir "$RESULTS_DIR" \
 	"${ALL_DATASET_COMMON_ARGS[@]}" \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_fm_ode_steps"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	"${BASE_PLOT_ARGS[@]}" \
 	--run crps_ad64_vit_azula_large_0f89f06_4667606 "CRPS (best val loss)" "$HUE_ABLATION_ALT_2" eval=eval \
 	--run crps_cns64_vit_azula_large_0f89f06_5b7332b "CRPS (best val loss)" "$HUE_ABLATION_ALT_2" eval=eval \
@@ -365,25 +365,25 @@ autocast-plots --results-dir "$RESULTS_DIR" \
 	${FOUR_DS_ABLATION_ARG:+$FOUR_DS_ABLATION_ARG} \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_crps_multiwinkler_eval_m8"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	--run diff_cns64_flow_matching_vit_09490da_636fcc3 "FM (6x)" "$HUE_FM_LATENT" \
 	--run diff_cns64_flow_matching_vit_43cbdde_bb55197 "FM (24x)" "$HUE_ABLATION_ALT_2" eval=eval_encode_once \
 	"${COMMON_ARGS[@]}" \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_fm_autoencoder"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (channel concatenation)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
 	--run crps_cns64_vit_azula_large_9c98db0_2fa67c5 "CRPS (backbone modulation)" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
 	"${COMMON_ARGS[@]}" \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_global_conditioning_m8"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	--run crps_cns64_vit_azula_large_bed4611_c99f534 "ViT" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
 	--run crps_cns64_unet_azula_large_9c98db0_65f8f71 "U-Net" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
 	"${COMMON_ARGS[@]}" \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_cns_vit_unet_m8"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	"${ALL_DATASET_COMMON_ARGS[@]}" \
 	--run crps_ad64_vit_azula_large_bed4611_da01a04 "CRPS (\$\alpha\$fCRPS loss)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
 	--run crps_cns64_vit_azula_large_bed4611_c99f534 "CRPS (\$\alpha\$fCRPS loss)" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
@@ -396,7 +396,7 @@ autocast-plots --results-dir "$RESULTS_DIR" \
 	--run crps_gs64_vit_azula_large_5a8c216_2ced703 "CRPS (fCRPS loss)" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_crps_variants"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	"${BASE_PLOT_ARGS[@]}" \
 	--run crps_cns64_vit_azula_large_9c98db0_957ff88 "M=4" "$HUE_ABLATION_ALT_1" eval=eval_best_multiwinkler_from0p25 \
 	--run crps_ad64_vit_azula_large_189c141_bbb0bc8 "M=4" "$HUE_ABLATION_ALT_1" eval=eval_best_multiwinkler_from0p25 \
@@ -431,7 +431,7 @@ autocast-plots --results-dir "$RESULTS_DIR" \
 	${FOUR_DS_ABLATION_ARG:+$FOUR_DS_ABLATION_ARG} \
 	--output-dir "$RESULTS_DIR/$PLOTS_PATH/ablation_ensemble_size"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	--run crps_cns64_vit_azula_large_bed4611_c99f534 "noise=1024, h=568" "$HUE_CRPS" eval=eval_best_multiwinkler_from0p25 \
 	--run crps_cns64_vit_azula_large_9c98db0_86e355d "noise=256, h=704" "$HUE_ABLATION_ALT_2" eval=eval_best_multiwinkler_from0p25 \
 	"${COMMON_ARGS[@]}" \

--- a/scripts/plots_rb_results.sh
+++ b/scripts/plots_rb_results.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+RESULTS_DIR=${RESULTS_DIR:-outputs/2026-05-18_rb}
+PLOTS_PATH=${PLOTS_PATH:-2026-05-18_plots_rb}
+OUTPUT_DIR=${OUTPUT_DIR:-$RESULTS_DIR/$PLOTS_PATH/rb_pair}
+FIGURE_FORMATS=${FIGURE_FORMATS:-png}
+
+FIGURE_FORMAT_ARRAY=()
+read -r -a FIGURE_FORMAT_ARRAY <<< "${FIGURE_FORMATS//,/ }"
+
+HUE_A=0
+HUE_B=1
+
+echo "Writing plots under: $OUTPUT_DIR"
+
+autocast-plots --results-dir "$RESULTS_DIR" \
+	--figure-formats "${FIGURE_FORMAT_ARRAY[@]}" \
+	--run diff_rayleigh_benard_flow_matching_vit_1de6ca4_5a7a7bb "FM (masked window)" "$HUE_A" \
+	--run diff_rayleigh_benard_flow_matching_vit_65377a2_acb8513 "FM (whole window)" "$HUE_B" \
+	--metrics vrmse_v2 coverage crps ssr \
+	--error-yscale linear \
+	--error-ylim 1e-5 1 \
+	--lead-time-error-metrics vrmse_v2 \
+	--lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1 \
+	--lead-time-coverage-delta \
+	--combined-lead-time \
+	--training-metrics val_loss train_loss \
+	--training-yscale log \
+	--panel-figure \
+	--panel-figure-no-training \
+	--coverage-panel-overall-rollout-windows \
+	--uniform-run-hue-color \
+	--tick-label-scale 1.5 \
+	--axis-label-scale 1.3 \
+	--legend-font-scale 1.5 \
+	--short-axis-labels \
+	--shared-axis-labels \
+	--coverage-panel-height-scale 1.5 \
+	--output-dir "$OUTPUT_DIR"

--- a/scripts/plots_rb_results.sh
+++ b/scripts/plots_rb_results.sh
@@ -14,7 +14,7 @@ HUE_B=1
 
 echo "Writing plots under: $OUTPUT_DIR"
 
-autocast-plots --results-dir "$RESULTS_DIR" \
+uv run autocast-plots --results-dir "$RESULTS_DIR" \
 	--figure-formats "${FIGURE_FORMAT_ARRAY[@]}" \
 	--run diff_rayleigh_benard_flow_matching_vit_1de6ca4_5a7a7bb "FM (masked window)" "$HUE_A" \
 	--run diff_rayleigh_benard_flow_matching_vit_65377a2_acb8513 "FM (whole window)" "$HUE_B" \

--- a/src/autocast/metrics/coverage.py
+++ b/src/autocast/metrics/coverage.py
@@ -121,7 +121,7 @@ class MultiCoverage(Metric):
         save_csv: bool = True,
     ):
         """
-        Plot reliability diagram showing expected vs observed coverage.
+        Plot reliability diagram showing nominal vs empirical coverage.
 
         Parameters
         ----------
@@ -159,7 +159,7 @@ class MultiCoverage(Metric):
         fig, ax = plt.subplots(figsize=(8, 8))
 
         # Optimal line (y=x)
-        ax.plot([0, 1], [0, 1], "k:", label="Expected", linewidth=2)
+        ax.plot([0, 1], [0, 1], "k:", label="Nominal", linewidth=2)
 
         # Plot channels
         observed_arr = np.stack(observed_channels)  # (L, C)
@@ -189,8 +189,8 @@ class MultiCoverage(Metric):
 
         # Plot mean coverage in bold
         ax.plot(levels, observed_means, "k-", linewidth=3, label="Mean")
-        ax.set_xlabel(r"Coverage level, $\alpha$")
-        ax.set_ylabel("Observed Coverage")
+        ax.set_xlabel(r"Nominal coverage (1 - $\alpha$)")
+        ax.set_ylabel("Empirical coverage")
         ax.set_title(title)
         ax.set_xlim(0, 1)
         ax.set_ylim(0, 1)
@@ -229,7 +229,7 @@ class MultiCoverage(Metric):
         save_path: Path or str
             Path for the PNG file. CSV will use the same path with .csv extension.
         levels: list of float
-            Coverage levels (expected coverage values).
+            Coverage levels (nominal coverage values).
         observed_means: list of float
             Mean observed coverage across all channels for each level.
         observed_channels: np.ndarray, shape (L, C)

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -87,6 +87,14 @@ from autocast.utils.plots import (
 
 log = logging.getLogger(__name__)
 
+
+def _metric_window_interval_label(window: tuple[int, int] | None) -> str:
+    """Format metric windows as closed-open intervals for plot labels."""
+    if window is None:
+        return "all"
+    return f"[{window[0]}:{window[1]})"
+
+
 AVAILABLE_METRICS = {
     "mae": MAE,
     "mse": MSE,
@@ -488,7 +496,10 @@ def _process_metrics_results(
                 metric.plot(
                     save_path=plot_dir
                     / f"{log_prefix.lower()}_coverage_window_{window_str}.png",
-                    title=f"{log_prefix} Coverage Window {window}",
+                    title=(
+                        f"{log_prefix} Coverage Window "
+                        f"{_metric_window_interval_label(window)}"
+                    ),
                 )
 
             # Try to get a scalar value for csv

--- a/src/autocast/scripts/plot_dataset_comparisons.py
+++ b/src/autocast/scripts/plot_dataset_comparisons.py
@@ -5,6 +5,7 @@ import math
 import re
 import sys
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, SupportsIndex, cast
@@ -202,6 +203,16 @@ SINGLE_STEP_RESULTS_LOWER_IS_BETTER = {
 SINGLE_STEP_RESULTS_TARGET_METRICS = {"SSR": 1.0}
 
 
+@dataclass(frozen=True)
+class RunTarget:
+    """Resolved run target plus the path that should be stored in plot data."""
+
+    path: Path
+    eval_subdir: str
+    ref: str
+    relative_path: str
+
+
 def _is_dispersion_metric(metric: str) -> bool:
     """Return True for ratio-style dispersion diagnostics."""
     return metric in DISPERSION_METRICS
@@ -333,6 +344,21 @@ def _set_figure_text_style(
 
 def _scaled_figsize(width: float, height: float, figure_scale: float = 1.0):
     return (width * figure_scale, height * figure_scale)
+
+
+def _apply_optional_ylim(
+    ax: MplAxes,
+    ylim: tuple[float | None, float | None] | None,
+) -> tuple[float, float] | None:
+    """Apply optional y-axis bounds, preserving automatic bounds for ``None``."""
+    if ylim is None:
+        return None
+    lo, hi = ylim
+    cur_lo, cur_hi = ax.get_ylim()
+    next_lo = lo if lo is not None else cur_lo
+    next_hi = hi if hi is not None else cur_hi
+    ax.set_ylim(bottom=next_lo, top=next_hi)
+    return (float(next_lo), float(next_hi))
 
 
 def _metric_axis_label(metric: str) -> str:
@@ -629,6 +655,54 @@ def apply_filter_expr(
 def resolve_results_root(outputs_dir: str) -> Path:  # noqa: D103
     p = Path(outputs_dir).expanduser()
     return (Path.cwd() / p).resolve() if not p.is_absolute() else p.resolve()
+
+
+def _run_relative_path(results_dir: Path, run_dir: Path, run_id: str | None) -> str:
+    """Return the path that plotting reloads should use under ``results_dir``."""
+    if run_id is not None and not Path(run_id).expanduser().is_absolute():
+        return Path(run_id).as_posix()
+    try:
+        return run_dir.resolve().relative_to(results_dir.resolve()).as_posix()
+    except ValueError:
+        return str(run_dir.expanduser().resolve())
+
+
+def _make_run_target(
+    results_dir: Path,
+    run_id: str,
+    eval_subdir: str | None = None,
+    run_ref: str | None = None,
+) -> RunTarget:
+    """Resolve a requested run id into a stable target record."""
+    run_path = Path(run_id).expanduser()
+    run_dir = run_path if run_path.is_absolute() else results_dir / run_path
+    resolved_eval_subdir = normalize_eval_subdir(eval_subdir)
+    return RunTarget(
+        path=run_dir,
+        eval_subdir=resolved_eval_subdir,
+        ref=run_ref or run_id,
+        relative_path=_run_relative_path(results_dir, run_dir, run_id),
+    )
+
+
+def _discover_run_targets(results_dir: Path) -> list[RunTarget]:
+    """Recursively discover runs with a default eval metrics CSV."""
+    targets = []
+    for metrics_csv in results_dir.rglob("evaluation_metrics.csv"):
+        eval_dir = metrics_csv.parent
+        if eval_dir.name != DEFAULT_EVAL_SUBDIR:
+            continue
+        run_dir = eval_dir.parent
+        relative_path = _run_relative_path(results_dir, run_dir, run_id=None)
+        targets.append(
+            RunTarget(
+                path=run_dir,
+                eval_subdir=DEFAULT_EVAL_SUBDIR,
+                ref=run_dir.name,
+                relative_path=relative_path,
+            )
+        )
+    return sorted(targets, key=lambda target: target.path)
 
 
 def normalize_eval_subdir(eval_subdir: str | None) -> str:
@@ -972,6 +1046,7 @@ def load_single_run_metrics(  # noqa: PLR0912, PLR0915
     run_dir: Path,
     eval_subdir: str = DEFAULT_EVAL_SUBDIR,
     run_ref: str | None = None,
+    run_path: str | None = None,
     force_training_refresh: bool = False,
 ) -> dict:
     """Load evaluation metrics and rollout metrics from a single run directory."""
@@ -979,7 +1054,7 @@ def load_single_run_metrics(  # noqa: PLR0912, PLR0915
     row = {
         "run_name": run_ref or run_dir.name,
         "run_id": run_dir.name,
-        "run_path": run_dir.name,
+        "run_path": run_path or run_dir.name,
         "eval_subdir": resolved_eval_subdir,
         "dataset": None,
     }
@@ -1080,15 +1155,15 @@ def load_single_run_metrics(  # noqa: PLR0912, PLR0915
 
     loss_family, _, _ = parse_loss_dataset_arch(run_dir.name)
     if loss_family == "crps":
-        best_winkler_epoch = _best_winkler_epoch_from_wandb(
+        best_winkler_epoch = _best_winkler_epoch_from_cache(
             run_dir,
             eval_subdir=resolved_eval_subdir,
-            force_refresh=force_training_refresh,
         )
-        if best_winkler_epoch is None:
-            best_winkler_epoch = _best_winkler_epoch_from_cache(
+        if best_winkler_epoch is None and force_training_refresh:
+            best_winkler_epoch = _best_winkler_epoch_from_wandb(
                 run_dir,
                 eval_subdir=resolved_eval_subdir,
+                force_refresh=True,
             )
         if best_winkler_epoch is not None:
             row["best_winkler_epoch"] = best_winkler_epoch
@@ -2170,13 +2245,7 @@ def grouped_bar(  # noqa: PLR0912, PLR0915
             alpha=0.65,
         )
 
-    if ylim is not None:
-        lo, hi = ylim
-        cur_lo, cur_hi = ax.get_ylim()
-        ax.set_ylim(
-            bottom=lo if lo is not None else cur_lo,
-            top=hi if hi is not None else cur_hi,
-        )
+    _apply_optional_ylim(ax, ylim)
 
     if show_legend:
         handles, labels = ax.get_legend_handles_labels()
@@ -2383,6 +2452,7 @@ def plot_lead_time_panel(  # noqa: PLR0912, PLR0915
     fig: FigureBase | None = None,
     save: bool = True,
     error_ylim: tuple[float | None, float | None] | None = None,
+    coverage_ylim: tuple[float | None, float | None] | None = None,
     show_legend: bool = True,
     yscale: str | None = None,
     ref_value: float | None = None,
@@ -2402,8 +2472,10 @@ def plot_lead_time_panel(  # noqa: PLR0912, PLR0915
 ) -> FigureBase | None:
     """Plot per-metric, per-dataset lead-time curves as a panel figure.
 
-    ``error_ylim`` (low, high) overrides auto y-limits for non-coverage rows;
-    coverage rows remain fixed at [0, 1]. Either bound may be ``None``.
+    ``error_ylim`` overrides auto y-limits for non-coverage rows.
+    ``coverage_ylim`` overrides coverage rows; otherwise raw coverage stays
+    fixed at [0, 1] and coverage-delta rows use symmetric auto limits.
+    Either bound may be ``None``.
     When ``axes`` is provided, draw into that pre-made grid with shape
     (len(metrics_to_plot), n_datasets).
 
@@ -2504,7 +2576,7 @@ def plot_lead_time_panel(  # noqa: PLR0912, PLR0915
         for c, ds_label in enumerate(datasets):
             ax = axes[r][c]
             ds = sub[sub["dataset_label"] == ds_label]
-            is_cov = metric.startswith("coverage_")
+            is_cov = metric == "coverage" or metric.startswith("coverage_")
             is_ssr = metric == "ssr"
             is_cov_delta = bool(coverage_delta and is_cov)
             cov_target: float | None = None
@@ -2643,17 +2715,10 @@ def plot_lead_time_panel(  # noqa: PLR0912, PLR0915
                     linewidth=ref_line_width,
                     alpha=0.6,
                 )
-            # Apply user override for error rows (skip SSR: ratio diagnostic)
-            if not is_cov and not is_ssr and error_ylim is not None:
-                lo, hi = error_ylim
-                cur_lo, cur_hi = ax.get_ylim()
-                next_lo = lo if lo is not None else cur_lo
-                next_hi = hi if hi is not None else cur_hi
-                ax.set_ylim(
-                    bottom=next_lo,
-                    top=next_hi,
-                )
-                y_limit = (float(next_lo), float(next_hi))
+            if is_cov and coverage_ylim is not None:
+                y_limit = _apply_optional_ylim(ax, coverage_ylim) or y_limit
+            elif not is_cov and not is_ssr and error_ylim is not None:
+                y_limit = _apply_optional_ylim(ax, error_ylim) or y_limit
             if (
                 sharey
                 and y_limit is not None
@@ -3264,24 +3329,11 @@ def plot_panel_figure(  # noqa: PLR0915
         fig=right_bot,
         save=False,
         error_ylim=None,
+        coverage_ylim=coverage_ylim,
         coverage_delta=lead_time_coverage_delta,
         show_legend=False,
         **plot_style_kwargs,
     )
-    if coverage_ylim is not None:
-        lo, hi = coverage_ylim
-        rb_arr = np.asarray(rb_axes)
-        for r, metric in enumerate(coverage_metrics):
-            # SSR is a ratio diagnostic (linear, ref=1.0) mixed into the
-            # coverage panel; do not squash it onto the coverage [0, 1] axis.
-            if metric == "ssr":
-                continue
-            for ax in rb_arr[r]:
-                cur_lo, cur_hi = ax.get_ylim()
-                ax.set_ylim(
-                    bottom=lo if lo is not None else cur_lo,
-                    top=hi if hi is not None else cur_hi,
-                )
 
     # --- Global legend --------------------------------------------------
     # Collect groups present anywhere for the legend.
@@ -4774,7 +4826,7 @@ def main():  # noqa: PLR0912, PLR0915
     # Gather explicitly requested runs, or fallback to auto-discover
     if explicit_groups:
         run_targets = [
-            (results_dir / r, DEFAULT_EVAL_SUBDIR, r)
+            _make_run_target(results_dir, r, DEFAULT_EVAL_SUBDIR, r)
             for g in explicit_groups
             for r in g
         ]
@@ -4791,35 +4843,29 @@ def main():  # noqa: PLR0912, PLR0915
                 n_seen = ref_counts.get(base_ref, 0)
                 ref_counts[base_ref] = n_seen + 1
                 run_ref = base_ref if n_seen == 0 else f"{base_ref}#{n_seen + 1}"
-                run_targets.append((results_dir / run_id, eval_subdir, run_ref))
+                run_targets.append(
+                    _make_run_target(results_dir, run_id, eval_subdir, run_ref)
+                )
             if args.runs:
                 for run_id in args.runs[len(args.run) :]:
-                    run_targets.append(
-                        (results_dir / run_id, DEFAULT_EVAL_SUBDIR, run_id)
-                    )
+                    run_targets.append(_make_run_target(results_dir, run_id))
         else:
             run_targets = [
-                (
-                    results_dir / r,
-                    normalize_eval_subdir(
-                        eval_subdir_by_run.get(r, DEFAULT_EVAL_SUBDIR)
-                    ),
+                _make_run_target(
+                    results_dir,
+                    r,
+                    eval_subdir_by_run.get(r, DEFAULT_EVAL_SUBDIR),
                     r,
                 )
                 for r in args.runs
             ]
     else:
-        run_targets = sorted(
-            [
-                (p, DEFAULT_EVAL_SUBDIR, p.name)
-                for p in results_dir.iterdir()
-                if p.is_dir() and (p / "eval" / "evaluation_metrics.csv").exists()
-            ],
-            key=lambda x: x[0],
-        )
+        run_targets = _discover_run_targets(results_dir)
 
     valid_run_names = {
-        name for rd, _, run_ref in run_targets for name in (run_ref, rd.name)
+        name
+        for target in run_targets
+        for name in (target.ref, target.path.name, target.relative_path)
     }
 
     try:
@@ -4834,9 +4880,13 @@ def main():  # noqa: PLR0912, PLR0915
     if args.list:
         print(f"Loading {len(run_targets)} runs...")
         m_rows = []
-        for rd, run_eval_subdir, run_ref in run_targets:
+        for target in run_targets:
             m_rows.append(
-                load_config_metadata(rd, eval_subdir=run_eval_subdir, run_ref=run_ref)
+                load_config_metadata(
+                    target.path,
+                    eval_subdir=target.eval_subdir,
+                    run_ref=target.ref,
+                )
             )
         mdf = pd.DataFrame(m_rows)
 
@@ -4984,19 +5034,20 @@ def main():  # noqa: PLR0912, PLR0915
 
     print(f"Loading {len(run_targets)} runs...")
     rows = []
-    for d, run_eval_subdir, run_ref in run_targets:
-        if not d.exists():
-            print(f"Warning: requested run not found: {d}")
+    for target in run_targets:
+        if not target.path.exists():
+            print(f"Warning: requested run not found: {target.path}")
             continue
         try:
             r = load_single_run_metrics(
-                d,
-                eval_subdir=run_eval_subdir,
-                run_ref=run_ref,
+                target.path,
+                eval_subdir=target.eval_subdir,
+                run_ref=target.ref,
+                run_path=target.relative_path,
                 force_training_refresh=args.training_refresh,
             )
         except Exception as e:
-            print(f"Error loading {d}: {e}")
+            print(f"Error loading {target.path}: {e}")
             continue
         rows.append(r)
 
@@ -5340,6 +5391,7 @@ def main():  # noqa: PLR0912, PLR0915
             styles,
             dataset_order=ds_order,
             hue_order=hu_order,
+            coverage_ylim=coverage_ylim,
             **plot_style_kwargs,
         )
         if args.lead_time_coverage_delta:
@@ -5354,6 +5406,7 @@ def main():  # noqa: PLR0912, PLR0915
                     styles,
                     dataset_order=ds_order,
                     hue_order=hu_order,
+                    coverage_ylim=coverage_ylim,
                     coverage_delta=True,
                     **plot_style_kwargs,
                 )
@@ -5371,6 +5424,7 @@ def main():  # noqa: PLR0912, PLR0915
             dataset_order=ds_order,
             hue_order=hu_order,
             error_ylim=error_ylim,
+            coverage_ylim=coverage_ylim,
             yscale=args.error_yscale,
             **plot_style_kwargs,
         )

--- a/src/autocast/scripts/plot_dataset_comparisons.py
+++ b/src/autocast/scripts/plot_dataset_comparisons.py
@@ -5235,14 +5235,6 @@ def main():  # noqa: PLR0912, PLR0915
         cov_metric = [m for m in cov_metric if m != "ssr"]
     paper_cov_metric = _paper_coverage_metrics(cov_metric)
 
-    write_single_step_results_table(
-        df,
-        out_dir,
-        styles,
-        dataset_order=ds_order,
-        hue_order=hu_order,
-    )
-
     if args.paper_only:
         if args.paper_main_figures:
             plot_paper_overall_coverage_figure(
@@ -5309,6 +5301,14 @@ def main():  # noqa: PLR0912, PLR0915
             )
         print("Finished generating paper plots.")
         return
+
+    write_single_step_results_table(
+        df,
+        out_dir,
+        styles,
+        dataset_order=ds_order,
+        hue_order=hu_order,
+    )
 
     # Render overall bars
     for m in args.metrics:

--- a/src/autocast/scripts/plot_dataset_comparisons.py
+++ b/src/autocast/scripts/plot_dataset_comparisons.py
@@ -1,0 +1,5540 @@
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import sys
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, SupportsIndex, cast
+
+import matplotlib as mpl
+import yaml
+from matplotlib.axes import Axes as MplAxes
+from matplotlib.figure import FigureBase
+from matplotlib.lines import Line2D
+
+mpl.use("Agg")  # Non-interactive backend
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import wandb
+
+# ---------------------------------------------------------------------------
+# Constants & Configuration
+# ---------------------------------------------------------------------------
+
+DATASET_LABEL_OVERRIDES = {
+    "ad64": "AD",
+    "adm32": "ADM32",
+    "cns64": "CNS",
+    "gpe_ri_high_complexity": "GPE-H",
+    "gpe_ri_low_complexity": "GPE-L",
+    "gpe_laser_only_wake": "GPE",
+    "gpe_laser_wake_only": "GPE",
+    "gpe64": "GPE",
+    "gpehc64": "GPEHC64",
+    "gpelc64": "GPELC64",
+    "gs64": "GS",
+    "lb128x32": "LB",
+    "rd64": "RD",
+    "shallow_water2d_128": "SW",
+    "sw2d464": "SW4",
+    "sw2d64": "SW",
+}
+
+# Canonical grid resolution for each known dataset module.
+DATASET_RESOLUTION: dict[str, str] = {
+    "ad64": "64x64",
+    "adm32": "64x64",
+    "cns64": "64x64",
+    "gpe_ri_high_complexity": "64x64",
+    "gpe_ri_low_complexity": "64x64",
+    "gpe_laser_only_wake": "64x64",
+    "gpe_laser_wake_only": "64x64",
+    "gpe64": "64x64",
+    "gpehc64": "64x64",
+    "gpelc64": "64x64",
+    "gs64": "64x64",
+    "lb128x32": "128x32",
+    "rd64": "64x64",
+    "shallow_water2d_128": "128x128",
+    "sw2d464": "64x64",
+    "sw2d64": "64x64",
+}
+
+ARCHITECTURE_PREFIXES = (
+    "flow_matching_vit",
+    "flow_matching_large",
+    "flow_matching",
+    "fno_concat",
+    "fno",
+    "vit_latent",
+    "vit_large",
+    "vit",
+    "diffusion_vit",
+    "diffusion",
+    "unet_large",
+    "unet",
+    "swin",
+    "unet_azula_large",
+    "unet_azula_small",
+    "unet_large_concat",
+    "unet_small_concat",
+    "swin_large",
+    "swin_small",
+    "vit_azula_large",
+    "vit_azula_small",
+)
+
+MODEL_FAMILY_DISPLAY_LABELS = {
+    "flow_matching_vit": "FM ViT",
+    "fno_concat": "FNO",
+    "flow_matching": "FM U-Net",
+    "flow_matching_large": "FM U-Net (large)",
+    "vit_large": "ViT (large)",
+    "vit": "ViT (small)",
+    "vit_latent": "ViT latent",
+    "diffusion": "Diffusion U-Net",
+    "diffusion_vit": "Diffusion ViT",
+    "unet_azula_large": "Azula U-Net (large)",
+    "unet_azula_small": "Azula U-Net (small)",
+    "unet_large_concat": "U-Net (large)",
+    "unet_small_concat": "U-Net (small)",
+    "swin_large": "Swin (large)",
+    "swin_small": "Swin (small)",
+    "vit_azula_large": "Azula ViT (large)",
+    "vit_azula_small": "Azula ViT (small)",
+}
+
+ROLL_WINDOWS = ["0-1", "0-4", "6-12", "13-30", "31-99"]
+WINDOW_ROWS = ["all", *ROLL_WINDOWS]
+WINDOW_ROWS_OVERALL_AND_ROLLOUT = ["all", "0-4", "6-12", "13-30", "31-99"]
+WINDOW_ROWS_OVERALL_ONLY = ["all"]
+WINDOW_ROWS_ROLLOUT_ONLY = ["0-4", "6-12", "13-30", "31-99"]
+MODEL_SCALE_PARAM_COL = "params_processor_total"
+DEFAULT_EVAL_SUBDIR = "eval"
+DEFAULT_PLOT_METRICS: tuple[str, ...] = ("vrmse", "coverage", "crps", "ssr")
+DISPERSION_METRICS: set[str] = {"ssr"}
+DEFAULT_TICK_LABEL_FONT_SIZE = 10.0
+DEFAULT_AXIS_LABEL_FONT_SIZE = 10.0
+DEFAULT_LEGEND_FONT_SIZE = 8.0
+PAPER_FIGURE_WIDTH_IN = 6.9
+PAPER_FONT_SIZE = 10.0
+PAPER_TICK_FONT_SIZE = 8.75
+PAPER_LEGEND_FONT_SIZE = 9.375
+PAPER_LINE_WIDTH = 1.0
+PAPER_REF_LINE_WIDTH = 0.8
+PAPER_LEGEND_LINE_WIDTH = 1.2
+PAPER_AXES_LINE_WIDTH = 0.55
+PAPER_TICK_LINE_WIDTH = 0.55
+PAPER_GRID_LINE_WIDTH = 0.45
+FIGURE_FORMATS: list[str] = ["png"]
+NOMINAL_COVERAGE_AXIS_LABEL = r"Nominal coverage (1 - $\alpha$)"
+PAPER_RC_PARAMS = {
+    "font.family": "serif",
+    "font.serif": [
+        "Times New Roman",
+        "Times",
+        "TeX Gyre Termes",
+        "STIXGeneral",
+        "DejaVu Serif",
+    ],
+    "font.size": PAPER_FONT_SIZE,
+    "axes.labelsize": PAPER_FONT_SIZE,
+    "axes.titlesize": PAPER_FONT_SIZE,
+    "axes.linewidth": PAPER_AXES_LINE_WIDTH,
+    "grid.linewidth": PAPER_GRID_LINE_WIDTH,
+    "xtick.major.width": PAPER_TICK_LINE_WIDTH,
+    "ytick.major.width": PAPER_TICK_LINE_WIDTH,
+    "xtick.minor.width": PAPER_TICK_LINE_WIDTH,
+    "ytick.minor.width": PAPER_TICK_LINE_WIDTH,
+    "xtick.labelsize": PAPER_TICK_FONT_SIZE,
+    "ytick.labelsize": PAPER_TICK_FONT_SIZE,
+    "legend.fontsize": PAPER_LEGEND_FONT_SIZE,
+    "mathtext.fontset": "stix",
+    "pdf.fonttype": 42,
+    "ps.fonttype": 42,
+}
+SINGLE_STEP_RESULTS_TABLE_METRICS: tuple[tuple[str, str], ...] = (
+    ("overall_vrmse", "VRMSE"),
+    ("overall_coverage", "Coverage MAE"),
+    ("overall_crps", "CRPS"),
+    ("overall_ssr", "SSR"),
+    ("model_latency_ms_per_sample", "Inference latency (ms/sample)"),
+    ("train_mean_epoch_s", "Training time (s/epoch)"),
+)
+SINGLE_STEP_RESULTS_LATEX_HEADERS: dict[str, str] = {
+    "Dataset": "Dataset",
+    "Model": "Model",
+    "VRMSE": (
+        r"{\begin{tabular}[c]{@{}c@{}}VRMSE\\"
+        r"{$\downarrow$}\end{tabular}}"
+    ),
+    "CRPS": (
+        r"{\begin{tabular}[c]{@{}c@{}}CRPS\\"
+        r"{$\downarrow$}\end{tabular}}"
+    ),
+    "Coverage MAE": (
+        r"{\begin{tabular}[c]{@{}c@{}}Coverage\\MAE {$\downarrow$}\end{tabular}}"
+    ),
+    "SSR": (
+        r"{\begin{tabular}[c]{@{}c@{}}SSR\\"
+        r"{$\to 1$}\end{tabular}}"
+    ),
+    "Inference latency (ms/sample)": (
+        r"{\begin{tabular}[c]{@{}c@{}}Latency\\"
+        r"(ms/sample) {$\downarrow$}\end{tabular}}"
+    ),
+    "Training time (s/epoch)": (
+        r"{\begin{tabular}[c]{@{}c@{}}Epoch time\\"
+        r"(s) {$\downarrow$}\end{tabular}}"
+    ),
+}
+SINGLE_STEP_RESULTS_LOWER_IS_BETTER = {
+    "VRMSE",
+    "CRPS",
+    "Coverage MAE",
+    "Inference latency (ms/sample)",
+    "Training time (s/epoch)",
+}
+SINGLE_STEP_RESULTS_TARGET_METRICS = {"SSR": 1.0}
+
+
+def _is_dispersion_metric(metric: str) -> bool:
+    """Return True for ratio-style dispersion diagnostics."""
+    return metric in DISPERSION_METRICS
+
+
+def _overall_or_window_bar_ylim(
+    metric: str,
+    error_ylim: tuple[float | None, float | None] | None,
+) -> tuple[float | None, float | None] | None:
+    """Apply error y-limits only to error-like scalar metrics."""
+    if "coverage" in metric or _is_dispersion_metric(metric):
+        return None
+    return error_ylim
+
+
+def _overall_or_window_bar_yscale(metric: str, error_yscale: str = "log") -> str:
+    """Choose a y-scale for scalar overall/window bar charts.
+
+    ``error_yscale='linear'`` forces error-like metrics onto a linear axis;
+    dispersion metrics (SSR) stay linear regardless.
+    """
+    if _is_dispersion_metric(metric):
+        return "linear"
+    if "coverage" in metric:
+        return "auto"
+    if error_yscale == "linear":
+        return "linear"
+    return "auto"
+
+
+def _overall_or_window_bar_ref_value(metric: str) -> float | None:
+    """Return the expected reference value for scalar bar charts."""
+    if metric == "ssr":
+        return 1.0
+    return None
+
+
+def _derive_lead_time_metrics(metrics: list[str]) -> tuple[list[str], list[str]]:
+    """Split scalar plot metrics into error and coverage lead-time rows."""
+    err_metric = [
+        m for m in metrics if "coverage" not in m and not _is_dispersion_metric(m)
+    ]
+    cov_metric = [m for m in metrics if "coverage" in m]
+    dispersion_metric = [m for m in metrics if _is_dispersion_metric(m)]
+
+    # Add common rollout variants if we only provided generic 'coverage'.
+    if "coverage" in metrics and "coverage_0.9" not in cov_metric:
+        cov_metric.extend(["coverage_0.9", "coverage_0.5"])
+        err_metric.append("rmse")
+
+    return err_metric, [*cov_metric, *dispersion_metric]
+
+
+def _resolve_font_size(
+    base_size: float,
+    font_scale: float = 1.0,
+    explicit_font_size: float | None = None,
+) -> float:
+    """Resolve configurable plot font sizes without changing defaults."""
+    if explicit_font_size is not None:
+        return float(explicit_font_size)
+    return float(base_size) * float(font_scale)
+
+
+def _apply_tick_label_style(ax: MplAxes, tick_label_scale: float = 1.0) -> None:
+    """Apply optional tick-label scaling to an axis."""
+    if tick_label_scale == 1.0:
+        return
+    ax.tick_params(
+        axis="both",
+        which="both",
+        labelsize=_resolve_font_size(DEFAULT_TICK_LABEL_FONT_SIZE, tick_label_scale),
+    )
+
+
+def _apply_axis_label_style(ax: MplAxes, axis_label_scale: float = 1.0) -> None:
+    """Apply optional axis-label scaling to an axis."""
+    if axis_label_scale == 1.0:
+        return
+    font_size = _resolve_font_size(DEFAULT_AXIS_LABEL_FONT_SIZE, axis_label_scale)
+    ax.xaxis.label.set_fontsize(font_size)
+    ax.yaxis.label.set_fontsize(font_size)
+
+
+def _set_shared_ylabel(
+    fig: FigureBase,
+    label: str,
+    axis_label_scale: float = 1.0,
+) -> None:
+    """Set a panel-level y label when repeated row labels would be noisy."""
+    if not hasattr(fig, "supylabel"):
+        return
+    text = fig.supylabel(label)
+    if axis_label_scale != 1.0:
+        text.set_fontsize(
+            _resolve_font_size(DEFAULT_AXIS_LABEL_FONT_SIZE, axis_label_scale)
+        )
+
+
+def _set_shared_xlabel(
+    fig: FigureBase,
+    label: str,
+    axis_label_scale: float = 1.0,
+) -> None:
+    """Set a panel-level x label when repeated labels would be noisy."""
+    if not hasattr(fig, "supxlabel"):
+        return
+    text = fig.supxlabel(label)
+    if axis_label_scale != 1.0:
+        text.set_fontsize(
+            _resolve_font_size(DEFAULT_AXIS_LABEL_FONT_SIZE, axis_label_scale)
+        )
+
+
+def _set_figure_text_style(
+    text,
+    axis_label_scale: float = 1.0,
+    x: float | None = None,
+    y: float | None = None,
+) -> None:
+    """Apply label sizing and optional position to a figure-level text artist."""
+    text.set_fontsize(
+        _resolve_font_size(DEFAULT_AXIS_LABEL_FONT_SIZE, axis_label_scale)
+    )
+    if x is not None or y is not None:
+        cur_x, cur_y = text.get_position()
+        text.set_position((cur_x if x is None else x, cur_y if y is None else y))
+
+
+def _scaled_figsize(width: float, height: float, figure_scale: float = 1.0):
+    return (width * figure_scale, height * figure_scale)
+
+
+def _metric_axis_label(metric: str) -> str:
+    """Format metric keys as publication-facing axis labels."""
+    if metric.startswith("coverage_"):
+        level = metric.split("_", 1)[1]
+        return f"COVERAGE {level}"
+    return metric.upper()
+
+
+def _coverage_window_axis_label(window: str, short: bool = False) -> str:
+    """Format coverage calibration y labels from rollout window values."""
+    prefix = "Emp. cov." if short else "Empirical coverage"
+    if window == "all":
+        return prefix
+    window_label = _coverage_window_interval_label(window)
+    return f"{prefix} {window_label}"
+
+
+def _coverage_window_row_tag(window: str) -> str:
+    """Short row identifier used when a shared y label carries the metric name."""
+    if window == "all":
+        return "all"
+    return _coverage_window_interval_label(window)
+
+
+def _coverage_window_interval_label(window: str) -> str:
+    """Format rollout window identifiers as closed-open intervals."""
+    match = re.fullmatch(r"(\d+)-(\d+)", str(window))
+    if match is None:
+        return str(window)
+    start, end = match.groups()
+    return f"[{start}:{end})"
+
+
+def _coverage_level_label(metric: str) -> str:
+    """Format a coverage_<level> metric as a compact interval label."""
+    level = metric.split("_", 1)[1]
+    return rf"$1-\alpha={level}$"
+
+
+def _empirical_coverage_label(short: bool = False) -> str:
+    """Return a coverage axis label with the measured empirical symbol."""
+    if short:
+        return r"Emp. Cov. ($1-\hat{\alpha}$)"
+    return r"Empirical coverage ($1-\hat{\alpha}$)"
+
+
+def _paper_empirical_coverage_label() -> str:
+    """Return the full empirical coverage label for paper figures."""
+    return r"Empirical Coverage ($1-\hat{\alpha}$)"
+
+
+def _paper_relative_coverage_label() -> str:
+    """Return the full relative coverage label for paper figures."""
+    return r"Relative $\Delta$ Empirical Coverage"
+
+
+# ---------------------------------------------------------------------------
+# Lead-time panel group presets
+# ---------------------------------------------------------------------------
+# Each preset targets a qualitatively distinct aspect of ensemble forecast
+# quality and produces a dedicated lead-time panel (rows=metrics, cols=datasets).
+# Fields:
+#   metrics:  row keys (must match rows in rollout_metrics_per_timestep_channel_all.csv)
+#   name:     output PNG filename
+#   title:    short human-readable group title (used for legend/caption)
+#   yscale:   'log' (default for error-like scores) or 'linear' (for ratios)
+#   ref:      optional y reference line (e.g. 1.0 for SSR's ideal dispersion)
+METRIC_GROUP_PRESETS: dict[str, dict[str, object]] = {
+    "probabilistic_scores": {
+        "metrics": ["crps", "fcrps", "afcrps", "winkler"],
+        "name": "lead_time_panel_probabilistic_scores.png",
+        "title": "Marginal proper scoring rules (CRPS family + Winkler)",
+        "yscale": "log",
+        "ref": None,
+    },
+    "coherence": {
+        "metrics": ["energy"],
+        "name": "lead_time_panel_coherence.png",
+        "title": "Spatiotemporal coherence (Energy Score / multivariate CRPS)",
+        "yscale": "log",
+        "ref": None,
+    },
+    "coherence_plus": {
+        "metrics": ["energy", "variogram"],
+        "name": "lead_time_panel_coherence_plus.png",
+        "title": "Spatiotemporal coherence (Energy + Variogram, memory-intensive)",
+        "yscale": "log",
+        "ref": None,
+    },
+    "dispersion": {
+        "metrics": ["ssr"],
+        "name": "lead_time_panel_dispersion.png",
+        "title": "Dispersion (Spread-Skill Ratio, ideal=1.0)",
+        "yscale": "linear",
+        "ref": 1.0,
+    },
+    "physics_ps": {
+        "metrics": [
+            "psrmse_low",
+            "psrmse_mid",
+            "psrmse_high",
+            "psrmse_tail",
+        ],
+        "name": "lead_time_panel_physics_ps.png",
+        "title": "Physics: power-spectrum RMSE by band",
+        "yscale": "log",
+        "ref": None,
+    },
+    "physics_pscc": {
+        "metrics": [
+            "pscc_low",
+            "pscc_mid",
+            "pscc_high",
+            "pscc_tail",
+        ],
+        "name": "lead_time_panel_physics_pscc.png",
+        "title": "Physics: power-spectrum cross-correlation RMSE by band",
+        "yscale": "log",
+        "ref": None,
+    },
+    "summary": {
+        "metrics": [
+            "crps",
+            "ssr",
+            "energy",
+            "winkler",
+            "psrmse_high",
+            "psrmse_mid",
+            "psrmse_low",
+        ],
+        "name": "lead_time_panel_summary.png",
+        "title": (
+            "Summary: CRPS, SSR, Energy Score, Winkler, "
+            "Power-spectrum RMSE (high/mid/low)"
+        ),
+        "yscale": "log",
+        "ref": None,
+    },
+}
+
+DEFAULT_METRIC_GROUPS: tuple[str, ...] = (
+    "probabilistic_scores",
+    "coherence",
+    "physics_ps",
+    "summary",
+)
+
+
+# ---------------------------------------------------------------------------
+# Filter expression parser
+# ---------------------------------------------------------------------------
+# Supports: KEY=VALUE, AND, OR, parentheses.
+#   e.g. "Scale=large AND (Dataset=SW2D64 OR Dataset=CNS64)"
+
+
+def _tokenize_filter(expr: str) -> list[str]:
+    """Split a filter expression into tokens.
+
+    Recognised tokens: ``(``, ``)``, ``AND``, ``OR``, ``KEY=VALUE``.
+    """
+    tokens: list[str] = []
+    i = 0
+    while i < len(expr):
+        c = expr[i]
+        if c in " \t":
+            i += 1
+            continue
+        if c in "()":
+            tokens.append(c)
+            i += 1
+            continue
+        # Read a word (could be AND/OR or a KEY=VALUE atom).
+        j = i
+        while j < len(expr) and expr[j] not in " \t()":
+            j += 1
+        tokens.append(expr[i:j])
+        i = j
+    return tokens
+
+
+def _parse_filter_expr(
+    tokens: list[str],
+    pos: int,
+    df: pd.DataFrame,
+    col_aliases: dict[str, str],
+) -> tuple[pd.Series, int]:
+    """Recursive-descent parser.  Returns (boolean mask, next position)."""
+    mask, pos = _parse_or(tokens, pos, df, col_aliases)
+    return mask, pos
+
+
+def _parse_or(
+    tokens: list[str],
+    pos: int,
+    df: pd.DataFrame,
+    col_aliases: dict[str, str],
+) -> tuple[pd.Series, int]:
+    left, pos = _parse_and(tokens, pos, df, col_aliases)
+    while pos < len(tokens) and tokens[pos].upper() == "OR":
+        pos += 1  # consume OR
+        right, pos = _parse_and(tokens, pos, df, col_aliases)
+        left = left | right
+    return left, pos
+
+
+def _parse_and(
+    tokens: list[str],
+    pos: int,
+    df: pd.DataFrame,
+    col_aliases: dict[str, str],
+) -> tuple[pd.Series, int]:
+    left, pos = _parse_atom(tokens, pos, df, col_aliases)
+    while pos < len(tokens) and tokens[pos].upper() == "AND":
+        pos += 1  # consume AND
+        right, pos = _parse_atom(tokens, pos, df, col_aliases)
+        left = left & right
+    return left, pos
+
+
+def _parse_atom(
+    tokens: list[str],
+    pos: int,
+    df: pd.DataFrame,
+    col_aliases: dict[str, str],
+) -> tuple[pd.Series, int]:
+    if pos >= len(tokens):
+        msg = "Unexpected end of filter expression."
+        raise ValueError(msg)
+    tok = tokens[pos]
+    if tok == "(":
+        pos += 1  # consume (
+        mask, pos = _parse_or(tokens, pos, df, col_aliases)
+        if pos >= len(tokens) or tokens[pos] != ")":
+            msg = "Missing closing ')' in filter expression."
+            raise ValueError(msg)
+        pos += 1  # consume )
+        return mask, pos
+    if "=" not in tok:
+        msg = f"Expected KEY=VALUE but got '{tok}' in filter expression."
+        raise ValueError(msg)
+    key, value = tok.split("=", 1)
+
+    # Resolve keys case-insensitively across aliases and dataframe columns.
+    key_cf = key.casefold()
+    col = col_aliases.get(key, key)
+    if col not in df.columns:
+        alias_keys_cf = {k.casefold(): k for k in col_aliases}
+        if key_cf in alias_keys_cf:
+            col = col_aliases[alias_keys_cf[key_cf]]
+        else:
+            cols_cf = {c.casefold(): c for c in df.columns}
+            if key_cf in cols_cf:
+                col = cols_cf[key_cf]
+
+    if col not in df.columns:
+        msg = f"Metadata filter key '{key}' not found."
+        raise ValueError(msg)
+    return df[col].astype(str) == value, pos + 1
+
+
+def apply_filter_expr(
+    expr: str,
+    df: pd.DataFrame,
+    col_aliases: dict[str, str] | None = None,
+) -> pd.DataFrame:
+    """Apply a boolean filter expression to *df* and return the filtered frame.
+
+    Examples::
+
+        apply_filter_expr("Scale=large", df)
+        apply_filter_expr("Scale=large AND Dataset=SW2D64", df)
+        apply_filter_expr("(Scale=large OR Scale=small) AND Dataset=SW2D64", df)
+    """
+    aliases = col_aliases or {}
+    tokens = _tokenize_filter(expr)
+    if not tokens:
+        return df
+    mask, pos = _parse_filter_expr(tokens, 0, df, aliases)
+    if pos != len(tokens):
+        msg = (
+            f"Unexpected token '{tokens[pos]}' at position {pos} in filter expression."
+        )
+        raise ValueError(msg)
+    return cast(pd.DataFrame, df[mask])
+
+
+# ---------------------------------------------------------------------------
+# Core Utilities
+# ---------------------------------------------------------------------------
+
+
+def resolve_results_root(outputs_dir: str) -> Path:  # noqa: D103
+    p = Path(outputs_dir).expanduser()
+    return (Path.cwd() / p).resolve() if not p.is_absolute() else p.resolve()
+
+
+def normalize_eval_subdir(eval_subdir: str | None) -> str:
+    """Normalize an eval subdir value and fall back to the default."""
+    if eval_subdir is None:
+        return DEFAULT_EVAL_SUBDIR
+    normalized = str(eval_subdir).strip().strip("/").strip()
+    if not normalized:
+        return DEFAULT_EVAL_SUBDIR
+
+    token = normalized.casefold()
+    # Friendly aliases for --run ... eval=<token>
+    if token in {"eval", "ambient", "default"}:
+        return DEFAULT_EVAL_SUBDIR
+    if token in {"latent", "eval_latent"}:
+        return "eval_latent"
+    return normalized
+
+
+def _apply_explicit_order(
+    items: list[str],
+    explicit_order: list[str] | None,
+) -> list[str]:
+    """Return *items* ordered by *explicit_order*, rest appended sorted."""
+    if not explicit_order:
+        return sorted(items)
+    item_set = set(items)
+    ordered = [x for x in explicit_order if x in item_set]
+    remaining = sorted(x for x in items if x not in set(explicit_order))
+    return ordered + remaining
+
+
+def _order_groups_by_label(
+    groups: list[str],
+    styles: dict,
+    hue_order: list[str] | None,
+) -> list[str]:
+    """Sort *groups* (plot_group keys) so their display labels follow *hue_order*."""
+    if not hue_order:
+        return sorted(groups)
+    label_rank = {label: i for i, label in enumerate(hue_order)}
+
+    def _key(pg: str) -> tuple[int, str]:
+        label = styles.get(pg, {}).get("label", pg)
+        rank = label_rank.get(label, len(hue_order))
+        return (rank, label)
+
+    return sorted(groups, key=_key)
+
+
+def dataset_label_from_module(dataset_module: str | None) -> str | None:
+    """Return a human-readable label for a dataset module name."""
+    if not dataset_module or pd.isna(dataset_module):
+        return None
+    if dataset_module in DATASET_LABEL_OVERRIDES:
+        return DATASET_LABEL_OVERRIDES[dataset_module]
+    return str(dataset_module).replace("_", " ").title()
+
+
+def _dataset_candidates() -> list[str]:
+    base = set(DATASET_LABEL_OVERRIDES.keys())
+    return sorted(base, key=len, reverse=True)
+
+
+def arch_key_from_processor_segment(segment: str) -> str:
+    """Map a processor name segment to a canonical architecture key."""
+    seg = str(segment)
+    if not seg:
+        return "unknown"
+    for pref in sorted(ARCHITECTURE_PREFIXES, key=len, reverse=True):
+        if seg == pref or seg.startswith(pref + "_"):
+            return pref
+    return seg.split("_")[0]
+
+
+def parse_loss_dataset_arch(
+    run_name: str | None,
+) -> tuple[str | None, str | None, str | None]:
+    """Parse a run directory name into (loss_family, dataset_module, arch_segment)."""
+    if not run_name:
+        return None, None, None
+    m = re.match(
+        r"^(diff|crps|epd)_(.+)_([0-9a-f]{7}|[a-z]+)_[0-9a-f]{7}(?:_[a-z0-9]+)*$",
+        str(run_name),
+    )
+    if not m:
+        return None, None, None
+    loss, mid = m.group(1), m.group(2)
+
+    # Try known datasets
+    for ds in _dataset_candidates():
+        pfx = ds + "_"
+        if mid.startswith(pfx):
+            return loss, ds, mid[len(pfx) :]
+
+    # Fallback using known architectures
+    for arch in sorted(ARCHITECTURE_PREFIXES, key=len, reverse=True):
+        sfx = "_" + arch
+        if sfx in mid:
+            idx = mid.index(sfx)
+            return loss, mid[:idx], mid[idx + 1 :]
+
+    # Ultimate fallback
+    if "_" in mid:
+        s1, s2 = mid.split("_", 1)
+        return loss, s1, s2
+
+    return loss, None, mid
+
+
+def normalize_dataset_module(dataset: str | None) -> str | None:
+    """Strip trailing hex/numeric suffixes from a dataset module path component."""
+    if dataset is None or not dataset:
+        return None
+    try:
+        if pd.isna(dataset):  # type: ignore[arg-type]
+            return None
+    except (TypeError, ValueError):
+        pass
+    m = re.match(r"^(?P<base>.+)_(?P<suffix>[0-9a-f]{6,}|\d{6,})$", str(dataset))
+    return m.group("base") if m else str(dataset)
+
+
+def dataset_module_from_data_path(data_path: str | None) -> str | None:
+    """Infer dataset module from data_path (including cached latents paths)."""
+    if not data_path:
+        return None
+    p = Path(str(data_path))
+
+    # Most direct case: explicit dataset directory.
+    direct = normalize_dataset_module(p.name)
+    if direct and direct not in {"cached_latents", "latents", "encoded"}:
+        return direct
+
+    # Cached latents case: parent directory usually encodes source AE run,
+    # e.g. ae_cns64_e011131_b3e6f6b -> cns64
+    parent = p.parent.name if p.name in {"cached_latents", "latents", "encoded"} else ""
+    if parent.startswith("ae_"):
+        toks = parent.split("_")[1:]
+        # Strip trailing run/hash suffixes while preserving dataset tokens.
+        while toks and re.fullmatch(r"[0-9a-f]{6,}|\d{6,}", toks[-1]):
+            toks.pop()
+        if toks:
+            return normalize_dataset_module("_".join(toks))
+    return None
+
+
+def resolution_from_run_name(run_name: str | None) -> str | None:
+    """Infer a model resolution token from run_name when present."""
+    if not run_name:
+        return None
+    # Common form: ..._vit_640_<hash>_<hash> or ..._vit_128_<hash>_<hash>
+    m = re.search(r"_vit_(\d{2,5})(?:_|$)", str(run_name))
+    if m:
+        return m.group(1)
+    return None
+
+
+def _format_spatial_resolution(vals: list[int] | tuple[int, ...]) -> str | None:
+    """Format 2D spatial resolution as 'W x H' with larger dim first."""
+    if len(vals) < 2:
+        return None
+    a, b = int(vals[0]), int(vals[1])
+    hi, lo = (a, b) if a >= b else (b, a)
+    return f"{hi}x{lo}"
+
+
+def dataset_grid_resolution(
+    dataset_module: str | None, data_path: str | None
+) -> str | None:
+    """Infer canonical grid resolution from dataset identifier or data path."""
+    ds = str(dataset_module or "")
+
+    # Explicit lookup from known dataset modules.
+    if ds in DATASET_RESOLUTION:
+        return DATASET_RESOLUTION[ds]
+
+    # Direct token like lb128x32
+    m = re.search(r"(\d+)x(\d+)", ds)
+    if m:
+        return _format_spatial_resolution([int(m.group(1)), int(m.group(2))])
+
+    # Heuristic: names ending in 64 are typically 64x64 grids.
+    if ds.endswith("64"):
+        return "64x64"
+
+    # 128-grid datasets often include this token in the full path/module name.
+    p = str(data_path or "")
+    if "_128" in ds or "_128" in p:
+        return "128x128"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Data Loading
+# ---------------------------------------------------------------------------
+
+
+def _as_finite_float(value: object) -> float | None:
+    """Convert scalar-like values to finite floats."""
+    try:
+        numeric_series = cast(
+            pd.Series,
+            pd.to_numeric(pd.Series([value]), errors="coerce"),
+        )
+        numeric = numeric_series.iloc[0]
+    except Exception:
+        return None
+    try:
+        out = float(numeric)
+    except (TypeError, ValueError):
+        return None
+    return out if np.isfinite(out) else None
+
+
+def _as_nonnegative_int(value: object) -> int | None:
+    """Convert scalar-like values to non-negative integer counts."""
+    numeric = _as_finite_float(value)
+    if numeric is None or numeric < 0:
+        return None
+    return round(numeric)
+
+
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
+    """Read a YAML mapping, returning an empty mapping on missing/invalid files."""
+    if not path.exists():
+        return {}
+    try:
+        with open(path) as f:
+            value = yaml.safe_load(f)
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _trainer_max_epochs_from_config(cfg: Mapping[str, Any]) -> int | None:
+    """Extract configured trainer.max_epochs from a resolved config."""
+    trainer = cfg.get("trainer")
+    if not isinstance(trainer, Mapping):
+        return None
+    return _as_nonnegative_int(trainer.get("max_epochs"))
+
+
+def _best_winkler_epoch_from_history(history: pd.DataFrame) -> int | None:
+    """Return the epoch with the lowest validation Winkler score."""
+    if history.empty or not {"epoch", "metric", "value"}.issubset(history.columns):
+        return None
+
+    hist = history.copy()
+    hist["metric"] = hist["metric"].astype(str)
+    exact_metric_order = [
+        "val_multiwinkler",
+        "val_winkler",
+        "multiwinkler",
+        "winkler",
+    ]
+    metric_name = next(
+        (name for name in exact_metric_order if (hist["metric"] == name).any()),
+        None,
+    )
+    if metric_name is None:
+        metric_names = hist["metric"].dropna().unique().tolist()
+        metric_name = next(
+            (
+                str(name)
+                for name in metric_names
+                if str(name).startswith("val_") and "winkler" in str(name)
+            ),
+            None,
+        )
+    if metric_name is None:
+        return None
+
+    sub = cast(pd.DataFrame, hist[hist["metric"] == metric_name].copy())
+    sub["epoch"] = pd.to_numeric(sub["epoch"], errors="coerce")
+    sub["value"] = pd.to_numeric(sub["value"], errors="coerce")
+    sub = cast(pd.DataFrame, sub.dropna(subset=["epoch", "value"]))
+    if sub.empty:
+        return None
+    best_idx = cast(pd.Series, sub["value"]).idxmin()
+    return _as_nonnegative_int(cast(pd.Series, sub.loc[best_idx]).get("epoch"))
+
+
+def _best_winkler_epoch_from_cache(
+    run_dir: Path,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+) -> int | None:
+    """Return the cached epoch with the lowest validation Winkler score."""
+    candidates = list(dict.fromkeys([eval_subdir, DEFAULT_EVAL_SUBDIR]))
+    for subdir in candidates:
+        history = _load_training_history_cache(run_dir, eval_subdir=subdir)
+        if history is None:
+            continue
+        best_epoch = _best_winkler_epoch_from_history(history)
+        if best_epoch is not None:
+            return best_epoch
+    return None
+
+
+def _best_winkler_epoch_from_wandb(
+    run_dir: Path,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+    force_refresh: bool = False,
+) -> int | None:
+    """Fetch W&B history and return the epoch with the lowest Winkler score."""
+    history = parse_training_metrics_from_wandb(
+        run_dir,
+        eval_subdir=eval_subdir,
+        force_refresh=force_refresh,
+    )
+    return _best_winkler_epoch_from_history(history)
+
+
+def _coverage_diagonal_mae_from_csv(path: Path) -> float | None:
+    """Compute mean |observed coverage - nominal coverage| from a curve CSV."""
+    if not path.exists():
+        return None
+    try:
+        df = pd.read_csv(path)
+    except Exception:
+        return None
+    if df.empty or not {"coverage_level", "observed_mean"}.issubset(df.columns):
+        return None
+    expected = cast(
+        pd.Series,
+        pd.to_numeric(df["coverage_level"], errors="coerce"),
+    ).to_numpy(dtype=float)
+    observed = cast(
+        pd.Series,
+        pd.to_numeric(df["observed_mean"], errors="coerce"),
+    ).to_numpy(dtype=float)
+    finite = np.isfinite(expected) & np.isfinite(observed)
+    if not finite.any():
+        return None
+    value = float(np.mean(np.abs(observed[finite] - expected[finite])))
+    return value if np.isfinite(value) else None
+
+
+def load_single_run_metrics(  # noqa: PLR0912, PLR0915
+    run_dir: Path,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+    run_ref: str | None = None,
+    force_training_refresh: bool = False,
+) -> dict:
+    """Load evaluation metrics and rollout metrics from a single run directory."""
+    resolved_eval_subdir = normalize_eval_subdir(eval_subdir)
+    row = {
+        "run_name": run_ref or run_dir.name,
+        "run_id": run_dir.name,
+        "run_path": run_dir.name,
+        "eval_subdir": resolved_eval_subdir,
+        "dataset": None,
+    }
+    eval_dir = run_dir / resolved_eval_subdir
+
+    # Evaluation metrics
+    p_eval = eval_dir / "evaluation_metrics.csv"
+    if p_eval.exists():
+        em = pd.read_csv(p_eval)
+        if not em.empty and "window" in em.columns:
+            em["window"] = em["window"].astype(str)
+            if "batch_idx" in em.columns:
+                em["batch_idx"] = em["batch_idx"].astype(str)
+                ov = em[(em["window"] == "all") & (em["batch_idx"] == "all")]
+                if ov.empty:
+                    ov = em[em["window"] == "all"]
+            else:
+                ov = em[em["window"] == "all"]
+            if not ov.empty:
+                rr = ov.iloc[0]
+                for col in em.columns:
+                    if col in {"window", "batch_idx"}:
+                        continue
+                    row[f"overall_{col}"] = pd.to_numeric(rr[col], errors="coerce")
+
+    if "overall_coverage" not in row:
+        coverage_mae = _coverage_diagonal_mae_from_csv(
+            eval_dir / "test_coverage_window_all.csv"
+        )
+        if coverage_mae is not None:
+            row["overall_coverage"] = coverage_mae
+
+    # Rollout metrics
+    p_roll = eval_dir / "rollout_metrics.csv"
+    if p_roll.exists():
+        rm = pd.read_csv(p_roll)
+        if not rm.empty and "window" in rm.columns:
+            rm["window"] = rm["window"].astype(str)
+            if "batch_idx" in rm.columns:
+                rm = rm[rm["batch_idx"].astype(str) == "all"]
+            for _, rr in rm.iterrows():
+                w = rr["window"]
+                for col in rm.columns:
+                    if col in {"window", "batch_idx"}:
+                        continue
+                    row[f"{col}_{w}"] = pd.to_numeric(rr[col], errors="coerce")
+
+    # Evaluation metadata (Params)
+    p_meta = eval_dir / "evaluation_metadata.csv"
+    if p_meta.exists():
+        md = pd.read_csv(p_meta)
+        if not md.empty and {"category", "metric", "value"}.issubset(md.columns):
+            rt = md[md["category"] == "runtime_train"]
+            for metric, out_col in [
+                ("mean_epoch_s", "train_mean_epoch_s"),
+                ("total_s", "train_total_s"),
+                ("min_epoch_s", "train_min_epoch_s"),
+                ("max_epoch_s", "train_max_epoch_s"),
+            ]:
+                s = rt.loc[rt["metric"] == metric, "value"]
+                if not s.empty:
+                    row[out_col] = pd.to_numeric(s.iloc[0], errors="coerce")
+
+            params = md[md["category"] == "params"]
+            for metric, out_col in [
+                ("model_total", "params_model_total"),
+                ("model_trainable", "params_model_trainable"),
+                ("processor_total", "params_processor_total"),
+                ("encoder_total", "params_encoder_total"),
+                ("decoder_total", "params_decoder_total"),
+            ]:
+                s = params.loc[params["metric"] == metric, "value"]
+                if not s.empty:
+                    row[out_col] = pd.to_numeric(s.iloc[0], errors="coerce")
+
+    # Benchmark metrics (inference/rollout latency, throughput, memory, flops)
+    p_bench = eval_dir / "benchmark_metrics.csv"
+    if p_bench.exists():
+        bm = pd.read_csv(p_bench)
+        if not bm.empty and {"benchmark_type", "metric", "value"}.issubset(bm.columns):
+            for _, rr in bm.iterrows():
+                prefix = str(rr["benchmark_type"])
+                metric = str(rr["metric"])
+                row[f"{prefix}_{metric}"] = pd.to_numeric(rr["value"], errors="coerce")
+
+    # Training metadata (dataset hints for cached latents)
+    p_config = run_dir / "resolved_config.yaml"
+    cfg = _read_yaml_mapping(p_config)
+    if cfg:
+        datamodule = cfg.get("datamodule", {})
+        if isinstance(datamodule, Mapping):
+            data_path = datamodule.get("data_path", "")
+            row["dataset"] = Path(data_path).name if data_path else row.get("dataset")
+            row["dataset_from_data_path"] = dataset_module_from_data_path(data_path)
+        trainer_max_epochs = _trainer_max_epochs_from_config(cfg)
+        if trainer_max_epochs is not None:
+            row["trainer_max_epochs"] = trainer_max_epochs
+
+    loss_family, _, _ = parse_loss_dataset_arch(run_dir.name)
+    if loss_family == "crps":
+        best_winkler_epoch = _best_winkler_epoch_from_wandb(
+            run_dir,
+            eval_subdir=resolved_eval_subdir,
+            force_refresh=force_training_refresh,
+        )
+        if best_winkler_epoch is None:
+            best_winkler_epoch = _best_winkler_epoch_from_cache(
+                run_dir,
+                eval_subdir=resolved_eval_subdir,
+            )
+        if best_winkler_epoch is not None:
+            row["best_winkler_epoch"] = best_winkler_epoch
+    return row
+
+
+def assign_model_scale(df_in: pd.DataFrame) -> pd.Series:
+    """Label each run as 'small' or 'large' relative to its architecture group."""
+    out = pd.Series("large", index=df_in.index, dtype="object")
+
+    # If the architecture segment already encodes size intent, trust it.
+    explicit_scale = pd.Series(None, index=df_in.index, dtype="object")
+    if "arch_segment" in df_in.columns:
+        seg = cast(pd.Series, df_in["arch_segment"].fillna(""))
+        seg_s = seg.astype(str)
+        explicit_scale = pd.Series(
+            np.where(
+                seg_s.str.contains(r"(?:^|_)small(?:_|$)"),
+                "small",
+                np.where(seg_s.str.contains(r"(?:^|_)large(?:_|$)"), "large", ""),
+            ),
+            index=df_in.index,
+            dtype="object",
+        )
+        explicit_scale = explicit_scale.replace("", np.nan)
+        out.loc[explicit_scale == "small"] = "small"
+        out.loc[explicit_scale == "large"] = "large"
+
+    if MODEL_SCALE_PARAM_COL not in df_in.columns:
+        return out
+    params = cast(
+        pd.Series, pd.to_numeric(df_in[MODEL_SCALE_PARAM_COL], errors="coerce")
+    )
+    group_cols = [
+        c for c in ["dataset_module", "loss_family", "arch_key"] if c in df_in.columns
+    ]
+    if len(group_cols) < 2:
+        return out
+
+    for _, g in df_in.groupby(group_cols, dropna=False):
+        idx = g.index
+        pending_idx = explicit_scale.loc[idx][explicit_scale.loc[idx].isna()].index
+        if len(pending_idx) == 0:
+            continue
+
+        p = cast(pd.Series, params.loc[pending_idx])
+        vals = sorted(p.dropna().unique().tolist())
+        if len(vals) <= 1:
+            out.loc[pending_idx] = "large"
+            continue
+        low, high = vals[0], vals[-1]
+        low_idx = cast(pd.Series, p[p == low]).index
+        high_idx = cast(pd.Series, p[p == high]).index
+        out.loc[low_idx] = "small"
+        out.loc[high_idx] = "large"
+        mid_mask = (p != low) & (p != high)
+        for ii in cast(pd.Series, p[mid_mask]).index:
+            val = p.loc[ii]
+            out.loc[ii] = (
+                "small"
+                if pd.notna(val) and abs(float(val) - low) <= abs(float(val) - high)
+                else "large"
+            )
+    return out
+
+
+def _resolve_resolution(
+    row: dict[str, object],
+    proc: dict,
+    data_path: str,
+) -> str | None:
+    """Resolve grid resolution from processor config or dataset heuristics."""
+    res = None
+    proc_sr = proc.get("spatial_resolution")
+    if isinstance(proc_sr, (list, tuple)):
+        vals = [int(v) for v in proc_sr[:2] if v is not None]
+        res = _format_spatial_resolution(vals)
+    if not res:
+        res = dataset_grid_resolution(
+            cast(str | None, row.get("dataset_from_data_path")),
+            data_path,
+        )
+    if not res:
+        _, ds_from_name, _ = parse_loss_dataset_arch(
+            cast(str | None, row.get("run_name"))
+        )
+        if ds_from_name:
+            res = dataset_grid_resolution(ds_from_name, data_path)
+    return res
+
+
+def _extract_config_fields(cfg: dict, row: dict[str, object]) -> None:
+    """Populate *row* with fields extracted from a resolved Hydra config."""
+    datamodule = cfg.get("datamodule", {})
+    row["n_steps_input"] = datamodule.get("n_steps_input")
+    row["n_steps_output"] = datamodule.get("n_steps_output")
+    row["batch_size"] = datamodule.get("batch_size")
+    data_path = datamodule.get("data_path", "")
+    row["dataset"] = Path(data_path).name
+    row["dataset_from_data_path"] = dataset_module_from_data_path(data_path)
+    row["loss_func"] = (
+        cfg.get("model", {}).get("loss_func", {}).get("_target_", "").split(".")[-1]
+    )
+    proc = cfg.get("model", {}).get("processor", {})
+    row["processor"] = proc.get("_target_", "").split(".")[-1]
+
+    if isinstance(proc, dict):
+        row["resolution"] = _resolve_resolution(row, proc, data_path)
+
+    inj = cfg.get("model", {}).get("input_noise_injector", {})
+    row["noise_injector"] = inj.get("_target_", "").split(".")[-1] if inj else "None"
+
+    # Noise channels from processor or injector
+    nc = proc.get("n_noise_channels")
+    if nc is None and inj:
+        nc = inj.get("n_noise_channels")
+    row["noise_channels"] = int(nc) if nc is not None else 0
+
+    # ODE / sampling steps (flow_ode_steps or sampler_steps)
+    ode = proc.get("flow_ode_steps") or proc.get("sampler_steps")
+    if ode is not None:
+        row["ode_steps"] = int(ode)
+
+    row["lr"] = cfg.get("optimizer", {}).get("learning_rate")
+
+    # GPU count from trainer config
+    trainer = cfg.get("trainer", {})
+    devices = trainer.get("devices", 1)
+    num_nodes = trainer.get("num_nodes", 1)
+    try:
+        n_gpus = int(devices) * int(num_nodes)
+    except (TypeError, ValueError):
+        n_gpus = 1
+    row["n_gpus"] = n_gpus
+
+    bs = row.get("batch_size")
+    if bs is not None:
+        assert isinstance(bs, int | str | float), (
+            "Batch size must be an integer, string, or float."
+        )
+        row["eff_batch_size"] = int(bs) * n_gpus
+
+
+def load_config_metadata(  # noqa: PLR0912
+    run_dir: Path,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+    run_ref: str | None = None,
+) -> dict[str, object]:
+    """Load training config metadata (LR, batch size, noise, etc.)."""
+    resolved_eval_subdir = normalize_eval_subdir(eval_subdir)
+    row: dict[str, object] = {
+        "run_name": run_ref or run_dir.name,
+        "run_id": run_dir.name,
+        "eval_subdir": resolved_eval_subdir,
+    }
+    p_config = run_dir / "resolved_config.yaml"
+    if p_config.exists():
+        try:
+            with open(p_config) as f:
+                cfg = yaml.safe_load(f)
+            if cfg:
+                _extract_config_fields(cfg, row)
+        except Exception:
+            pass
+
+    # Run date: inspect only local directory names to avoid following symlinks.
+    _date_found = False
+    for _anc in (run_dir, *run_dir.parents):
+        dm = re.match(r"(\d{4}-\d{2}-\d{2})$", _anc.name)
+        if dm:
+            row["run_date"] = dm.group(1)
+            _date_found = True
+            break
+    if not _date_found and p_config.exists():
+        mtime = p_config.stat().st_mtime
+        row["run_date"] = datetime.fromtimestamp(mtime, tz=timezone.utc).strftime(
+            "%Y-%m-%d"
+        )
+
+    # Training time from evaluation_metadata.csv
+    p_meta = run_dir / resolved_eval_subdir / "evaluation_metadata.csv"
+    if p_meta.exists():
+        try:
+            md = pd.read_csv(p_meta)
+            if not md.empty and {"category", "metric", "value"}.issubset(md.columns):
+                rt = md[md["category"] == "runtime_train"]
+                s = rt.loc[rt["metric"] == "total_s", "value"]
+                if not s.empty:
+                    row["train_total_s"] = pd.to_numeric(s.iloc[0], errors="coerce")
+                s = rt.loc[rt["metric"] == "mean_epoch_s", "value"]
+                if not s.empty:
+                    row["train_mean_epoch_s"] = pd.to_numeric(
+                        s.iloc[0], errors="coerce"
+                    )
+
+                params = md[md["category"] == "params"]
+                p = params.loc[params["metric"] == "processor_total", "value"]
+                if not p.empty:
+                    row["params_processor_total"] = pd.to_numeric(
+                        p.iloc[0], errors="coerce"
+                    )
+        except Exception:
+            pass
+
+    # Inference latency from benchmark_metrics.csv
+    p_bench = run_dir / resolved_eval_subdir / "benchmark_metrics.csv"
+    if p_bench.exists():
+        try:
+            bm = pd.read_csv(p_bench)
+            if not bm.empty and {
+                "benchmark_type",
+                "metric",
+                "value",
+            }.issubset(bm.columns):
+                lat = bm.loc[
+                    (bm["benchmark_type"].astype(str) == "model")
+                    & (bm["metric"].astype(str) == "latency_ms_per_sample"),
+                    "value",
+                ]
+                if not lat.empty:
+                    row["model_latency_ms_per_sample"] = pd.to_numeric(
+                        lat.iloc[0], errors="coerce"
+                    )
+        except Exception:
+            pass
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Coloring / Styling
+# ---------------------------------------------------------------------------
+
+
+def _mix_with_white(color, frac):
+    r, g, b, a = color
+    return (r + (1.0 - r) * frac, g + (1.0 - g) * frac, b + (1.0 - b) * frac, a)
+
+
+def _mix_with_black(color, frac):
+    r, g, b, a = color
+    scale = max(0.0, 1.0 - frac)
+    return (r * scale, g * scale, b * scale, a)
+
+
+def _rgb_luminance(rgba):
+    return 0.2126 * rgba[0] + 0.7152 * rgba[1] + 0.0722 * rgba[2]
+
+
+def get_hue_and_lightness(
+    pg: str, df_in: pd.DataFrame, explicit_groups: list[list[str]] | None
+):
+    """Get hue and lightness for a plot group.
+
+    Returns (base_color, assigned_color, is_diff, scale).
+    If explicit_groups is used, different groups get different base_colors.
+    Within a group, lightness varies.
+    """
+    parts = pg.split("__")
+    arch = parts[0]
+    loss = parts[1] if len(parts) > 1 else "unknown"
+    scale = parts[2] if len(parts) > 2 else "large"
+
+    if explicit_groups:
+        # Find which group index contains a run resolving to this pg.
+        # This requires tracking which run names belong to which group and their pg.
+        # We handle this mapping explicitly in build_family_style.
+        pass
+
+    # Default notebook scheme fallback
+    cmap = plt.get_cmap("tab20")
+    hues = sorted(
+        {p.split("__")[0] for p in cast(pd.Series, df_in["plot_group"]).unique()}
+    )
+    h_idx = hues.index(arch) % 10 if arch in hues else 0
+    c0, c1 = cmap(2 * h_idx), cmap(2 * h_idx + 1)
+    light, dark = (c0, c1) if _rgb_luminance(c0) > _rgb_luminance(c1) else (c1, c0)
+    color = light if scale == "small" else dark
+    return color, loss == "diff", scale
+
+
+def plot_group_display_label(pg: str) -> str:
+    """Return a human-readable label for a plot_group key."""
+    parts = pg.split("__")
+    arch, loss, scale = (
+        parts[0],
+        parts[1] if len(parts) > 1 else "?",
+        parts[2] if len(parts) > 2 else "?",
+    )
+    run_name = parts[3] if len(parts) > 3 else ""
+    model_l = MODEL_FAMILY_DISPLAY_LABELS.get(arch, arch)
+    loss_l = {"crps": "CRPS", "diff": "FM"}.get(loss, loss)
+
+    h = ""
+    if run_name:
+        m = re.search(r"_[0-9a-f]{7}$", run_name)
+        h = f" [{run_name[-7:]}]" if m else f" [{run_name[:7]}]"
+
+    return f"{model_l} · {scale} · {loss_l}{h}"
+
+
+def _run_name_from_plot_group(pg: str) -> str | None:
+    """Extract run_name from a plot_group token when present."""
+    parts = pg.split("__")
+    if len(parts) > 3 and parts[3]:
+        return parts[3]
+    return None
+
+
+def _run_ref_aliases(run_name: str) -> list[str]:
+    """Return lookup aliases for a run ref with optional eval/index suffixes."""
+    aliases = [run_name]
+    base = run_name.split("#", 1)[0]
+    if base not in aliases:
+        aliases.append(base)
+    core = base.split("::eval=", 1)[0]
+    if core not in aliases:
+        aliases.append(core)
+    return aliases
+
+
+def _style_label_for_plot_group(
+    pg: str,
+    custom_label_by_run: dict[str, str] | None,
+) -> str:
+    """Return custom label for a run when provided, else the default label."""
+    if custom_label_by_run:
+        run_name = _run_name_from_plot_group(pg)
+        if run_name:
+            for alias in _run_ref_aliases(run_name):
+                if alias in custom_label_by_run:
+                    return custom_label_by_run[alias]
+    return plot_group_display_label(pg)
+
+
+def extract_valid_plot_groups_from_run_names(
+    run_names: list[str], df_in: pd.DataFrame
+) -> set[str]:
+    """Return the plot_group keys that correspond to the given run directory names."""
+    # Given a list of run dir names, find their corresponding plot_groups in df_in
+    mask = cast(pd.Series, df_in["run_name"].isin(run_names))
+    if "run_id" in df_in.columns:
+        mask = cast(pd.Series, mask | df_in["run_id"].isin(run_names))
+    return set(cast(pd.Series, df_in[mask]["plot_group"]).unique())
+
+
+def _shade_variant(base_color, idx: int, total: int):
+    """Return a deterministic lightness variant for a color within a family."""
+    if total <= 1:
+        return base_color
+    if total == 2:
+        return (
+            _mix_with_white(base_color, 0.22)
+            if idx == 0
+            else _mix_with_black(base_color, 0.22)
+        )
+    frac = (idx / (total - 1)) - 0.5  # -0.5..0.5
+    # Positive frac → darker, negative → lighter (first item = lightest).
+    return (
+        _mix_with_black(base_color, frac * 0.6)
+        if frac > 0
+        else _mix_with_white(base_color, -frac * 0.8)
+    )
+
+
+def _build_label_color_map(
+    labels: list[str],
+) -> dict[str, tuple]:
+    """Map labels to colors, grouping by prefix before '('."""
+    base_cmap = plt.get_cmap("tab10")
+
+    def _prefix(lbl: str) -> str:
+        idx = lbl.find("(")
+        return lbl[:idx].strip() if idx >= 0 else lbl.strip()
+
+    prefixes = sorted({_prefix(lb) for lb in labels})
+    pfx_hue = {p: i for i, p in enumerate(prefixes)}
+
+    hue_members: dict[int, list[str]] = {}
+    seen: set[str] = set()
+    for lb in labels:
+        if lb in seen:
+            continue
+        seen.add(lb)
+        hi = pfx_hue[_prefix(lb)]
+        hue_members.setdefault(hi, []).append(lb)
+
+    result: dict[str, tuple] = {}
+    for hi, members in hue_members.items():
+        base = base_cmap(hi % 10)
+        for j, lb in enumerate(members):
+            result[lb] = _shade_variant(base, j, len(members))
+    return result
+
+
+def _apply_explicit_group_styles(
+    styles: dict,
+    df_in: pd.DataFrame,
+    explicit_groups: list[list[str]],
+    custom_label_by_run: dict[str, str] | None,
+    uniform_group_color: bool,
+    group_hues: list[int] | None,
+) -> None:
+    """Assign styles from explicit --run-group definitions."""
+    base_cmap = plt.get_cmap("tab10")
+
+    hue_family: dict[int, list[int]] = {}
+    if group_hues:
+        for gi, hi in enumerate(group_hues):
+            hue_family.setdefault(hi, []).append(gi)
+
+    for i, group_runs in enumerate(explicit_groups):
+        if group_hues and i < len(group_hues):
+            hue_idx = group_hues[i]
+            base_color = base_cmap(hue_idx % 10)
+            siblings = hue_family.get(hue_idx, [i])
+            c = _shade_variant(base_color, siblings.index(i), len(siblings))
+        else:
+            base_color = base_cmap(i % 10)
+            c = base_color
+
+        group_pgs = extract_valid_plot_groups_from_run_names(group_runs, df_in)
+        group_pgs = sorted(group_pgs)
+        for j, pg in enumerate(group_pgs):
+            if pg in styles:
+                continue
+            run_c = (
+                c
+                if (uniform_group_color or group_hues)
+                else _shade_variant(base_color, j, len(group_pgs))
+            )
+            parts = pg.split("__")
+            loss = parts[1] if len(parts) > 1 else "unknown"
+            styles[pg] = {
+                "color": run_c,
+                "label": _style_label_for_plot_group(pg, custom_label_by_run),
+                "marker": "^" if loss == "diff" else "o",
+                "linestyle": "-" if loss == "diff" else "--",
+            }
+
+
+def _apply_run_hue_styles(
+    styles: dict,
+    pgs: list[str],
+    hue_group_by_run: dict[str, int],
+    custom_label_by_run: dict[str, str] | None,
+    uniform_run_hue_color: bool,
+) -> None:
+    """Assign styles using per-run hue group indices from --run <id> [label] <hue>."""
+    base_cmap = plt.get_cmap("tab10")
+
+    # Group plot_groups by hue index, preserving --runs order within each group.
+    hue_members: dict[int, list[str]] = {}
+    no_hue: list[str] = []
+    for pg in pgs:
+        rn = _run_name_from_plot_group(pg)
+        hue_idx: int | None = None
+        if rn:
+            for alias in _run_ref_aliases(rn):
+                if alias in hue_group_by_run:
+                    hue_idx = hue_group_by_run[alias]
+                    break
+        if hue_idx is not None:
+            hue_members.setdefault(hue_idx, []).append(pg)
+            continue
+        no_hue.append(pg)
+
+    for hi, members in sorted(hue_members.items()):
+        base_color = base_cmap(hi % 10)
+        # Assign shades by unique label (first-seen), not by run index.
+        # This keeps color/lightness stable across datasets when the label matches.
+        member_labels = [
+            str(_style_label_for_plot_group(pg, custom_label_by_run)) for pg in members
+        ]
+        unique_labels = list(dict.fromkeys(member_labels))
+        label_to_color = {
+            lb: (
+                base_color
+                if uniform_run_hue_color
+                else _shade_variant(base_color, j, len(unique_labels))
+            )
+            for j, lb in enumerate(unique_labels)
+        }
+
+        for pg, lb in zip(members, member_labels, strict=False):
+            parts = pg.split("__")
+            loss = parts[1] if len(parts) > 1 else "unknown"
+            styles[pg] = {
+                "color": label_to_color[lb],
+                "label": lb,
+                "marker": "^" if loss == "diff" else "o",
+                "linestyle": "-" if loss == "diff" else "--",
+            }
+
+    # Runs without an explicit hue get sequential colors after the last hue.
+    next_hi = max(hue_members.keys(), default=-1) + 1
+    for i, pg in enumerate(no_hue):
+        parts = pg.split("__")
+        loss = parts[1] if len(parts) > 1 else "unknown"
+        styles[pg] = {
+            "color": base_cmap((next_hi + i) % 10),
+            "label": _style_label_for_plot_group(pg, custom_label_by_run),
+            "marker": "^" if loss == "diff" else "o",
+            "linestyle": "-" if loss == "diff" else "--",
+        }
+
+
+def _apply_label_color_styles(
+    styles: dict,
+    pgs: list[str],
+    custom_label_by_run: dict[str, str],
+) -> None:
+    """Assign styles by label — same label gets same color."""
+    pg_label = {}
+    for pg in pgs:
+        rn = _run_name_from_plot_group(pg)
+        lbl: str | None = None
+        if rn:
+            for alias in _run_ref_aliases(rn):
+                if alias in custom_label_by_run:
+                    lbl = custom_label_by_run[alias]
+                    break
+        pg_label[pg] = (
+            lbl
+            if lbl is not None
+            else _style_label_for_plot_group(pg, custom_label_by_run)
+        )
+    label_color = _build_label_color_map(list(pg_label.values()))
+    for pg in pgs:
+        lb = pg_label[pg]
+        parts = pg.split("__")
+        loss = parts[1] if len(parts) > 1 else "unknown"
+        styles[pg] = {
+            "color": label_color[lb],
+            "label": _style_label_for_plot_group(pg, custom_label_by_run),
+            "marker": "^" if loss == "diff" else "o",
+            "linestyle": "-" if loss == "diff" else "--",
+        }
+
+
+def build_family_style(
+    df_in: pd.DataFrame,
+    explicit_groups: list[list[str]] | None = None,
+    custom_label_by_run: dict[str, str] | None = None,
+    uniform_group_color: bool = False,
+    uniform_run_hue_color: bool = False,
+    group_hues: list[int] | None = None,
+    color_by_label: bool = False,
+    hue_group_by_run: dict[str, int] | None = None,
+) -> dict:
+    """Build a style dict (color, label, marker, linestyle) for each plot_group."""
+    styles: dict = {}
+    _present_raw = cast(pd.Series, df_in["plot_group"].dropna())
+    # Preserve first-seen order (reflects --runs order) instead of sorting.
+    present = list(dict.fromkeys(_present_raw.tolist()))
+
+    if explicit_groups and len(explicit_groups) > 0:
+        _apply_explicit_group_styles(
+            styles,
+            df_in,
+            explicit_groups,
+            custom_label_by_run,
+            uniform_group_color,
+            group_hues,
+        )
+
+    remaining = [pg for pg in present if pg not in styles]
+    if hue_group_by_run and remaining:
+        _apply_run_hue_styles(
+            styles,
+            remaining,
+            hue_group_by_run,
+            custom_label_by_run,
+            uniform_run_hue_color,
+        )
+        remaining = []
+    elif color_by_label and custom_label_by_run and remaining:
+        _apply_label_color_styles(styles, remaining, custom_label_by_run)
+        remaining = []
+
+    # Fallback for remaining plot groups: each run gets its own hue.
+    cmap = plt.get_cmap("tab20")
+    for i, pg in enumerate(sorted(remaining)):
+        parts = pg.split("__")
+        loss = parts[1] if len(parts) > 1 else "unknown"
+        styles[pg] = {
+            "color": cmap(i % 20),
+            "label": _style_label_for_plot_group(pg, custom_label_by_run),
+            "marker": "^" if loss == "diff" else "o",
+            "linestyle": "-" if loss == "diff" else "--",
+        }
+    return styles
+
+
+def build_custom_label_map(
+    label_run_pairs: list[list[str]] | None,
+    valid_run_names: set[str] | None = None,
+) -> dict[str, str]:
+    """Build run_name -> custom label map from ``--label-run`` entries.
+
+    A label value of "None" (case-insensitive) means: keep default auto label.
+    """
+    if not label_run_pairs:
+        return {}
+
+    custom: dict[str, str] = {}
+    for pair in label_run_pairs:
+        if len(pair) != 2:
+            msg = "Each --label-run must provide exactly two values: <run_id> <label>."
+            raise ValueError(msg)
+
+        run_name, label = pair[0], pair[1]
+        if valid_run_names is not None and run_name not in valid_run_names:
+            msg = (
+                f"--label-run references unknown run_id '{run_name}'. "
+                "Ensure it is included via --runs/--run-group or exists in "
+                "auto-discovery."
+            )
+            raise ValueError(msg)
+
+        norm = str(label).strip()
+        if norm.casefold() == "none":
+            continue
+        custom[run_name] = norm
+
+    return custom
+
+
+# ---------------------------------------------------------------------------
+# Plotting Implementations
+# ---------------------------------------------------------------------------
+
+
+def save_fig(fig, out_dir: Path, name: str):
+    """Save a matplotlib figure to disk and close it."""
+    p = out_dir / name
+    base = p.with_suffix("") if p.suffix else p
+    original_format = p.suffix.lower().lstrip(".")
+    formats = FIGURE_FORMATS or (original_format or "png",)
+    for figure_format in formats:
+        fmt = figure_format.lower().lstrip(".")
+        target = p if fmt == original_format else base.with_suffix(f".{fmt}")
+        save_kwargs: dict[str, Any] = {"bbox_inches": "tight", "format": fmt}
+        if fmt == "png":
+            save_kwargs["dpi"] = 120
+        fig.savefig(target, **save_kwargs)
+        print(f"Saved: {target}")
+    plt.close(fig)
+
+
+def _dedup_legend_handles(groups: list, styles: dict) -> list[Line2D]:
+    """Build legend handles with duplicate labels removed."""
+    handles = []
+    seen: set[str] = set()
+    for g in groups:
+        if g not in styles:
+            continue
+        lbl = str(styles[g]["label"])
+        if lbl in seen:
+            continue
+        seen.add(lbl)
+        handles.append(
+            Line2D(
+                [0],
+                [0],
+                color=styles[g]["color"],
+                ls=styles[g].get("linestyle", "-"),
+                lw=2,
+                label=lbl,
+            )
+        )
+    return handles
+
+
+def _single_step_epochs_trained(row: pd.Series) -> float:
+    """Resolve the epoch count shown in the single-step results table."""
+    loss_family = str(row.get("loss_family", "")).lower()
+    if loss_family == "crps":
+        candidates = ("best_winkler_epoch",)
+    else:
+        candidates = ("trainer_max_epochs",)
+
+    for column in candidates:
+        value = _as_nonnegative_int(row.get(column))
+        if value is not None:
+            return float(value)
+    return float("nan")
+
+
+def build_single_step_results_table(
+    df_in: pd.DataFrame,
+    styles: dict,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+) -> pd.DataFrame:
+    """Build the CSV/LaTeX table from the same grouped means as bar plots."""
+    if "dataset_label" not in df_in.columns or "plot_group" not in df_in.columns:
+        return pd.DataFrame()
+
+    data = df_in.copy()
+    if "single_step_epochs_trained" not in data.columns:
+        data["single_step_epochs_trained"] = data.apply(
+            _single_step_epochs_trained,
+            axis=1,
+        )
+    metric_cols = [src for src, _ in SINGLE_STEP_RESULTS_TABLE_METRICS]
+    available = [c for c in metric_cols if c in data.columns]
+    if not available:
+        return pd.DataFrame()
+
+    for col in available:
+        data[col] = pd.to_numeric(data[col], errors="coerce")
+
+    grouped = (
+        data.groupby(["dataset_label", "plot_group"], dropna=False)[available]
+        .mean()
+        .reset_index()
+    )
+    datasets = _apply_explicit_order(
+        list(grouped["dataset_label"].dropna().unique()), dataset_order
+    )
+
+    rows: list[dict[str, object]] = []
+    for ds_label in datasets:
+        ds_rows = grouped[grouped["dataset_label"] == ds_label]
+        groups = _order_groups_by_label(
+            cast(pd.Series, ds_rows["plot_group"].astype(str)).dropna().tolist(),
+            styles,
+            hue_order,
+        )
+        for group in groups:
+            row_match = cast(
+                pd.DataFrame,
+                ds_rows[ds_rows["plot_group"].astype(str) == str(group)],
+            )
+            if row_match.empty:
+                continue
+            raw = cast(pd.Series, row_match.iloc[0])
+            style = styles.get(group, {"label": group})
+            table_row: dict[str, object] = {
+                "Dataset": ds_label,
+                "Model": str(style.get("label", group)),
+            }
+            for src, label in SINGLE_STEP_RESULTS_TABLE_METRICS:
+                table_row[label] = raw[src] if src in raw.index else np.nan
+            rows.append(table_row)
+
+    columns = [
+        "Dataset",
+        "Model",
+        *[label for _, label in SINGLE_STEP_RESULTS_TABLE_METRICS],
+    ]
+    return pd.DataFrame(rows, columns=pd.Index(columns))
+
+
+def _latex_escape(value: object) -> str:
+    """Escape plain text for insertion into a LaTeX table."""
+    text = "" if value is None else str(value)
+    replacements = {
+        "\\": r"\textbackslash{}",
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+        "~": r"\textasciitilde{}",
+        "^": r"\textasciicircum{}",
+    }
+    return "".join(replacements.get(ch, ch) for ch in text)
+
+
+def _format_latex_table_value(value: object, column: str | None = None) -> str:  # noqa: PLR0911
+    """Format table cells for publication-ready LaTeX output."""
+    if isinstance(value, str):
+        return _latex_escape(value)
+    if value is None:
+        return ""
+    if isinstance(value, (pd.Series, pd.DataFrame, np.ndarray)):
+        return ""
+    if isinstance(value, (int, float, np.integer, np.floating)):
+        numeric = float(value)
+    elif isinstance(value, (bytes, bytearray)):
+        try:
+            numeric = float(value.decode("utf-8", errors="ignore"))
+        except ValueError:
+            return _latex_escape(value)
+    else:
+        # Fallback: treat as non-numeric text.
+        return _latex_escape(value)
+    if not np.isfinite(numeric) or math.isnan(numeric):
+        return ""
+    if column in {"VRMSE", "CRPS"}:
+        return f"{numeric:.1e}"
+    if column == "Coverage MAE":
+        return f"{numeric:.2f}"
+    if column == "SSR":
+        return f"{numeric:.2f}"
+    if column in {
+        "Inference latency (ms/sample)",
+        "Training time (s/epoch)",
+    }:
+        return f"{numeric:.0f}"
+    return f"{numeric:.3g}"
+
+
+def _best_latex_cells_by_dataset(table: pd.DataFrame) -> set[tuple[int, str]]:
+    """Return table cells that should be highlighted as best-in-dataset."""
+    best_cells: set[tuple[int, str]] = set()
+    if "Dataset" not in table.columns:
+        return best_cells
+
+    for _, dataset_rows in table.groupby("Dataset", sort=False):
+        for metric in [label for _, label in SINGLE_STEP_RESULTS_TABLE_METRICS]:
+            if metric not in dataset_rows.columns:
+                continue
+            metric_col = cast(pd.Series, dataset_rows[metric])
+            values_ser = cast(pd.Series, pd.to_numeric(metric_col, errors="coerce"))
+            values_ser = cast(pd.Series, values_ser.dropna())
+            if values_ser.empty:
+                continue
+            if metric in SINGLE_STEP_RESULTS_TARGET_METRICS:
+                target = SINGLE_STEP_RESULTS_TARGET_METRICS[metric]
+                scores = (values_ser - target).abs()
+                best_score = float(scores.min())
+                mask = cast(pd.Series, scores == best_score)
+                winners = cast(pd.Index, values_ser.index[mask])
+            elif metric in SINGLE_STEP_RESULTS_LOWER_IS_BETTER:
+                best_value = float(values_ser.min())
+                mask = cast(pd.Series, values_ser == best_value)
+                winners = cast(pd.Index, values_ser.index[mask])
+            else:
+                continue
+            for idx in winners:
+                best_cells.add((int(cast(SupportsIndex, idx)), metric))
+    return best_cells
+
+
+def _single_step_results_latex_column_spec(column: str) -> str:
+    """Return a LaTeX tabular column spec for a single table column."""
+    specs = {
+        "Dataset": "l",
+        "Model": "l",
+        "VRMSE": "S[table-format=1.1e-1, detect-weight=true]",
+        "CRPS": "S[table-format=1.1e-1, detect-weight=true]",
+        "Coverage MAE": "S[table-format=1.2, detect-weight=true]",
+        "SSR": "S[table-format=1.2, detect-weight=true]",
+        "Inference latency (ms/sample)": "S[table-format=3.0, detect-weight=true]",
+        "Training time (s/epoch)": "S[table-format=3.0, detect-weight=true]",
+    }
+    return specs.get(column, "l")
+
+
+def render_single_step_results_latex(table: pd.DataFrame) -> str:
+    """Render the results table using booktabs + siunitx styling."""
+    columns = table.columns.tolist()
+    align = (
+        "@{}"
+        + "\n  ".join(_single_step_results_latex_column_spec(col) for col in columns)
+        + "@{}"
+    )
+    header = " & ".join(
+        SINGLE_STEP_RESULTS_LATEX_HEADERS.get(col, _latex_escape(col))
+        for col in columns
+    )
+    best_cells = _best_latex_cells_by_dataset(table)
+    body = []
+    table_rows = list(table.iterrows())
+    last_dataset: str | None = None
+    for row_pos, (idx, row) in enumerate(table_rows):
+        idx_i = int(cast(SupportsIndex, idx))
+        cells = []
+        for col in columns:
+            if col == "Dataset":
+                current_dataset = str(row[col])
+                if current_dataset == "nan":
+                    current_dataset = ""
+                cell = (
+                    _latex_escape(current_dataset)
+                    if current_dataset != last_dataset
+                    else ""
+                )
+                last_dataset = current_dataset
+            else:
+                cell = _format_latex_table_value(row[col], column=col)
+            if cell and (idx_i, col) in best_cells:
+                cell = rf"\bfseries {cell}"
+            cells.append(cell)
+        body.append(" & ".join(cells) + r" \\")
+        is_last_row = row_pos == (len(table_rows) - 1)
+        if not is_last_row and "Dataset" in table.columns:
+            next_dataset = str(table_rows[row_pos + 1][1]["Dataset"])
+            if next_dataset != str(row["Dataset"]):
+                body.append(r"\midrule")
+    lines = [
+        r"% Requires \usepackage{booktabs,siunitx}",
+        r"\setlength{\tabcolsep}{3.5pt}",
+        rf"\begin{{tabular}}{{{align}}}",
+        r"\toprule",
+        header + r" \\",
+        r"\midrule",
+        *body,
+        r"\bottomrule",
+        r"\end{tabular}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_single_step_results_table(
+    df_in: pd.DataFrame,
+    out_dir: Path,
+    styles: dict,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    stem: str = "single_step_overall_results",
+) -> pd.DataFrame:
+    """Write single-step overall results as CSV and LaTeX."""
+    table = build_single_step_results_table(
+        df_in,
+        styles,
+        dataset_order=dataset_order,
+        hue_order=hue_order,
+    )
+    if table.empty:
+        print("No single-step overall results table available.")
+        return table
+
+    csv_path = out_dir / f"{stem}.csv"
+    tex_path = out_dir / f"{stem}.tex"
+    table.to_csv(csv_path, index=False, float_format="%.6g")
+    tex_path.write_text(render_single_step_results_latex(table), encoding="utf-8")
+    print(f"Saved: {csv_path}")
+    print(f"Saved: {tex_path}")
+    return table
+
+
+def grouped_bar(  # noqa: PLR0912, PLR0915
+    df_in: pd.DataFrame,
+    metric: str,
+    title: str,
+    ylabel: str,
+    out_dir: Path,
+    styles: dict,
+    y_scale: str = "auto",
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    ax: MplAxes | None = None,
+    save: bool = True,
+    ylim: tuple[float | None, float | None] | None = None,
+    show_legend: bool = True,
+    ref_value: float | None = None,
+    tick_label_scale: float = 1.0,
+    axis_label_scale: float = 1.0,
+    legend_font_scale: float = 1.0,
+    legend_font_size: float | None = None,
+    figure_scale: float = 1.0,
+    short_axis_labels: bool = False,
+    shared_axis_labels: bool = False,
+    height_scale: float = 1.0,
+) -> FigureBase | None:
+    """Render a grouped bar chart of a metric across datasets and model families.
+
+    When ``ax`` is provided, draw into it and skip figure creation/saving.
+    ``ylim`` (low, high) overrides automatic y-axis limits; either bound may be
+    ``None`` to keep the auto-computed value on that side.
+    ``ref_value`` draws a dotted horizontal reference line at that value.
+    """
+    _ = (short_axis_labels, shared_axis_labels, height_scale)
+    if metric not in df_in.columns:
+        return None
+    d = df_in.dropna(subset=[metric]).copy()
+    if d.empty:
+        return None
+
+    group_col = "plot_group"
+    g = (
+        d.groupby(["dataset_label", group_col], dropna=False)[metric]
+        .mean()
+        .reset_index()
+    )
+
+    datasets = _apply_explicit_order(list(g["dataset_label"].unique()), dataset_order)
+    _families = _order_groups_by_label(list(g[group_col].unique()), styles, hue_order)
+    x = np.arange(len(datasets), dtype=float)
+
+    # Width should reflect groups present per dataset, not global families across all
+    # datasets. Otherwise datasets with fewer groups render overly narrow bars.
+    present_by_dataset: dict[str, list[str]] = {}
+    max_present = 1
+    for ds in datasets:
+        ds_groups = _order_groups_by_label(
+            cast(
+                pd.Series,
+                g.loc[g["dataset_label"] == ds, group_col].astype(str),  # type: ignore  # noqa: PGH003
+            )
+            .dropna()
+            .unique()
+            .tolist(),
+            styles,
+            hue_order,
+        )
+        present_by_dataset[ds] = ds_groups
+        max_present = max(max_present, len(ds_groups))
+
+    width = 0.8 / max(1, max_present)
+
+    if ax is None:
+        fig, ax = plt.subplots(
+            figsize=_scaled_figsize(
+                max(8.0, 0.9 * len(datasets) + 2.0),
+                3.8,
+                figure_scale,
+            )
+        )
+    else:
+        fig = ax.figure
+    all_positive = []
+
+    seen_labels: set[str] = set()
+    for ds_idx, ds in enumerate(datasets):
+        ds_rows = g[g["dataset_label"] == ds].set_index(group_col)
+        ds_groups = present_by_dataset.get(ds, [])
+        for j, fam in enumerate(ds_groups):
+            if fam not in ds_rows.index:
+                continue
+            raw_val = ds_rows.loc[fam, metric]
+            raw_scalar = raw_val.iloc[0] if isinstance(raw_val, pd.Series) else raw_val
+            val_ser = cast(
+                pd.Series,
+                pd.to_numeric(pd.Series([raw_scalar]), errors="coerce"),
+            )
+            if val_ser.empty or pd.isna(val_ser.iloc[0]):
+                continue
+            val = float(val_ser.iloc[0])
+            if not np.isfinite(val):
+                continue
+
+            if val > 0:
+                all_positive.append(val)
+
+            offs = (j - (len(ds_groups) - 1) / 2.0) * width
+            style = styles.get(fam, {"color": "k", "label": fam})
+            label = str(style["label"])
+            if label in seen_labels:
+                label = "_nolegend_"
+            else:
+                seen_labels.add(label)
+
+            ax.bar(
+                float(x[ds_idx]) + offs,
+                val,
+                width=width,
+                label=label,
+                color=style["color"],
+                edgecolor="0.25",
+                linewidth=0.6,
+                linestyle=style.get("linestyle", "-"),
+            )
+
+    if y_scale == "linear":
+        ax.set_yscale("linear")
+    elif all_positive and min(all_positive) > 0:
+        ax.set_yscale("log")
+
+    ax.set_xticks(list(x))
+    ax.set_xticklabels(datasets, rotation=0 if len(datasets) <= 4 else 30, ha="right")
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.grid(axis="y", alpha=0.25)
+    _apply_tick_label_style(ax, tick_label_scale)
+    _apply_axis_label_style(ax, axis_label_scale)
+    if ref_value is not None:
+        ax.axhline(
+            ref_value,
+            color="black",
+            linestyle=":",
+            linewidth=1.0,
+            alpha=0.65,
+        )
+
+    if ylim is not None:
+        lo, hi = ylim
+        cur_lo, cur_hi = ax.get_ylim()
+        ax.set_ylim(
+            bottom=lo if lo is not None else cur_lo,
+            top=hi if hi is not None else cur_hi,
+        )
+
+    if show_legend:
+        handles, labels = ax.get_legend_handles_labels()
+        if handles:
+            ax.legend(
+                handles,
+                labels,
+                loc="upper left",
+                bbox_to_anchor=(1.01, 1.0),
+                fontsize=_resolve_font_size(
+                    DEFAULT_LEGEND_FONT_SIZE,
+                    legend_font_scale,
+                    legend_font_size,
+                ),
+                frameon=False,
+            )
+
+    if save:
+        save_fig(fig, out_dir, f"{metric}.png")
+        return None
+    return fig
+
+
+def plot_coverage_calibration_panel(  # noqa: PLR0912, PLR0915
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    axes: np.ndarray | None = None,
+    fig: FigureBase | None = None,
+    save: bool = True,
+    show_legend: bool = True,
+    window_rows: list[str] | None = None,
+    name: str = "coverage_calibration_panel.png",
+    tick_label_scale: float = 1.0,
+    axis_label_scale: float = 1.0,
+    legend_font_scale: float = 1.0,
+    legend_font_size: float | None = None,
+    figure_scale: float = 1.0,
+    short_axis_labels: bool = False,
+    shared_axis_labels: bool = False,
+    height_scale: float = 1.0,
+    line_width: float = 2.0,
+    ref_line_width: float = 1.0,
+) -> FigureBase | None:
+    """Plot the coverage calibration panel (rollout windows x datasets).
+
+    When ``axes`` (2D grid with shape (len(window_rows), n_datasets)) is given,
+    draw into that grid instead of creating a new figure.
+    """
+    rows = window_rows if window_rows is not None else WINDOW_ROWS
+    curves = []
+    base = df_in.dropna(
+        subset=["run_path", "dataset_label", "plot_group"]
+    ).drop_duplicates()
+    for _, r in base.iterrows():
+        for w in rows:
+            fn = (
+                "test_coverage_window_all.csv"
+                if w == "all"
+                else f"rollout_coverage_window_{w}.csv"
+            )
+            eval_subdir = normalize_eval_subdir(cast(str | None, r.get("eval_subdir")))
+            p = results_root / str(r["run_path"]) / eval_subdir / fn
+            if p.exists():
+                c = pd.read_csv(p)
+                if not c.empty and {"coverage_level", "observed_mean"}.issubset(
+                    c.columns
+                ):
+                    c["window"] = w
+                    c["dataset_label"] = r["dataset_label"]
+                    c["plot_group"] = r["plot_group"]
+                    c["run_path"] = r["run_path"]
+                    curves.append(c)
+
+    if not curves:
+        return None
+    cur_panel = pd.concat(curves, ignore_index=True)
+    datasets = _apply_explicit_order(
+        list(cur_panel["dataset_label"].unique()), dataset_order
+    )
+    groups = _order_groups_by_label(
+        list(cur_panel["plot_group"].unique()), styles, hue_order
+    )
+
+    nrows, ncols = len(rows), max(1, len(datasets))
+    if axes is None:
+        fig, axes = plt.subplots(
+            nrows,
+            ncols,
+            figsize=_scaled_figsize(
+                4.0 * ncols,
+                2.3 * nrows * height_scale,
+                figure_scale,
+            ),
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+        )
+    else:
+        # axes supplied by caller; make sure it's a 2D array
+        axes = np.atleast_2d(axes)
+        if fig is None:
+            fig = axes[0][0].figure
+
+    assert axes is not None
+    assert fig is not None
+
+    for i, w in enumerate(rows):
+        for j, ds_label in enumerate(datasets):
+            ax = axes[i][j]
+            ax.plot(
+                [0, 1],
+                [0, 1],
+                linestyle=":",
+                color="0.45",
+                alpha=0.6,
+                lw=ref_line_width,
+            )
+            sub = cur_panel[
+                (cur_panel["window"] == w) & (cur_panel["dataset_label"] == ds_label)
+            ]
+            for fam in groups:
+                sf = cast(pd.DataFrame, sub[sub["plot_group"] == fam])
+                if sf.empty:
+                    continue
+                st = styles.get(fam, {"color": "k", "linestyle": "-"})
+
+                # Plot each run's curve individually (no averaging)
+                mean_curve = cast(
+                    pd.DataFrame,
+                    cast(
+                        pd.DataFrame,
+                        sf.groupby("coverage_level", as_index=False)[
+                            "observed_mean"
+                        ].mean(),
+                    ).sort_values(by="coverage_level"),
+                )
+                ax.plot(
+                    mean_curve["coverage_level"],
+                    mean_curve["observed_mean"],
+                    color=st["color"],
+                    lw=line_width,
+                    linestyle=st.get("linestyle", "-"),
+                )
+            if i == 0:
+                ax.set_title(ds_label)
+            if i == nrows - 1:
+                ax.set_xlabel("" if shared_axis_labels else NOMINAL_COVERAGE_AXIS_LABEL)
+            if j == 0:
+                if shared_axis_labels:
+                    ax.set_ylabel(_coverage_window_row_tag(str(w)))
+                else:
+                    ax.set_ylabel(
+                        _coverage_window_axis_label(str(w), short=short_axis_labels)
+                    )
+            ax.set_xlim(0, 1)
+            ax.set_ylim(0, 1)
+            ax.grid(alpha=0.2)
+            _apply_tick_label_style(ax, tick_label_scale)
+            _apply_axis_label_style(ax, axis_label_scale)
+
+    if shared_axis_labels:
+        _set_shared_xlabel(fig, NOMINAL_COVERAGE_AXIS_LABEL, axis_label_scale)
+        _set_shared_ylabel(
+            fig,
+            _empirical_coverage_label(short=short_axis_labels),
+            axis_label_scale,
+        )
+    if show_legend:
+        legend_handles = _dedup_legend_handles(groups, styles)
+        fig.legend(
+            legend_handles,
+            [str(h.get_label()) for h in legend_handles],
+            loc="upper center",
+            bbox_to_anchor=(0.5, 0.995),
+            ncol=4,
+            fontsize=_resolve_font_size(
+                DEFAULT_LEGEND_FONT_SIZE,
+                legend_font_scale,
+                legend_font_size,
+            ),
+            frameon=False,
+        )
+    if save:
+        plt.tight_layout(rect=(0, 0, 1, 0.975))
+        save_fig(fig, out_dir, name)
+        return None
+    return fig
+
+
+def plot_lead_time_panel(  # noqa: PLR0912, PLR0915
+    df_in: pd.DataFrame,
+    metrics: list[str],
+    results_root: Path,
+    out_dir: Path,
+    name: str,
+    styles: dict,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    axes: np.ndarray | None = None,
+    fig: FigureBase | None = None,
+    save: bool = True,
+    error_ylim: tuple[float | None, float | None] | None = None,
+    show_legend: bool = True,
+    yscale: str | None = None,
+    ref_value: float | None = None,
+    coverage_delta: bool = False,
+    tick_label_scale: float = 1.0,
+    axis_label_scale: float = 1.0,
+    legend_font_scale: float = 1.0,
+    legend_font_size: float | None = None,
+    figure_scale: float = 1.0,
+    short_axis_labels: bool = False,
+    shared_axis_labels: bool = False,
+    height_scale: float = 1.0,
+    sharey: bool = False,
+    coverage_delta_row_labels: bool = False,
+    line_width: float = 2.0,
+    ref_line_width: float = 1.0,
+) -> FigureBase | None:
+    """Plot per-metric, per-dataset lead-time curves as a panel figure.
+
+    ``error_ylim`` (low, high) overrides auto y-limits for non-coverage rows;
+    coverage rows remain fixed at [0, 1]. Either bound may be ``None``.
+    When ``axes`` is provided, draw into that pre-made grid with shape
+    (len(metrics_to_plot), n_datasets).
+
+    ``yscale`` forces the y-axis scale for non-coverage rows (``'log'`` or
+    ``'linear'``). When omitted, the historical default of log-scale is used.
+    ``ref_value`` draws a dashed horizontal reference line at that y value on
+    every non-coverage subplot (e.g. 1.0 for SSR's ideal dispersion).
+    """
+    rows: list[pd.DataFrame] = []
+    base = df_in.dropna(
+        subset=["run_path", "dataset_label", "plot_group"]
+    ).drop_duplicates()
+    for r in base.itertuples(index=False):
+        run_path = getattr(r, "run_path", None)
+        eval_subdir = normalize_eval_subdir(getattr(r, "eval_subdir", None))
+        ds_label = getattr(r, "dataset_label", None)
+        pg = getattr(r, "plot_group", None)
+        if run_path is None or ds_label is None or pg is None:
+            continue
+        p = (
+            results_root
+            / str(run_path)
+            / eval_subdir
+            / "rollout_metrics_per_timestep_channel_all.csv"
+        )
+        if not p.exists():
+            continue
+        raw = pd.read_csv(p, index_col=0)
+        if raw.empty:
+            continue
+        long = raw.reset_index().rename(columns={raw.index.name or "index": "metric"})
+        long = long.melt(
+            id_vars="metric", var_name="timestep", value_name="value"
+        ).dropna()
+        long["timestep"] = pd.to_numeric(long["timestep"], errors="coerce")
+        long["value"] = pd.to_numeric(long["value"], errors="coerce")
+        long = cast(pd.DataFrame, long[long["metric"].isin(metrics)].copy())
+        if long.empty:
+            continue
+        long["dataset_label"] = ds_label
+        long["plot_group"] = pg
+        rows.append(long)
+
+    if not rows:
+        return None
+    metrics_long = pd.concat(rows, ignore_index=True).dropna(subset=["value"])
+
+    available_metrics = set(metrics_long["metric"].dropna().astype(str).unique())
+    metrics_to_plot = [m for m in metrics if m in available_metrics]
+    missing_metrics = [m for m in metrics if m not in available_metrics]
+    if missing_metrics:
+        print(
+            "Skipping lead-time metrics not present in per-timestep file: "
+            + ", ".join(missing_metrics)
+        )
+    if not metrics_to_plot:
+        return None
+
+    datasets = _apply_explicit_order(
+        list(metrics_long["dataset_label"].unique()), dataset_order
+    )
+    groups = _order_groups_by_label(
+        list(metrics_long["plot_group"].unique()), styles, hue_order
+    )
+
+    nrows, ncols = len(metrics_to_plot), len(datasets)
+    shared_ylabel = (
+        r"Rel. $\Delta$ empirical coverage"
+        if coverage_delta and short_axis_labels
+        else r"$\Delta$ empirical coverage (proportional)"
+        if coverage_delta
+        else None
+    )
+    if axes is None:
+        fig, axes = plt.subplots(
+            nrows,
+            ncols,
+            figsize=_scaled_figsize(
+                3.6 * ncols,
+                2.7 * nrows * height_scale,
+                figure_scale,
+            ),
+            sharex=True,
+            sharey=sharey,
+            squeeze=False,
+        )
+    else:
+        axes = np.atleast_2d(axes)
+        if fig is None:
+            fig = axes[0][0].figure
+
+    assert axes is not None
+    assert fig is not None
+
+    shared_row_limits: list[list[tuple[float, float]]] = [[] for _ in range(nrows)]
+    for r, metric in enumerate(metrics_to_plot):
+        sub = metrics_long[metrics_long["metric"] == metric]
+        for c, ds_label in enumerate(datasets):
+            ax = axes[r][c]
+            ds = sub[sub["dataset_label"] == ds_label]
+            is_cov = metric.startswith("coverage_")
+            is_ssr = metric == "ssr"
+            is_cov_delta = bool(coverage_delta and is_cov)
+            cov_target: float | None = None
+            if is_cov_delta:
+                try:
+                    cov_target = float(metric.split("_", 1)[1])
+                except Exception:
+                    # If the metric name doesn't encode its nominal level,
+                    # fall back to the raw coverage series.
+                    is_cov_delta = False
+                    cov_target = None
+            # Per-metric y treatment: SSR is a dimensionless reliability
+            # diagnostic with ideal=1.0, so it renders on a linear axis with
+            # a dashed reference line regardless of the panel-wide settings.
+            row_yscale = "linear" if (is_ssr or is_cov_delta) else yscale
+            row_ref = 1.0 if (is_ssr and ref_value is None) else ref_value
+            if is_cov_delta:
+                row_ref = 0.0
+            vals: list[float] = []
+            for fam in groups:
+                sf = cast(pd.DataFrame, ds[ds["plot_group"] == fam])
+                if sf.empty:
+                    continue
+                agg = cast(
+                    pd.DataFrame,
+                    sf.groupby("timestep", as_index=False)["value"]
+                    .agg(["mean", "std", "count"])
+                    .set_index("timestep")
+                    .sort_index()
+                    .reset_index(),
+                )
+                st = styles.get(fam, {"color": "k"})
+                mean = cast(pd.Series, agg["mean"])
+                std = cast(pd.Series, agg["std"]).fillna(0)
+
+                if is_cov_delta and cov_target is not None:
+                    m = (mean / cov_target) - 1.0
+                    vals.extend(m.dropna().tolist())
+                else:
+                    m = (
+                        mean.clip(lower=0, upper=1)
+                        if is_cov
+                        else mean.clip(lower=1e-06)
+                    )
+                if (not is_cov) and (not is_cov_delta):
+                    vals.extend(m.dropna().tolist())
+                ax.plot(
+                    agg["timestep"],
+                    m,
+                    color=st["color"],
+                    lw=line_width,
+                    linestyle=st.get("linestyle", "-"),
+                )
+                if (agg["count"] > 1).any():
+                    if is_cov_delta and cov_target is not None:
+                        y1 = ((mean - std) / cov_target) - 1.0
+                        y2 = ((mean + std) / cov_target) - 1.0
+                        vals.extend(y1.dropna().tolist())
+                        vals.extend(y2.dropna().tolist())
+                    elif is_cov:
+                        y1 = (mean - std).clip(lower=0, upper=1)
+                        y2 = (mean + std).clip(lower=0, upper=1)
+                    else:
+                        y1 = (mean - std).clip(lower=1e-6)
+                        y2 = (mean + std).clip(lower=1e-6)
+                    if (not is_cov) and (not is_cov_delta):
+                        vals.extend(y1.dropna().tolist())
+                        vals.extend(y2.dropna().tolist())
+                    ax.fill_between(
+                        agg["timestep"], y1, y2, color=st["color"], alpha=0.15
+                    )
+
+            if r == 0:
+                ax.set_title(ds_label)
+            if r == nrows - 1:
+                ax.set_xlabel("" if shared_axis_labels else "Lead time")
+            if c == 0:
+                if is_cov_delta and cov_target is not None:
+                    row_label = (
+                        _coverage_level_label(metric)
+                        if coverage_delta_row_labels
+                        else ""
+                    )
+                    ax.set_ylabel(row_label)
+                else:
+                    ax.set_ylabel(_metric_axis_label(metric))
+            ax.grid(alpha=0.25)
+            _apply_tick_label_style(ax, tick_label_scale)
+            _apply_axis_label_style(ax, axis_label_scale)
+            use_log = (row_yscale or "log") == "log"
+            y_limit: tuple[float, float] | None = None
+            if is_cov and not is_cov_delta:
+                ax.set_ylim(0, 1)
+                y_limit = (0.0, 1.0)
+            elif is_cov_delta:
+                finite = [v for v in vals if np.isfinite(v)]
+                if finite:
+                    max_abs = max(abs(v) for v in finite)
+                    pad = max(1e-6, 0.1 * max_abs)
+                    lim = max(0.02, max_abs + pad)
+                else:
+                    lim = 0.1
+                ax.set_yscale("linear")
+                ax.set_ylim(-lim, lim)
+                y_limit = (-lim, lim)
+            elif vals:
+                if use_log:
+                    ax.set_yscale("log")
+                    ymin = max(1e-6, min(vals) * 0.8)
+                    ymax = max(vals) * 1.25
+                    if not np.isfinite(ymin) or np.isnan(ymin):
+                        ymin = 1e-6
+                    if not np.isfinite(ymax) or np.isnan(ymax):
+                        ymax = 10.0
+                else:
+                    ax.set_yscale("linear")
+                    finite = [v for v in vals if np.isfinite(v)]
+                    if finite:
+                        lo_v, hi_v = min(finite), max(finite)
+                        pad = max(
+                            1e-6, 0.1 * (hi_v - lo_v if hi_v > lo_v else abs(hi_v))
+                        )
+                        ymin, ymax = lo_v - pad, hi_v + pad
+                        if row_ref is not None:
+                            ymin = min(ymin, row_ref - pad)
+                            ymax = max(ymax, row_ref + pad)
+                    else:
+                        ymin, ymax = 0.0, 1.0
+                ax.set_ylim(bottom=ymin, top=ymax)
+                y_limit = (float(ymin), float(ymax))
+            if (not is_cov or is_cov_delta) and row_ref is not None:
+                ax.axhline(
+                    row_ref,
+                    color="black",
+                    linestyle=":",
+                    linewidth=ref_line_width,
+                    alpha=0.6,
+                )
+            # Apply user override for error rows (skip SSR: ratio diagnostic)
+            if not is_cov and not is_ssr and error_ylim is not None:
+                lo, hi = error_ylim
+                cur_lo, cur_hi = ax.get_ylim()
+                next_lo = lo if lo is not None else cur_lo
+                next_hi = hi if hi is not None else cur_hi
+                ax.set_ylim(
+                    bottom=next_lo,
+                    top=next_hi,
+                )
+                y_limit = (float(next_lo), float(next_hi))
+            if (
+                sharey
+                and y_limit is not None
+                and np.isfinite(y_limit[0])
+                and np.isfinite(y_limit[1])
+            ):
+                shared_row_limits[r].append(y_limit)
+    if sharey:
+        axes_arr = np.asarray(axes)
+        for r, row_axes in enumerate(axes_arr):
+            finite_limits = shared_row_limits[r]
+            if not finite_limits:
+                finite_limits = [
+                    ax.get_ylim()
+                    for ax in row_axes
+                    if np.isfinite(ax.get_ylim()[0]) and np.isfinite(ax.get_ylim()[1])
+                ]
+            if not finite_limits:
+                continue
+            ymin = min(lo for lo, _ in finite_limits)
+            ymax = max(hi for _, hi in finite_limits)
+            if any(ax.get_yscale() == "log" for ax in row_axes):
+                ymin = max(ymin, 1e-12)
+            for ax in row_axes:
+                ax.set_ylim(ymin, ymax)
+    if shared_ylabel is not None:
+        _set_shared_ylabel(fig, shared_ylabel, axis_label_scale)
+    if shared_axis_labels:
+        _set_shared_xlabel(fig, "Lead time", axis_label_scale)
+    if show_legend:
+        handles = _dedup_legend_handles(groups, styles)
+        fig.legend(
+            handles,
+            [str(h.get_label()) for h in handles],
+            loc="upper center",
+            bbox_to_anchor=(0.5, 0.98),
+            ncol=4,
+            fontsize=_resolve_font_size(
+                DEFAULT_LEGEND_FONT_SIZE,
+                legend_font_scale,
+                legend_font_size,
+            ),
+            frameon=False,
+        )
+    if save:
+        plt.tight_layout(rect=(0, 0, 1, 0.94))
+        save_fig(fig, out_dir, name)
+        return None
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Training curves: wandb API
+# ---------------------------------------------------------------------------
+
+
+def _training_history_cache_path(
+    run_dir: Path,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+) -> Path:
+    return run_dir / normalize_eval_subdir(eval_subdir) / "training_history.csv"
+
+
+def _load_training_history_cache(
+    run_dir: Path,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+) -> pd.DataFrame | None:
+    p = _training_history_cache_path(run_dir, eval_subdir=eval_subdir)
+    if not p.exists():
+        return None
+    try:
+        df = pd.read_csv(p)
+    except Exception:
+        return None
+    if df.empty or not {"epoch", "metric", "value"}.issubset(df.columns):
+        return None
+    return df
+
+
+def _save_training_history_cache(
+    run_dir: Path,
+    df: pd.DataFrame,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+) -> None:
+    p = _training_history_cache_path(run_dir, eval_subdir=eval_subdir)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(p, index=False)
+    except OSError:
+        pass
+
+
+def parse_training_metrics_from_wandb(  # noqa: PLR0911, PLR0912, PLR0915
+    run_dir: Path,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+    force_refresh: bool = False,
+) -> pd.DataFrame:
+    """Fetch per-epoch training metrics from wandb for a single run.
+
+    Uses ``resolved_config.yaml`` for the wandb project/entity/display name,
+    resolves the run via the public API, and scans its full history. Assumes
+    ``WANDB_API_KEY`` is set. Results are cached to
+    ``<run_dir>/<eval_subdir>/training_history.csv`` to avoid repeat API calls.
+
+    Returns a long-format frame with columns ``epoch, metric, value``. Empty
+    on any failure.
+    """
+    empty = pd.DataFrame(columns=pd.Index(["epoch", "metric", "value"]))
+
+    if not force_refresh:
+        cached = _load_training_history_cache(run_dir, eval_subdir=eval_subdir)
+        if cached is not None:
+            return cached
+
+    config_p = run_dir / "resolved_config.yaml"
+    if not config_p.exists():
+        return empty
+
+    try:
+        with open(config_p) as f:
+            cfg = yaml.safe_load(f) or {}
+    except OSError:
+        return empty
+
+    wb = (
+        ((cfg.get("logging") or {}).get("wandb") or {}) if isinstance(cfg, dict) else {}
+    )
+    project = wb.get("project") or "autocast"
+    entity = wb.get("entity")
+    display_name = wb.get("name") or run_dir.name
+
+    try:
+        api = wandb.Api(timeout=60)
+    except Exception as e:
+        print(f"wandb API init failed ({e}); skipping {display_name}.")
+        return empty
+
+    if not entity:
+        entity = getattr(api, "default_entity", None)
+    if not entity:
+        print(
+            f"wandb: no entity configured for {display_name}; "
+            "set logging.wandb.entity or WANDB_ENTITY."
+        )
+        return empty
+
+    path = f"{entity}/{project}"
+    try:
+        runs = list(api.runs(path=path, filters={"display_name": display_name}))
+    except Exception as e:
+        print(f"wandb runs() failed for {display_name} ({path}): {e}")
+        return empty
+
+    if not runs:
+        print(f"wandb: no run found for display_name={display_name!r} in {path}.")
+        return empty
+    if len(runs) > 1:
+        # Prefer the most recently finished run for determinism.
+        runs.sort(key=lambda r: getattr(r, "created_at", ""), reverse=True)
+
+    wrun = runs[0]
+    try:
+        rows = list(wrun.scan_history())
+    except Exception as e:
+        print(f"wandb scan_history failed for {display_name}: {e}")
+        return empty
+
+    if not rows:
+        return empty
+
+    hist = pd.DataFrame(rows)
+    # Find an epoch-like column; prefer an explicit 'epoch' log key.
+    epoch_col: str | None = None
+    for c in ("epoch", "trainer/global_epoch", "_step"):
+        if c in hist.columns:
+            epoch_col = c
+            break
+    if epoch_col is None:
+        return empty
+
+    metric_cols = [
+        c
+        for c in hist.columns
+        if c != epoch_col
+        and not c.startswith("_")
+        and pd.api.types.is_numeric_dtype(hist[c])
+    ]
+    if not metric_cols:
+        return empty
+
+    sub = hist[[epoch_col, *metric_cols]].copy()
+    sub[epoch_col] = pd.to_numeric(sub[epoch_col], errors="coerce")
+    sub = cast(pd.DataFrame, sub[pd.notna(sub[epoch_col])])
+    long = sub.melt(id_vars=epoch_col, var_name="metric", value_name="value").dropna(
+        subset=["value"]
+    )
+    long = long.rename(columns={epoch_col: "epoch"})
+    # Collapse multi-log-per-epoch to a single representative value.
+    grouped = cast(
+        pd.DataFrame,
+        long.groupby(["epoch", "metric"], as_index=False).agg(value=("value", "mean")),
+    )
+    long = cast(
+        pd.DataFrame,
+        grouped.sort_values(by="metric").sort_values(by="epoch", kind="stable"),
+    ).reset_index(drop=True)
+    long["epoch"] = long["epoch"].astype(int, errors="ignore")
+
+    _save_training_history_cache(run_dir, long, eval_subdir=eval_subdir)
+    return long
+
+
+def load_training_metrics(
+    run_dir: Path,
+    eval_subdir: str = DEFAULT_EVAL_SUBDIR,
+    force_refresh: bool = False,
+) -> pd.DataFrame:
+    """Load per-epoch training metrics for a single run from wandb."""
+    return parse_training_metrics_from_wandb(
+        run_dir,
+        eval_subdir=eval_subdir,
+        force_refresh=force_refresh,
+    )
+
+
+def plot_training_curves(  # noqa: PLR0912, PLR0915
+    df_in: pd.DataFrame,
+    metrics: list[str],
+    results_root: Path,
+    out_dir: Path,
+    name: str,
+    styles: dict,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    y_scale: str = "log",
+    ylim: tuple[float | None, float | None] | None = None,
+    axes: np.ndarray | None = None,
+    fig: FigureBase | None = None,
+    save: bool = True,
+    show_legend: bool = True,
+    force_refresh: bool = False,
+    tick_label_scale: float = 1.0,
+    axis_label_scale: float = 1.0,
+    legend_font_scale: float = 1.0,
+    legend_font_size: float | None = None,
+    figure_scale: float = 1.0,
+    short_axis_labels: bool = False,
+    shared_axis_labels: bool = False,
+    height_scale: float = 1.0,
+) -> FigureBase | None:
+    """Plot per-metric, per-dataset training curves (epoch vs metric value).
+
+    Training metrics are loaded via :func:`load_training_metrics` from wandb.
+    ``metrics`` names should match logged keys, e.g. ``val_loss``, ``val_vrmse``.
+    """
+    _ = short_axis_labels
+    rows: list[pd.DataFrame] = []
+    base = df_in.dropna(
+        subset=["run_path", "dataset_label", "plot_group"]
+    ).drop_duplicates()
+    for r in base.itertuples(index=False):
+        run_path = getattr(r, "run_path", None)
+        eval_subdir = normalize_eval_subdir(getattr(r, "eval_subdir", None))
+        ds_label = getattr(r, "dataset_label", None)
+        pg = getattr(r, "plot_group", None)
+        if run_path is None or ds_label is None or pg is None:
+            continue
+        run_dir = results_root / str(run_path)
+        if not run_dir.exists():
+            continue
+        tm = load_training_metrics(
+            run_dir,
+            eval_subdir=eval_subdir,
+            force_refresh=force_refresh,
+        )
+        if tm.empty:
+            continue
+        tm = cast(pd.DataFrame, tm[tm["metric"].isin(metrics)].copy())
+        if tm.empty:
+            continue
+        tm["dataset_label"] = ds_label
+        tm["plot_group"] = pg
+        rows.append(tm)
+
+    if not rows:
+        print("No training metrics available from wandb history.")
+        return None
+
+    long = pd.concat(rows, ignore_index=True).dropna(subset=["value"])
+    available = set(long["metric"].astype(str).unique())
+    metrics_to_plot = [m for m in metrics if m in available]
+    missing = [m for m in metrics if m not in available]
+    if missing:
+        print("Skipping training metrics not found in logs: " + ", ".join(missing))
+    if not metrics_to_plot:
+        return None
+
+    datasets = _apply_explicit_order(
+        list(long["dataset_label"].unique()), dataset_order
+    )
+    groups = _order_groups_by_label(
+        list(long["plot_group"].unique()), styles, hue_order
+    )
+
+    nrows, ncols = len(metrics_to_plot), len(datasets)
+    if axes is None:
+        fig, axes = plt.subplots(
+            nrows,
+            ncols,
+            figsize=_scaled_figsize(
+                3.6 * ncols,
+                2.7 * nrows * height_scale,
+                figure_scale,
+            ),
+            sharex=False,
+            sharey=False,
+            squeeze=False,
+        )
+    else:
+        axes = np.atleast_2d(axes)
+        if fig is None:
+            fig = axes[0][0].figure
+
+    assert axes is not None
+    assert fig is not None
+
+    for r_idx, metric in enumerate(metrics_to_plot):
+        sub = long[long["metric"] == metric]
+        for c_idx, ds_label in enumerate(datasets):
+            ax = axes[r_idx][c_idx]
+            ds = sub[sub["dataset_label"] == ds_label]
+            vals: list[float] = []
+            for fam in groups:
+                sf = cast(pd.DataFrame, ds[ds["plot_group"] == fam])
+                if sf.empty:
+                    continue
+                agg = cast(
+                    pd.DataFrame,
+                    sf.groupby("epoch", as_index=False).agg(value=("value", "mean")),
+                )
+                agg = cast(pd.DataFrame, agg.sort_values(by="epoch"))
+                st = styles.get(fam, {"color": "k"})
+                ax.plot(
+                    agg["epoch"],
+                    agg["value"],
+                    color=st["color"],
+                    lw=2,
+                    linestyle=st.get("linestyle", "-"),
+                )
+                vals.extend(agg["value"].dropna().tolist())
+
+            if r_idx == 0:
+                ax.set_title(ds_label)
+            if r_idx == nrows - 1:
+                ax.set_xlabel("" if shared_axis_labels else "Epoch")
+            if c_idx == 0:
+                ax.set_ylabel(metric)
+            ax.grid(alpha=0.25)
+            _apply_tick_label_style(ax, tick_label_scale)
+            _apply_axis_label_style(ax, axis_label_scale)
+
+            positive = [v for v in vals if np.isfinite(v) and v > 0]
+            if y_scale == "log" and positive:
+                ax.set_yscale("log")
+            elif y_scale == "linear":
+                ax.set_yscale("linear")
+
+            if ylim is not None:
+                lo, hi = ylim
+                cur_lo, cur_hi = ax.get_ylim()
+                ax.set_ylim(
+                    bottom=lo if lo is not None else cur_lo,
+                    top=hi if hi is not None else cur_hi,
+                )
+
+    if shared_axis_labels:
+        _set_shared_xlabel(fig, "Epoch", axis_label_scale)
+    if show_legend:
+        handles = _dedup_legend_handles(groups, styles)
+        fig.legend(
+            handles,
+            [str(h.get_label()) for h in handles],
+            loc="upper center",
+            bbox_to_anchor=(0.5, 0.98),
+            ncol=4,
+            fontsize=_resolve_font_size(
+                DEFAULT_LEGEND_FONT_SIZE,
+                legend_font_scale,
+                legend_font_size,
+            ),
+            frameon=False,
+        )
+    if save:
+        plt.tight_layout(rect=(0, 0, 1, 0.94))
+        save_fig(fig, out_dir, name)
+        return None
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Panel composite figure
+# ---------------------------------------------------------------------------
+
+
+def plot_panel_figure(  # noqa: PLR0915
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    overall_metrics: tuple[str, ...] = DEFAULT_PLOT_METRICS,
+    error_metrics: list[str] | None = None,
+    coverage_metrics: list[str] | None = None,
+    training_metrics: list[str] | None = None,
+    training_yscale: str = "log",
+    training_ylim: tuple[float | None, float | None] | None = None,
+    training_refresh: bool = False,
+    error_ylim: tuple[float | None, float | None] | None = None,
+    coverage_ylim: tuple[float | None, float | None] | None = None,
+    name: str = "panel_figure.png",
+    tick_label_scale: float = 1.0,
+    axis_label_scale: float = 1.0,
+    legend_font_scale: float = 1.0,
+    legend_font_size: float | None = None,
+    figure_scale: float = 1.0,
+    short_axis_labels: bool = False,
+    shared_axis_labels: bool = False,
+    lead_time_coverage_delta: bool = False,
+    error_yscale: str = "log",
+) -> None:
+    """Render a panel composite figure with a reserved notes area.
+
+    Layout::
+
+        ┌──── notes (~20% x ~20%) ────┬───────────────────────────────┐
+        │                              │ global legend                 │
+        ├────────────┬─────────────────┼───────────────┬───────────────┤
+        │ training   │ overall         │ coverage      │ lead-time     │
+        │ curves     │ metrics         │ calibration   │ (err + cov)   │
+        │ (far left) │                 │ panel         │ panel         │
+        └────────────┴─────────────────┴───────────────┴───────────────┘
+    """
+    overall_metrics = tuple(overall_metrics or DEFAULT_PLOT_METRICS)
+    error_metrics = error_metrics or ["vrmse"]
+    coverage_metrics = coverage_metrics or ["coverage_0.9", "coverage_0.5"]
+    if training_metrics is None:
+        training_metrics = ["val_loss", "train_loss"]
+    training_metrics = list(training_metrics)
+    include_training_panel = len(training_metrics) > 0
+
+    datasets = _apply_explicit_order(
+        list(df_in["dataset_label"].dropna().unique()), dataset_order
+    )
+    n_ds = max(1, len(datasets))
+
+    # Keep output shape approximately 16:10 and avoid over-compact single-dataset
+    # renders by using a fixed minimum canvas with gentle dataset-driven scaling.
+    panel_scale = max(1.0, np.sqrt(n_ds / 2.0))
+    fig = plt.figure(
+        figsize=_scaled_figsize(16.0 * panel_scale, 10.0 * panel_scale, figure_scale)
+    )
+    plot_style_kwargs = {
+        "tick_label_scale": tick_label_scale,
+        "axis_label_scale": axis_label_scale,
+        "legend_font_scale": legend_font_scale,
+        "legend_font_size": legend_font_size,
+        "figure_scale": figure_scale,
+        "short_axis_labels": short_axis_labels,
+        "shared_axis_labels": shared_axis_labels,
+    }
+    if include_training_panel:
+        outer = fig.add_gridspec(
+            5,
+            5,
+            width_ratios=[1.3 * n_ds, 1.0, 1.1 * n_ds, 1.1 * n_ds, 1.0 * n_ds],
+            height_ratios=[0.2, 0.8, 1.0, 1.0, 1.0],
+            wspace=0.28,
+            hspace=0.24,
+        )
+        left_spec = outer[1:, 1]
+        middle_spec = outer[1:, 2:4]
+        right_spec = outer[1:, 4]
+    else:
+        outer = fig.add_gridspec(
+            5,
+            4,
+            width_ratios=[1.0, 1.1 * n_ds, 1.1 * n_ds, 1.0 * n_ds],
+            height_ratios=[0.2, 0.8, 1.0, 1.0, 1.0],
+            wspace=0.28,
+            hspace=0.24,
+        )
+        left_spec = outer[1:, 0]
+        middle_spec = outer[1:, 1:3]
+        right_spec = outer[1:, 3]
+
+    # Top-left reserved notes region (intentionally blank).
+    notes_ax = fig.add_subplot(outer[0, 0])
+    notes_ax.set_axis_off()
+
+    # --- Far-left: training curves panel --------------------------------
+    if include_training_panel:
+        train = fig.add_subfigure(outer[1:, 0])
+        n_train = max(1, len(training_metrics))
+        tr_axes = train.subplots(
+            n_train, n_ds, sharex=True, sharey=False, squeeze=False
+        )
+        _ = plot_training_curves(
+            df_in,
+            training_metrics,
+            results_root,
+            out_dir,
+            "panel_training_curves.png",
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            y_scale=training_yscale,
+            ylim=training_ylim,
+            axes=tr_axes,
+            fig=train,
+            save=False,
+            show_legend=False,
+            force_refresh=training_refresh,
+            **plot_style_kwargs,
+        )
+
+    # --- Left-middle: stacked overall-metric bar charts -----------------
+    left = fig.add_subfigure(left_spec)
+    n_overall = max(1, len(overall_metrics))
+    left_axes = np.asarray(left.subplots(n_overall, 1, squeeze=False)).reshape(-1)
+    for i, m in enumerate(overall_metrics):
+        grouped_bar(
+            df_in,
+            f"overall_{m}",
+            f"Overall {m.upper()}",
+            m.upper(),
+            out_dir,
+            styles,
+            y_scale=_overall_or_window_bar_yscale(m, error_yscale),
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            ax=left_axes[i],
+            save=False,
+            ylim=_overall_or_window_bar_ylim(m, error_ylim),
+            show_legend=False,
+            ref_value=_overall_or_window_bar_ref_value(m),
+            **plot_style_kwargs,
+        )
+    left.suptitle("")
+
+    # --- Middle: coverage calibration panel -----------------------------
+    middle = fig.add_subfigure(middle_spec)
+    nrows_cov = len(WINDOW_ROWS)
+    mid_axes = middle.subplots(nrows_cov, n_ds, sharex=True, sharey=True, squeeze=False)
+    plot_coverage_calibration_panel(
+        df_in,
+        results_root,
+        out_dir,
+        styles,
+        dataset_order=dataset_order,
+        hue_order=hue_order,
+        axes=mid_axes,
+        fig=middle,
+        save=False,
+        show_legend=False,
+        **plot_style_kwargs,
+    )
+
+    # --- Right: lead-time error (top) + coverage (bottom) ---------------
+    right = fig.add_subfigure(right_spec)
+    n_err = len(error_metrics)
+    n_cov = len(coverage_metrics)
+    right_top, right_bot = right.subfigures(
+        2,
+        1,
+        height_ratios=[max(1, n_err), max(1, n_cov)],
+        hspace=0.08,
+    )
+    rt_axes = right_top.subplots(n_err, n_ds, sharex=True, sharey=False, squeeze=False)
+    plot_lead_time_panel(
+        df_in,
+        error_metrics,
+        results_root,
+        out_dir,
+        "slide_lead_time_error.png",
+        styles,
+        dataset_order=dataset_order,
+        hue_order=hue_order,
+        axes=rt_axes,
+        fig=right_top,
+        save=False,
+        error_ylim=error_ylim,
+        yscale=error_yscale,
+        show_legend=False,
+        **plot_style_kwargs,
+    )
+    rb_axes = right_bot.subplots(n_cov, n_ds, sharex=True, sharey=False, squeeze=False)
+    plot_lead_time_panel(
+        df_in,
+        coverage_metrics,
+        results_root,
+        out_dir,
+        "slide_lead_time_coverage.png",
+        styles,
+        dataset_order=dataset_order,
+        hue_order=hue_order,
+        axes=rb_axes,
+        fig=right_bot,
+        save=False,
+        error_ylim=None,
+        coverage_delta=lead_time_coverage_delta,
+        show_legend=False,
+        **plot_style_kwargs,
+    )
+    if coverage_ylim is not None:
+        lo, hi = coverage_ylim
+        rb_arr = np.asarray(rb_axes)
+        for r, metric in enumerate(coverage_metrics):
+            # SSR is a ratio diagnostic (linear, ref=1.0) mixed into the
+            # coverage panel; do not squash it onto the coverage [0, 1] axis.
+            if metric == "ssr":
+                continue
+            for ax in rb_arr[r]:
+                cur_lo, cur_hi = ax.get_ylim()
+                ax.set_ylim(
+                    bottom=lo if lo is not None else cur_lo,
+                    top=hi if hi is not None else cur_hi,
+                )
+
+    # --- Global legend --------------------------------------------------
+    # Collect groups present anywhere for the legend.
+    all_groups = list(df_in["plot_group"].dropna().unique())
+    ordered_groups = _order_groups_by_label(all_groups, styles, hue_order)
+    handles = _dedup_legend_handles(ordered_groups, styles)
+    if handles:
+        fig.legend(
+            handles,
+            [str(h.get_label()) for h in handles],
+            loc="upper center",
+            bbox_to_anchor=(0.5, 0.995),
+            ncol=min(6, len(handles)),
+            fontsize=_resolve_font_size(9.0, legend_font_scale, legend_font_size),
+            frameon=False,
+        )
+
+    save_fig(fig, out_dir, name)
+
+
+def _ordered_plot_groups(
+    df_in: pd.DataFrame,
+    styles: dict,
+    hue_order: list[str] | None = None,
+) -> list:
+    """Return plot groups in legend/display order."""
+    groups = list(dict.fromkeys(df_in["plot_group"].dropna().tolist()))
+    return _order_groups_by_label(groups, styles, hue_order)
+
+
+def _paper_legend(
+    fig: FigureBase,
+    df_in: pd.DataFrame,
+    styles: dict,
+    hue_order: list[str] | None = None,
+    *,
+    loc: str = "upper left",
+    bbox_to_anchor: tuple[float, float] = (0.06, 0.995),
+    ncol: int | None = None,
+) -> None:
+    """Add a compact paper-style legend with duplicate labels removed."""
+    groups = _ordered_plot_groups(df_in, styles, hue_order)
+    handles = _dedup_legend_handles(groups, styles)
+    if not handles:
+        return
+    for handle in handles:
+        handle.set_linewidth(PAPER_LEGEND_LINE_WIDTH)
+    fig.legend(
+        handles,
+        [str(h.get_label()) for h in handles],
+        loc=loc,
+        bbox_to_anchor=bbox_to_anchor,
+        ncol=ncol or len(handles),
+        fontsize=PAPER_LEGEND_FONT_SIZE,
+        frameon=False,
+        handlelength=2.2,
+        columnspacing=1.1,
+    )
+
+
+def _paper_datasets(
+    df_in: pd.DataFrame,
+    dataset_order: list[str] | None = None,
+) -> list[str]:
+    """Return datasets present in a dataframe in requested plot order."""
+    datasets = list(dict.fromkeys(df_in["dataset_label"].dropna().tolist()))
+    return _apply_explicit_order(datasets, dataset_order)
+
+
+def _paper_coverage_metrics(metrics: list[str]) -> list[str]:
+    """Keep only nominal coverage metrics used by proportional-delta panels."""
+    return [m for m in metrics if m.startswith("coverage_")]
+
+
+def _paper_style_kwargs(shared_axis_labels: bool = True) -> dict[str, Any]:
+    """Use rcParams-driven font sizes for paper figures."""
+    return {
+        "tick_label_scale": PAPER_TICK_FONT_SIZE / DEFAULT_TICK_LABEL_FONT_SIZE,
+        "axis_label_scale": PAPER_FONT_SIZE / DEFAULT_AXIS_LABEL_FONT_SIZE,
+        "legend_font_size": PAPER_LEGEND_FONT_SIZE,
+        "short_axis_labels": True,
+        "shared_axis_labels": shared_axis_labels,
+        "line_width": PAPER_LINE_WIDTH,
+        "ref_line_width": PAPER_REF_LINE_WIDTH,
+    }
+
+
+def _remove_figure_text(fig: FigureBase, labels: set[str]) -> None:
+    """Remove selected figure-level labels after using shared-axis helpers."""
+    for text in list(fig.texts):
+        if text.get_text() in labels:
+            text.remove()
+
+
+def _replace_figure_text(
+    fig: FigureBase,
+    old_label: str,
+    new_label: str,
+    *,
+    axis_label_scale: float = PAPER_FONT_SIZE / DEFAULT_AXIS_LABEL_FONT_SIZE,
+    x: float | None = None,
+    y: float | None = None,
+) -> None:
+    """Replace and restyle a selected figure-level label."""
+    for text in fig.texts:
+        if text.get_text() == old_label:
+            text.set_text(new_label)
+            _set_figure_text_style(text, axis_label_scale, x=x, y=y)
+
+
+def _set_paper_xlabel(fig: FigureBase, label: str, y: float = 0.07) -> None:
+    """Set a paper-sized shared x label with stable vertical alignment."""
+    xlabel = fig.text(0.5, y, label, ha="center", va="center")
+    _set_figure_text_style(
+        xlabel,
+        PAPER_FONT_SIZE / DEFAULT_AXIS_LABEL_FONT_SIZE,
+    )
+
+
+def _set_paper_lead_time_xlabel(fig: FigureBase, y: float = 0.07) -> None:
+    """Set a paper-sized shared lead-time x label."""
+    _set_paper_xlabel(fig, "Lead time", y=y)
+
+
+def _set_paper_nominal_coverage_xlabel(
+    fig: FigureBase,
+    y: float = 0.07,
+) -> None:
+    """Set a paper-sized shared nominal-coverage x label."""
+    _set_paper_xlabel(fig, NOMINAL_COVERAGE_AXIS_LABEL, y=y)
+
+
+def _add_paper_panel_label(
+    fig: FigureBase,
+    label: str,
+    *,
+    x: float,
+    y: float,
+    ha: str = "left",
+) -> None:
+    """Add a small paper-style subplot label such as ``a)``."""
+    if plt.rcParams.get("text.usetex", False):
+        label = rf"\textbf{{{label}}}"
+    text = fig.text(x, y, label, ha=ha, va="top", fontweight="bold")
+    _set_figure_text_style(
+        text,
+        PAPER_FONT_SIZE / DEFAULT_AXIS_LABEL_FONT_SIZE,
+    )
+
+
+def _plot_paper_combined_lead_time_panel(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    error_metrics: list[str],
+    delta_metrics: list[str],
+    fig: FigureBase,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    error_ylim: tuple[float | None, float | None] | None = None,
+    name_stem: str = "paper_combined_lead_time",
+    delta_ylabel_x: float = -0.065,
+    lead_time_y: float = 0.07,
+) -> None:
+    """Draw coverage-delta rows and VRMSE rows in one shared lead-time grid."""
+    datasets = _paper_datasets(df_in, dataset_order)
+    n_ds = max(1, len(datasets))
+    n_delta = len(delta_metrics)
+    n_error = len(error_metrics)
+    axes = fig.subplots(
+        n_delta + n_error,
+        n_ds,
+        sharex=True,
+        sharey="row",
+        squeeze=False,
+    )
+
+    if n_delta:
+        delta_axes = axes[:n_delta, :]
+        plot_lead_time_panel(
+            df_in,
+            delta_metrics,
+            results_root,
+            out_dir,
+            f"{name_stem}_coverage_delta_inner.png",
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=delta_axes,
+            fig=fig,
+            save=False,
+            show_legend=False,
+            coverage_delta=True,
+            sharey=True,
+            coverage_delta_row_labels=True,
+            **_paper_style_kwargs(),
+        )
+        _replace_figure_text(
+            fig,
+            r"Rel. $\Delta$ empirical coverage",
+            _paper_relative_coverage_label(),
+            x=delta_ylabel_x,
+            y=0.62,
+        )
+        for ax in delta_axes[:, 0]:
+            ax.yaxis.labelpad = 0.0
+
+    if n_error:
+        error_axes = axes[n_delta:, :]
+        plot_lead_time_panel(
+            df_in,
+            error_metrics,
+            results_root,
+            out_dir,
+            f"{name_stem}_error_inner.png",
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=error_axes,
+            fig=fig,
+            save=False,
+            show_legend=False,
+            error_ylim=error_ylim,
+            sharey=True,
+            **_paper_style_kwargs(),
+        )
+        for ax in error_axes.flat:
+            ax.set_title("")
+
+    for ax in axes.flat:
+        ax.label_outer()
+
+    _remove_figure_text(fig, {"Lead time"})
+    _set_paper_lead_time_xlabel(fig, y=lead_time_y)
+
+
+def plot_paper_overall_coverage_figure(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    name: str = "paper_coverage_calibration_panel_overall_only.png",
+) -> None:
+    """Render the single-step coverage panel at paper linewidth."""
+    datasets = _paper_datasets(df_in, dataset_order)
+    n_ds = max(1, len(datasets))
+    with mpl.rc_context(PAPER_RC_PARAMS):
+        fig, axes = plt.subplots(
+            1,
+            n_ds,
+            figsize=(PAPER_FIGURE_WIDTH_IN, 1.75),
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+        )
+        plot_coverage_calibration_panel(
+            df_in,
+            results_root,
+            out_dir,
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=axes,
+            fig=fig,
+            save=False,
+            show_legend=False,
+            window_rows=WINDOW_ROWS_OVERALL_ONLY,
+            short_axis_labels=True,
+            shared_axis_labels=False,
+            line_width=PAPER_LINE_WIDTH,
+            ref_line_width=PAPER_REF_LINE_WIDTH,
+        )
+        for ax in axes.flat:
+            ax.set_xlabel("")
+        axes[0][0].set_ylabel(_paper_empirical_coverage_label())
+        xlabel = fig.supxlabel(NOMINAL_COVERAGE_AXIS_LABEL, y=0.03)
+        xlabel.set_fontsize(PAPER_FONT_SIZE)
+        _paper_legend(
+            fig,
+            df_in,
+            styles,
+            hue_order,
+            loc="upper left",
+            bbox_to_anchor=(0.06, 1.03),
+        )
+        fig.subplots_adjust(
+            left=0.075,
+            right=0.995,
+            bottom=0.25,
+            top=0.76,
+            wspace=0.18,
+        )
+        save_fig(fig, out_dir, name)
+
+
+def plot_paper_uq_reliability_figure(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    coverage_metrics: list[str],
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    name: str = "paper_uq_reliability_by_lead_time.png",
+    panel_labels: bool = True,
+) -> None:
+    """Render rollout-window calibration and coverage-delta panels together."""
+    datasets = _paper_datasets(df_in, dataset_order)
+    n_ds = max(1, len(datasets))
+    delta_metrics = _paper_coverage_metrics(coverage_metrics)
+    if not delta_metrics:
+        return
+
+    with mpl.rc_context(PAPER_RC_PARAMS):
+        fig = plt.figure(figsize=(PAPER_FIGURE_WIDTH_IN, 3.45))
+        outer = fig.add_gridspec(
+            1,
+            3,
+            width_ratios=[1.08, 0.12, 1.0],
+            left=0.065,
+            right=0.995,
+            bottom=0.13,
+            top=0.84,
+            wspace=0.0,
+        )
+        left = fig.add_subfigure(outer[0, 0])
+        right = fig.add_subfigure(outer[0, 2])
+
+        left_axes = left.subplots(
+            len(WINDOW_ROWS_ROLLOUT_ONLY),
+            n_ds,
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+        )
+        plot_coverage_calibration_panel(
+            df_in,
+            results_root,
+            out_dir,
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=left_axes,
+            fig=left,
+            save=False,
+            show_legend=False,
+            window_rows=WINDOW_ROWS_ROLLOUT_ONLY,
+            **_paper_style_kwargs(),
+        )
+        _replace_figure_text(
+            left,
+            _empirical_coverage_label(short=True),
+            _paper_empirical_coverage_label(),
+            x=-0.065,
+        )
+        _replace_figure_text(
+            left,
+            NOMINAL_COVERAGE_AXIS_LABEL,
+            NOMINAL_COVERAGE_AXIS_LABEL,
+            y=-0.02,
+        )
+
+        right_axes = right.subplots(
+            len(delta_metrics),
+            n_ds,
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+        )
+        plot_lead_time_panel(
+            df_in,
+            delta_metrics,
+            results_root,
+            out_dir,
+            "paper_lead_time_coverage_delta.png",
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=right_axes,
+            fig=right,
+            save=False,
+            show_legend=False,
+            coverage_delta=True,
+            sharey=True,
+            coverage_delta_row_labels=True,
+            **_paper_style_kwargs(),
+        )
+        _replace_figure_text(
+            right,
+            r"Rel. $\Delta$ empirical coverage",
+            _paper_relative_coverage_label(),
+            x=-0.094,
+        )
+        for ax in right_axes[:, 0]:
+            ax.yaxis.labelpad = 0.0
+        _replace_figure_text(right, "Lead time", "Lead time", y=-0.02)
+
+        if panel_labels:
+            _add_paper_panel_label(left, "a)", x=-0.10, y=0.93)
+            _add_paper_panel_label(right, "b)", x=-0.094, y=0.93, ha="center")
+
+        _paper_legend(
+            fig,
+            df_in,
+            styles,
+            hue_order,
+            bbox_to_anchor=(0.06, 1.03),
+        )
+        save_fig(fig, out_dir, name)
+
+
+def plot_paper_lead_time_error_figure(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    error_metrics: list[str],
+    error_ylim: tuple[float | None, float | None] | None = None,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    name: str = "paper_lead_time_panel_error.png",
+) -> None:
+    """Render lead-time error curves at paper linewidth."""
+    if not error_metrics:
+        return
+    datasets = _paper_datasets(df_in, dataset_order)
+    n_ds = max(1, len(datasets))
+    nrows = max(1, len(error_metrics))
+    with mpl.rc_context(PAPER_RC_PARAMS):
+        fig, axes = plt.subplots(
+            nrows,
+            n_ds,
+            figsize=(PAPER_FIGURE_WIDTH_IN, 1.65 + 1.05 * (nrows - 1)),
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+        )
+        plot_lead_time_panel(
+            df_in,
+            error_metrics,
+            results_root,
+            out_dir,
+            "paper_lead_time_error_inner.png",
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=axes,
+            fig=fig,
+            save=False,
+            show_legend=False,
+            error_ylim=error_ylim,
+            sharey=True,
+            **_paper_style_kwargs(),
+        )
+        _paper_legend(
+            fig,
+            df_in,
+            styles,
+            hue_order,
+            bbox_to_anchor=(0.06, 1.03),
+        )
+        fig.subplots_adjust(
+            left=0.075,
+            right=0.995,
+            bottom=0.27,
+            top=0.72,
+            wspace=0.2,
+        )
+        save_fig(fig, out_dir, name)
+
+
+def _paper_summary_metric_label(metric: str) -> str:
+    """Return concise row labels for the paper summary rollout panel."""
+    labels = {
+        "vrmse": "VRMSE",
+        "crps": "CRPS",
+        "ssr": "SSR",
+        "energy": "Energy",
+        "winkler": "Winkler",
+        "psrmse_high": "PSRMSE-H",
+        "psrmse_mid": "PSRMSE-M",
+        "psrmse_low": "PSRMSE-L",
+    }
+    return labels.get(metric, _metric_axis_label(metric))
+
+
+def _share_y_limits_by_row(axes: np.ndarray) -> None:
+    """Apply common y-limits across columns within each subplot row."""
+    for row_axes in np.atleast_2d(axes):
+        finite_limits = [
+            ax.get_ylim()
+            for ax in row_axes
+            if np.isfinite(ax.get_ylim()[0]) and np.isfinite(ax.get_ylim()[1])
+        ]
+        if not finite_limits:
+            continue
+        ymin = min(lo for lo, _ in finite_limits)
+        ymax = max(hi for _, hi in finite_limits)
+        if any(ax.get_yscale() == "log" for ax in row_axes):
+            ymin = max(ymin, 1e-12)
+        for ax in row_axes:
+            ax.set_ylim(ymin, ymax)
+
+
+def _align_left_column_ylabels(fig: FigureBase, axes: np.ndarray) -> None:
+    """Align y-axis labels across rows in the left subplot column."""
+    if not hasattr(fig, "align_ylabels"):
+        return
+    left_axes = np.atleast_2d(axes)[:, 0].tolist()
+    fig.align_ylabels(left_axes)
+
+
+def plot_paper_lead_time_summary_figure(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    name: str = "paper_lead_time_panel_summary.png",
+) -> None:
+    """Render the multi-metric lead-time summary at paper linewidth."""
+    preset = METRIC_GROUP_PRESETS["summary"]
+    metrics = [
+        "vrmse",
+        "crps",
+        "ssr",
+        "energy",
+        "psrmse_high",
+        "psrmse_mid",
+        "psrmse_low",
+    ]
+    datasets = _paper_datasets(df_in, dataset_order)
+    n_ds = max(1, len(datasets))
+    if not metrics:
+        return
+
+    with mpl.rc_context(PAPER_RC_PARAMS):
+        fig, axes = plt.subplots(
+            len(metrics),
+            n_ds,
+            figsize=(PAPER_FIGURE_WIDTH_IN, 6.68),
+            sharex=True,
+            squeeze=False,
+        )
+        plot_lead_time_panel(
+            df_in,
+            metrics,
+            results_root,
+            out_dir,
+            "paper_lead_time_summary_inner.png",
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=axes,
+            fig=fig,
+            save=False,
+            show_legend=False,
+            yscale=cast(str, preset.get("yscale", "log")),
+            ref_value=cast("float | None", preset.get("ref")),
+            **_paper_style_kwargs(),
+        )
+        for metric, ax in zip(metrics, axes[:, 0], strict=False):
+            ax.set_ylabel(_paper_summary_metric_label(metric))
+        _share_y_limits_by_row(axes)
+        for ax in axes[:, 1:].flat:
+            ax.tick_params(labelleft=False)
+
+        _remove_figure_text(fig, {"Lead time"})
+        _set_paper_lead_time_xlabel(fig, y=0.02)
+        _paper_legend(
+            fig,
+            df_in,
+            styles,
+            hue_order,
+            bbox_to_anchor=(0.06, 0.995),
+        )
+        fig.subplots_adjust(
+            left=0.11,
+            right=0.995,
+            bottom=0.08,
+            top=0.93,
+            wspace=0.22,
+            hspace=0.22,
+        )
+        _align_left_column_ylabels(fig, axes)
+        save_fig(fig, out_dir, name)
+
+
+def plot_four_ds_ablation_figure(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    error_metrics: list[str],
+    coverage_metrics: list[str],
+    error_ylim: tuple[float | None, float | None] | None = None,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    name: str = "paper_four_ds_ablation.png",
+    panel_labels: bool = True,
+) -> None:
+    """Render the four-dataset ablation as a single paper-width figure."""
+    datasets = _paper_datasets(df_in, dataset_order)
+    n_ds = max(1, len(datasets))
+    delta_metrics = _paper_coverage_metrics(coverage_metrics)
+    if not delta_metrics or not error_metrics:
+        return
+
+    with mpl.rc_context(PAPER_RC_PARAMS):
+        fig = plt.figure(figsize=(PAPER_FIGURE_WIDTH_IN, 4.95))
+        outer = fig.add_gridspec(
+            1,
+            3,
+            width_ratios=[1.08, 0.12, 1.0],
+            left=0.065,
+            right=0.995,
+            bottom=0.08,
+            top=0.84,
+            wspace=0.0,
+        )
+        left = fig.add_subfigure(outer[0, 0])
+        right = fig.add_subfigure(outer[0, 2])
+
+        coverage_axes = left.subplots(
+            len(WINDOW_ROWS_ROLLOUT_ONLY),
+            n_ds,
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+        )
+        plot_coverage_calibration_panel(
+            df_in,
+            results_root,
+            out_dir,
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=coverage_axes,
+            fig=left,
+            save=False,
+            show_legend=False,
+            window_rows=WINDOW_ROWS_ROLLOUT_ONLY,
+            **_paper_style_kwargs(),
+        )
+        _replace_figure_text(
+            left,
+            _empirical_coverage_label(short=True),
+            _paper_empirical_coverage_label(),
+            x=-0.078,
+        )
+        _remove_figure_text(left, {NOMINAL_COVERAGE_AXIS_LABEL})
+        _set_paper_nominal_coverage_xlabel(left, y=0.03)
+
+        _plot_paper_combined_lead_time_panel(
+            df_in,
+            results_root,
+            out_dir,
+            styles,
+            error_metrics,
+            delta_metrics,
+            right,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            error_ylim=error_ylim,
+            name_stem="four_ds_ablation",
+            delta_ylabel_x=-0.090,
+            lead_time_y=0.03,
+        )
+
+        if panel_labels:
+            _add_paper_panel_label(left, "a)", x=-0.10, y=0.93)
+            _add_paper_panel_label(right, "b)", x=-0.090, y=0.93, ha="center")
+            _add_paper_panel_label(right, "c)", x=-0.090, y=0.275, ha="center")
+
+        _paper_legend(
+            fig,
+            df_in,
+            styles,
+            hue_order,
+            bbox_to_anchor=(0.06, 0.995),
+        )
+        save_fig(fig, out_dir, name)
+
+
+def plot_one_ds_ablation_figure_a(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    error_metrics: list[str],
+    coverage_metrics: list[str],
+    error_ylim: tuple[float | None, float | None] | None = None,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    name: str = "paper_one_ds_ablation_a.png",
+    panel_labels: bool = True,
+) -> None:
+    """Render a vertical one-dataset ablation panel without the all row."""
+    datasets = _paper_datasets(df_in, dataset_order)
+    n_ds = max(1, len(datasets))
+    delta_metrics = _paper_coverage_metrics(coverage_metrics)
+    if not delta_metrics or not error_metrics:
+        return
+
+    with mpl.rc_context(PAPER_RC_PARAMS):
+        fig = plt.figure(figsize=(PAPER_FIGURE_WIDTH_IN, 4.85))
+        outer = fig.add_gridspec(
+            1,
+            3,
+            width_ratios=[0.95, 0.12, 1.05],
+            left=0.075,
+            right=0.99,
+            bottom=0.08,
+            top=0.84,
+            wspace=0.0,
+        )
+        left = fig.add_subfigure(outer[0, 0])
+        right = fig.add_subfigure(outer[0, 2])
+
+        coverage_axes = left.subplots(
+            len(WINDOW_ROWS_ROLLOUT_ONLY),
+            n_ds,
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+        )
+        plot_coverage_calibration_panel(
+            df_in,
+            results_root,
+            out_dir,
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=coverage_axes,
+            fig=left,
+            save=False,
+            show_legend=False,
+            window_rows=WINDOW_ROWS_ROLLOUT_ONLY,
+            **_paper_style_kwargs(),
+        )
+        _replace_figure_text(
+            left,
+            _empirical_coverage_label(short=True),
+            _paper_empirical_coverage_label(),
+            x=-0.085,
+        )
+        _remove_figure_text(left, {NOMINAL_COVERAGE_AXIS_LABEL})
+        _set_paper_nominal_coverage_xlabel(left, y=0.03)
+
+        _plot_paper_combined_lead_time_panel(
+            df_in,
+            results_root,
+            out_dir,
+            styles,
+            error_metrics,
+            delta_metrics,
+            right,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            error_ylim=error_ylim,
+            name_stem="one_ds_ablation_a",
+            delta_ylabel_x=-0.073,
+            lead_time_y=0.03,
+        )
+
+        if panel_labels:
+            _add_paper_panel_label(left, "a)", x=-0.10, y=0.93)
+            _add_paper_panel_label(right, "b)", x=-0.073, y=0.93, ha="center")
+            _add_paper_panel_label(right, "c)", x=-0.073, y=0.275, ha="center")
+
+        _paper_legend(
+            fig,
+            df_in,
+            styles,
+            hue_order,
+            bbox_to_anchor=(0.06, 0.995),
+        )
+        save_fig(fig, out_dir, name)
+
+
+def plot_one_ds_ablation_figure_b(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    error_metrics: list[str],
+    coverage_metrics: list[str],
+    error_ylim: tuple[float | None, float | None] | None = None,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    name: str = "paper_one_ds_ablation_b.png",
+    panel_labels: bool = True,
+) -> None:
+    """Render a transposed one-dataset ablation panel."""
+    delta_metrics = _paper_coverage_metrics(coverage_metrics)
+    if not delta_metrics or not error_metrics:
+        return
+
+    with mpl.rc_context(PAPER_RC_PARAMS):
+        fig = plt.figure(figsize=(PAPER_FIGURE_WIDTH_IN, 4.0))
+        outer = fig.add_gridspec(
+            2,
+            1,
+            height_ratios=[1.0, 1.0],
+            left=0.075,
+            right=0.99,
+            bottom=0.15,
+            top=0.77,
+            hspace=0.55,
+        )
+        top = fig.add_subfigure(outer[0, 0])
+        bottom = fig.add_subfigure(outer[1, 0])
+
+        coverage_axes_visual = top.subplots(
+            1,
+            len(WINDOW_ROWS_ROLLOUT_ONLY),
+            sharex=True,
+            sharey=True,
+            squeeze=False,
+        )
+        plot_coverage_calibration_panel(
+            df_in,
+            results_root,
+            out_dir,
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=coverage_axes_visual.T,
+            fig=top,
+            save=False,
+            show_legend=False,
+            window_rows=WINDOW_ROWS_ROLLOUT_ONLY,
+            short_axis_labels=True,
+            shared_axis_labels=False,
+            line_width=PAPER_LINE_WIDTH,
+            ref_line_width=PAPER_REF_LINE_WIDTH,
+        )
+        for i, window in enumerate(WINDOW_ROWS_ROLLOUT_ONLY):
+            ax = coverage_axes_visual[0][i]
+            ax.set_title(_coverage_window_row_tag(window))
+            ax.set_xlabel("")
+            ax.set_ylabel(_paper_empirical_coverage_label() if i == 0 else "")
+        bottom_grid = bottom.add_gridspec(
+            1,
+            len(delta_metrics) + len(error_metrics),
+            wspace=0.32,
+        )
+        delta_axes_visual = np.asarray(
+            [[bottom.add_subplot(bottom_grid[0, i]) for i in range(len(delta_metrics))]]
+        )
+        plot_lead_time_panel(
+            df_in,
+            delta_metrics,
+            results_root,
+            out_dir,
+            "one_ds_ablation_b_coverage_delta_inner.png",
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=delta_axes_visual.T,
+            fig=bottom,
+            save=False,
+            show_legend=False,
+            coverage_delta=True,
+            sharey=True,
+            **_paper_style_kwargs(shared_axis_labels=False),
+        )
+        _remove_figure_text(bottom, {r"Rel. $\Delta$ empirical coverage"})
+        for i, metric in enumerate(delta_metrics):
+            ax = delta_axes_visual[0][i]
+            ax.set_title(_coverage_level_label(metric))
+            ax.set_xlabel("Lead time")
+            ax.set_ylabel(_paper_relative_coverage_label() if i == 0 else "")
+
+        error_axes = np.asarray(
+            [
+                [
+                    bottom.add_subplot(
+                        bottom_grid[0, len(delta_metrics) + i],
+                    )
+                    for i in range(len(error_metrics))
+                ]
+            ]
+        )
+        plot_lead_time_panel(
+            df_in,
+            error_metrics,
+            results_root,
+            out_dir,
+            "one_ds_ablation_b_error_inner.png",
+            styles,
+            dataset_order=dataset_order,
+            hue_order=hue_order,
+            axes=error_axes.T,
+            fig=bottom,
+            save=False,
+            show_legend=False,
+            error_ylim=error_ylim,
+            sharey=True,
+            **_paper_style_kwargs(shared_axis_labels=False),
+        )
+        for i, _metric in enumerate(error_metrics):
+            ax = error_axes[0][i]
+            ax.set_title("")
+            ax.set_xlabel("Lead time")
+
+        if panel_labels:
+            _add_paper_panel_label(top, "a)", x=-0.04, y=0.95)
+            _add_paper_panel_label(bottom, "b)", x=-0.04, y=0.95)
+            _add_paper_panel_label(bottom, "c)", x=0.73, y=0.95)
+
+        _paper_legend(
+            fig,
+            df_in,
+            styles,
+            hue_order,
+            bbox_to_anchor=(0.06, 0.995),
+        )
+        save_fig(fig, out_dir, name)
+
+
+def plot_one_ds_ablation_figures(
+    df_in: pd.DataFrame,
+    results_root: Path,
+    out_dir: Path,
+    styles: dict,
+    error_metrics: list[str],
+    coverage_metrics: list[str],
+    error_ylim: tuple[float | None, float | None] | None = None,
+    dataset_order: list[str] | None = None,
+    hue_order: list[str] | None = None,
+    panel_labels: bool = True,
+) -> None:
+    """Render the selected one-dataset ablation layout."""
+    plot_one_ds_ablation_figure_a(
+        df_in,
+        results_root,
+        out_dir,
+        styles,
+        error_metrics,
+        coverage_metrics,
+        error_ylim=error_ylim,
+        dataset_order=dataset_order,
+        hue_order=hue_order,
+        panel_labels=panel_labels,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main Routine
+# ---------------------------------------------------------------------------
+
+
+def main():  # noqa: PLR0912, PLR0915
+    """Entry point: parse CLI args and generate all comparison plots."""
+    parser = argparse.ArgumentParser(
+        description="Generate dataset comparison plots (extracted from notebook)"
+    )
+    parser.add_argument(
+        "--results-dir", required=True, help="Path to collated results folder"
+    )
+    parser.add_argument(
+        "--output-dir",
+        help="Directory to save plots (defaults to <results-dir>/plots/<name>)",
+    )
+    parser.add_argument(
+        "--figure-formats",
+        nargs="+",
+        default=["png"],
+        choices=["png", "pdf"],
+        help="Figure file formats to write (default: png). Use: png pdf",
+    )
+    parser.add_argument(
+        "--name",
+        default="comparison_plots",
+        help="Leaf directory name inside plots if --output-dir is not given",
+    )
+    parser.add_argument(
+        "--run",
+        action="append",
+        nargs="+",
+        metavar="RUN_ID",
+        help=(
+            "Add a run, with optional label: "
+            '--run <id> ["label"] [hue] [eval=<subdir>]. '
+            "Repeat for each run. Integer hue overrides --color-by-label "
+            "for that run and groups runs into a shared hue family."
+        ),
+    )
+    parser.add_argument(
+        "--run-group",
+        action="append",
+        nargs="+",
+        help="Group of runs sharing a color hue. Repeat for multiple groups.",
+    )
+    parser.add_argument(
+        "--runs",
+        nargs="+",
+        help="Run directory names to include (alternative to --run).",
+    )
+    parser.add_argument(
+        "--label-run",
+        action="append",
+        nargs=2,
+        metavar=("RUN_ID", "LABEL"),
+        help="(Deprecated, use --run) Assign a custom legend label.",
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        help="Filter to specific dataset modules (e.g., ad64 gs64)",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        help="Filter to specific model families (e.g., fno_concat unet_large_concat)",
+    )
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        default=list(DEFAULT_PLOT_METRICS),
+        help=(
+            "Metrics to plot for rollouts and overall "
+            f"(default: {' '.join(DEFAULT_PLOT_METRICS)})"
+        ),
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print a summarized table of run metadata and exit",
+    )
+    parser.add_argument(
+        "--key",
+        action="append",
+        help="(Deprecated, use --filter) Key for metadata filtering.",
+    )
+    parser.add_argument(
+        "--value",
+        action="append",
+        help="(Deprecated, use --filter) Value matching the --key.",
+    )
+    parser.add_argument(
+        "--filter",
+        dest="filter_expr",
+        help=(
+            "Boolean filter expression with AND, OR, and parentheses. "
+            'e.g. --filter "Scale=large AND (Dataset=SW2D64 OR '
+            'Dataset=CNS64)"'
+        ),
+    )
+    parser.add_argument(
+        "--sort",
+        dest="sort_col",
+        help=(
+            "Column name (display name) to sort the --list table by, "
+            "e.g. --sort Date or --sort Train_hr"
+        ),
+    )
+    parser.add_argument(
+        "--reverse",
+        action="store_true",
+        help="Reverse the sort order when --sort is used",
+    )
+    parser.add_argument(
+        "--uniform-group-color",
+        action="store_true",
+        help="Use the same color for all runs in a --run-group",
+    )
+    parser.add_argument(
+        "--uniform-run-hue-color",
+        action="store_true",
+        help=(
+            "Use the same color for runs sharing an integer hue in --run "
+            "(otherwise shades vary within each hue group)."
+        ),
+    )
+    parser.add_argument(
+        "--group-hues",
+        type=int,
+        nargs="+",
+        help=(
+            "Map each --run-group to a hue index (0-based). "
+            "Groups sharing a hue get shade variants. "
+            "e.g. --group-hues 0 1 0 1"
+        ),
+    )
+    parser.add_argument(
+        "--color-by-label",
+        action="store_true",
+        help=(
+            "Derive colors from --label-run mappings: same label = same color. "
+            "Hue families from prefix before '('. "
+            "No --run-group needed."
+        ),
+    )
+    parser.add_argument(
+        "--dataset-order",
+        nargs="+",
+        help=(
+            "Display order for datasets on the x-axis (by label). "
+            'e.g. --dataset-order "SW" "CNS64"'
+        ),
+    )
+    parser.add_argument(
+        "--error-ylim",
+        nargs=2,
+        metavar=("LOW", "HIGH"),
+        help=(
+            "Fixed y-axis range for error metrics (VRMSE, RMSE, etc.) on both "
+            "bar charts and lead-time panels. Use 'auto' on either side to "
+            "keep the automatic bound, e.g. --error-ylim 1e-3 auto"
+        ),
+    )
+    parser.add_argument(
+        "--coverage-ylim",
+        nargs=2,
+        metavar=("LOW", "HIGH"),
+        help=(
+            "Fixed y-axis range for coverage lead-time panels "
+            "(defaults to 0-1). Coverage bars/calibration are unaffected."
+        ),
+    )
+    parser.add_argument(
+        "--lead-time-error-metrics",
+        nargs="+",
+        help=(
+            "Metrics shown as rows in the lead-time error panel and top of "
+            "the combined lead-time panel (default derives from --metrics)."
+        ),
+    )
+    parser.add_argument(
+        "--lead-time-coverage-metrics",
+        nargs="+",
+        help=(
+            "Coverage metrics shown as rows in the lead-time coverage panel "
+            "and bottom of the combined lead-time panel. "
+            "e.g. --lead-time-coverage-metrics coverage_0.9 coverage_0.5 coverage_0.1"
+        ),
+    )
+    parser.add_argument(
+        "--lead-time-coverage-delta",
+        action="store_true",
+        help=(
+            "Also render an additional lead-time coverage panel where each "
+            "coverage_<p> curve is transformed to coverage / p - 1, i.e. "
+            "proportional deviation from the nominal coverage level. Output: "
+            "lead_time_panel_coverage_delta.png"
+        ),
+    )
+    parser.add_argument(
+        "--combined-lead-time",
+        action="store_true",
+        help=(
+            "Also render a single lead-time panel stacking error metrics "
+            "(top rows) and coverage metrics (bottom rows)."
+        ),
+    )
+    parser.add_argument(
+        "--no-ssr-in-coverage",
+        dest="include_ssr_in_coverage",
+        action="store_false",
+        default=True,
+        help=(
+            "Suppress the default inclusion of 'ssr' as a row in "
+            "the lead-time coverage panel (ssr renders with a linear axis "
+            "and a reference line at 1.0)."
+        ),
+    )
+    parser.add_argument(
+        "--metric-groups",
+        nargs="+",
+        default=list(DEFAULT_METRIC_GROUPS),
+        choices=[*METRIC_GROUP_PRESETS.keys(), "all", "none"],
+        help=(
+            "Lead-time panel groups to render. "
+            "Presets: "
+            + ", ".join(METRIC_GROUP_PRESETS.keys())
+            + ". Use 'all' for every preset or 'none' to skip. "
+            f"Default: {' '.join(DEFAULT_METRIC_GROUPS)}."
+        ),
+    )
+    parser.add_argument(
+        "--training-metrics",
+        nargs="+",
+        help=(
+            "Training-curve metrics read from wandb history, "
+            "e.g. --training-metrics val_loss train_loss. "
+            "Omit to skip training curve plots."
+        ),
+    )
+    parser.add_argument(
+        "--training-yscale",
+        choices=["log", "linear"],
+        default="log",
+        help="Y-axis scale for training-curve plots (default: log).",
+    )
+    parser.add_argument(
+        "--error-yscale",
+        choices=["log", "linear"],
+        default="log",
+        help=(
+            "Y-axis scale for error-like metrics (VRMSE, CRPS, power-spectrum "
+            "RMSE, ...) in lead-time panels, overall/window bar charts, and "
+            "metric-group panels. Coverage and dispersion (SSR) plots are "
+            "unaffected. Default: log."
+        ),
+    )
+    parser.add_argument(
+        "--training-ylim",
+        nargs=2,
+        metavar=("LOW", "HIGH"),
+        help=(
+            "Fixed y-axis range for training-curve plots. "
+            "Use 'auto' on either side to keep the automatic bound."
+        ),
+    )
+    parser.add_argument(
+        "--training-refresh",
+        action="store_true",
+        help=(
+            "Force re-fetching training history from wandb even if a local "
+            "cache (<run>/<eval_subdir>/training_history.csv) already exists."
+        ),
+    )
+    parser.add_argument(
+        "--panel-figure",
+        action="store_true",
+        help=(
+            "Also render a composite panel with overall bars, coverage "
+            "calibration, lead-time panels, training curves, and a blank "
+            "top-left notes area (~20% x ~20%)."
+        ),
+    )
+    parser.add_argument(
+        "--panel-figure-no-training",
+        action="store_true",
+        help=(
+            "Also render a panel variant without the training-curves column. "
+            "Can be combined with --panel-figure to save both variants."
+        ),
+    )
+    parser.add_argument(
+        "--coverage-panel-overall-rollout-windows",
+        action="store_true",
+        help=(
+            "Also render coverage calibration panel variants for: "
+            "all plus rollout windows, all only, and rollout windows only "
+            "(using 0-4, 6-12, 13-30, 31-99; excluding the 0-1 rollout window)."
+        ),
+    )
+    parser.add_argument(
+        "--tick-label-scale",
+        type=float,
+        default=1.0,
+        help="Scale tick label font sizes for publication plots (default: 1.0).",
+    )
+    parser.add_argument(
+        "--axis-label-scale",
+        type=float,
+        default=1.0,
+        help="Scale axis label font sizes for publication plots (default: 1.0).",
+    )
+    parser.add_argument(
+        "--legend-font-scale",
+        type=float,
+        default=1.0,
+        help="Scale legend font sizes for publication plots (default: 1.0).",
+    )
+    parser.add_argument(
+        "--legend-font-size",
+        type=float,
+        help="Explicit legend font size; overrides --legend-font-scale.",
+    )
+    parser.add_argument(
+        "--figure-scale",
+        type=float,
+        default=1.0,
+        help="Scale generated figure sizes without changing layout (default: 1.0).",
+    )
+    parser.add_argument(
+        "--short-axis-labels",
+        action="store_true",
+        help="Use compact axis labels for dense publication grid plots.",
+    )
+    parser.add_argument(
+        "--shared-axis-labels",
+        action="store_true",
+        help="Use panel-level shared x/y labels where repeated labels are redundant.",
+    )
+    parser.add_argument(
+        "--coverage-panel-height-scale",
+        type=float,
+        default=1.0,
+        help="Scale standalone coverage-calibration panel height (default: 1.0).",
+    )
+    parser.add_argument(
+        "--paper-main-figures",
+        action="store_true",
+        help=(
+            "Also render paper-width main-result figures: single-step coverage, "
+            "rollout UQ reliability, lead-time error, and summary metrics."
+        ),
+    )
+    parser.add_argument(
+        "--paper-only",
+        action="store_true",
+        help="Only render requested paper_* figures; skip standard plot outputs.",
+    )
+    parser.add_argument(
+        "--paper-use-tex",
+        action="store_true",
+        help=(
+            "Render text and math with an external LaTeX installation for "
+            "paper figures. Requires latex to be available on PATH."
+        ),
+    )
+    parser.add_argument(
+        "--no-paper-panel-labels",
+        dest="paper_panel_labels",
+        action="store_false",
+        default=True,
+        help="Disable a), b), c) panel labels on combined paper figures.",
+    )
+    parser.add_argument(
+        "--four-ds-ablation",
+        action="store_true",
+        help="Also render the four-dataset ablation as one paper-width figure.",
+    )
+    parser.add_argument(
+        "--one-ds-ablation",
+        action="store_true",
+        help="Also render the one-dataset ablation paper layout.",
+    )
+    args = parser.parse_args()
+    FIGURE_FORMATS[:] = list(dict.fromkeys(args.figure_formats))
+    if args.paper_use_tex:
+        PAPER_RC_PARAMS.update(
+            {
+                "text.usetex": True,
+                "text.latex.preamble": r"\usepackage{amsmath}",
+            }
+        )
+    for style_arg in (
+        "tick_label_scale",
+        "axis_label_scale",
+        "legend_font_scale",
+        "figure_scale",
+        "coverage_panel_height_scale",
+    ):
+        if getattr(args, style_arg) <= 0:
+            msg = f"--{style_arg.replace('_', '-')} must be positive"
+            raise SystemExit(msg)
+    if args.legend_font_size is not None and args.legend_font_size <= 0:
+        msg = "--legend-font-size must be positive"
+        raise SystemExit(msg)
+
+    def _parse_ylim(pair: list[str] | None) -> tuple[float | None, float | None] | None:
+        if not pair:
+            return None
+
+        def _one(v: str) -> float | None:
+            if v is None or str(v).lower() in {"auto", "none", "-"}:
+                return None
+            try:
+                return float(v)
+            except ValueError as exc:
+                msg = f"Invalid ylim value: {v!r} (expected number or 'auto')"
+                raise SystemExit(msg) from exc
+
+        return (_one(pair[0]), _one(pair[1]))
+
+    error_ylim = _parse_ylim(args.error_ylim)
+    coverage_ylim = _parse_ylim(args.coverage_ylim)
+    training_ylim = _parse_ylim(args.training_ylim)
+
+    results_dir = resolve_results_root(args.results_dir)
+    if args.output_dir:
+        out_dir = Path(args.output_dir)
+    else:
+        out_dir = results_dir / "plots" / args.name
+
+    if not args.list:
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Merge --run entries into --runs / --label-run for unified handling.
+    # Each --run entry is: <id> [label] [hue] [eval=<subdir>] in any order
+    # for optional fields, with backward-compatible support for:
+    #   <id>
+    #   <id> <label>
+    #   <id> <hue>
+    #   <id> <label> <hue>
+    hue_group_by_run: dict[str, int] = {}
+    eval_subdir_by_run: dict[str, str] = {}
+    run_order: list[str] = []
+
+    def _parse_run_entry(
+        entry: list[str],
+    ) -> tuple[str, str | None, int | None, str | None]:
+        if not entry:
+            msg = "Error: --run requires at least <id>."
+            raise ValueError(msg)
+
+        run_id = entry[0]
+        label: str | None = None
+        hue: int | None = None
+        eval_subdir: str | None = None
+
+        for tok in entry[1:]:
+            tok_s = str(tok)
+            tok_l = tok_s.lower()
+            if tok_l.startswith("eval="):
+                if eval_subdir is not None:
+                    msg = (
+                        f"Error: duplicate eval subdir in --run {run_id!r}. "
+                        "Use one eval=<subdir> token."
+                    )
+                    raise ValueError(msg)
+                eval_value = tok_s.split("=", 1)[1]
+                if not eval_value.strip():
+                    msg = (
+                        f"Error: empty eval subdir in --run {run_id!r}. "
+                        "Use eval=<subdir>."
+                    )
+                    raise ValueError(msg)
+                eval_subdir = eval_value
+                continue
+
+            if hue is None and tok_s.lstrip("-").isdigit():
+                hue = int(tok_s)
+                continue
+
+            if label is None:
+                label = tok_s
+                continue
+
+            msg = (
+                f"Error: unrecognized extra token {tok_s!r} in --run {run_id!r}. "
+                "Expected optional [label] [hue] and/or eval=<subdir>."
+            )
+            raise ValueError(msg)
+
+        return run_id, label, hue, eval_subdir
+
+    if args.run:
+        merged_runs: list[str] = []
+        merged_labels: list[list[str]] = list(args.label_run or [])
+        parsed_entries: list[tuple[str, str | None, int | None, str]] = []
+        for entry in args.run:
+            try:
+                run_id, label, hue, run_eval_subdir = _parse_run_entry(entry)
+            except ValueError as e:
+                print(e)
+                sys.exit(1)
+            parsed_entries.append(
+                (run_id, label, hue, normalize_eval_subdir(run_eval_subdir))
+            )
+            merged_runs.append(run_id)
+            eval_subdir_by_run[run_id] = normalize_eval_subdir(run_eval_subdir)
+
+        # Build stable per-entry refs so repeated run_ids with different eval/labels
+        # are treated as distinct series in style/legend/hue mapping.
+        ref_counts: dict[str, int] = {}
+        for run_id, label, hue, run_eval_subdir in parsed_entries:
+            base_ref = run_id
+            if run_eval_subdir != DEFAULT_EVAL_SUBDIR:
+                base_ref = f"{run_id}::eval={run_eval_subdir}"
+            n_seen = ref_counts.get(base_ref, 0)
+            ref_counts[base_ref] = n_seen + 1
+            run_ref = base_ref if n_seen == 0 else f"{base_ref}#{n_seen + 1}"
+            run_order.append(run_ref)
+            if label is not None:
+                merged_labels.append([run_ref, label])
+            if hue is not None:
+                hue_group_by_run[run_ref] = hue
+        # --run takes precedence; append any extra --runs
+        if args.runs:
+            for run_id in args.runs:
+                merged_runs.append(run_id)
+                run_order.append(run_id)
+        args.runs = merged_runs
+        args.label_run = merged_labels or None
+    elif args.runs:
+        run_order = list(args.runs)
+
+    explicit_groups = args.run_group or []
+    # Gather explicitly requested runs, or fallback to auto-discover
+    if explicit_groups:
+        run_targets = [
+            (results_dir / r, DEFAULT_EVAL_SUBDIR, r)
+            for g in explicit_groups
+            for r in g
+        ]
+    elif args.runs:
+        run_targets = []
+        if args.run:
+            ref_counts = {}
+            for entry in args.run:
+                run_id, _, _, run_eval_subdir = _parse_run_entry(entry)
+                eval_subdir = normalize_eval_subdir(run_eval_subdir)
+                base_ref = run_id
+                if eval_subdir != DEFAULT_EVAL_SUBDIR:
+                    base_ref = f"{run_id}::eval={eval_subdir}"
+                n_seen = ref_counts.get(base_ref, 0)
+                ref_counts[base_ref] = n_seen + 1
+                run_ref = base_ref if n_seen == 0 else f"{base_ref}#{n_seen + 1}"
+                run_targets.append((results_dir / run_id, eval_subdir, run_ref))
+            if args.runs:
+                for run_id in args.runs[len(args.run) :]:
+                    run_targets.append(
+                        (results_dir / run_id, DEFAULT_EVAL_SUBDIR, run_id)
+                    )
+        else:
+            run_targets = [
+                (
+                    results_dir / r,
+                    normalize_eval_subdir(
+                        eval_subdir_by_run.get(r, DEFAULT_EVAL_SUBDIR)
+                    ),
+                    r,
+                )
+                for r in args.runs
+            ]
+    else:
+        run_targets = sorted(
+            [
+                (p, DEFAULT_EVAL_SUBDIR, p.name)
+                for p in results_dir.iterdir()
+                if p.is_dir() and (p / "eval" / "evaluation_metrics.csv").exists()
+            ],
+            key=lambda x: x[0],
+        )
+
+    valid_run_names = {
+        name for rd, _, run_ref in run_targets for name in (run_ref, rd.name)
+    }
+
+    try:
+        custom_label_by_run = build_custom_label_map(
+            args.label_run,
+            valid_run_names=valid_run_names,
+        )
+    except ValueError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+    if args.list:
+        print(f"Loading {len(run_targets)} runs...")
+        m_rows = []
+        for rd, run_eval_subdir, run_ref in run_targets:
+            m_rows.append(
+                load_config_metadata(rd, eval_subdir=run_eval_subdir, run_ref=run_ref)
+            )
+        mdf = pd.DataFrame(m_rows)
+
+        if mdf.empty:
+            print("No valid runs to process.")
+            sys.exit(1)
+
+        _parsed = mdf["run_id"].map(parse_loss_dataset_arch)
+        mdf["loss_family"] = _parsed.map(
+            lambda x: x[0] if isinstance(x, tuple) and len(x) > 0 else None
+        )
+        parsed_dataset = _parsed.map(
+            lambda x: x[1] if isinstance(x, tuple) and len(x) > 1 else None
+        )
+        parsed_dataset = cast(
+            pd.Series,
+            parsed_dataset.where(
+                ~parsed_dataset.isin(["cached_latents", "latents", "encoded"]),
+                np.nan,
+            ),
+        )
+        mdf["dataset_module"] = parsed_dataset.fillna(
+            mdf.get("dataset_from_data_path")
+        ).fillna(mdf["dataset"].map(normalize_dataset_module))
+        mdf["dataset_label"] = mdf["dataset_module"].map(dataset_label_from_module)
+        mdf["arch_segment"] = _parsed.map(
+            lambda x: x[2] if isinstance(x, tuple) and len(x) > 2 else None
+        )
+        mdf["arch_key"] = mdf["arch_segment"].map(arch_key_from_processor_segment)
+        mdf["model_scale"] = assign_model_scale(mdf)
+
+        merged = mdf.copy()
+
+        if "train_total_s" in merged.columns:
+            _train_s = cast(
+                pd.Series,
+                pd.to_numeric(merged["train_total_s"], errors="coerce"),
+            )
+            merged["train_hrs"] = (_train_s / 3600.0).round(1)
+
+        if "model_latency_ms_per_sample" in merged.columns:
+            _infer_ms = cast(
+                pd.Series,
+                pd.to_numeric(merged["model_latency_ms_per_sample"], errors="coerce"),
+            )
+            merged["infer_ms"] = _infer_ms.round(2)
+
+        if "params_processor_total" in merged.columns:
+            _params = pd.to_numeric(merged["params_processor_total"], errors="coerce")
+            merged["params_M"] = (
+                (_params / 1e6).round(1).astype(str) + "M"  # type: ignore[operator]
+            )
+
+        show_cols = [
+            "run_name",
+            "dataset_label",
+            "processor",
+            "resolution",
+            "model_scale",
+            "params_M",
+            "n_steps_input",
+            "n_steps_output",
+            "loss_func",
+            "noise_injector",
+            "noise_channels",
+            "ode_steps",
+            "n_gpus",
+            "batch_size",
+            "eff_batch_size",
+            "lr",
+            "train_hrs",
+            "train_mean_epoch_s",
+            "infer_ms",
+            "run_date",
+        ]
+        show_cols = [c for c in show_cols if c in merged.columns]
+
+        renames = {
+            "run_name": "Run",
+            "dataset_label": "Dataset",
+            "processor": "Model",
+            "resolution": "Resolution",
+            "model_scale": "Scale",
+            "params_M": "Params",
+            "n_steps_input": "N_In",
+            "n_steps_output": "N_Out",
+            "loss_func": "Loss",
+            "noise_injector": "NoiseInj",
+            "noise_channels": "NoiseC",
+            "ode_steps": "ODE",
+            "n_gpus": "GPUs",
+            "batch_size": "BS",
+            "eff_batch_size": "EffBS",
+            "lr": "LR",
+            "train_hrs": "Train_hr",
+            "train_mean_epoch_s": "Epoch_s",
+            "infer_ms": "Infer_ms",
+            "run_date": "Date",
+        }
+        merged = merged.rename(columns=renames)
+
+        # Build filter expression from legacy --key/--value or --filter.
+        filter_expr = args.filter_expr or ""
+        if not filter_expr and args.key and args.value:
+            if len(args.key) != len(args.value):
+                print(
+                    "Error: --key and --value must be given the same number of times."
+                )
+                sys.exit(1)
+            parts = [f"{k}={v}" for k, v in zip(args.key, args.value, strict=False)]
+            filter_expr = " OR ".join(parts)
+
+        if filter_expr:
+            merged = apply_filter_expr(
+                filter_expr,
+                merged,
+                col_aliases=renames,
+            )
+
+        if args.sort_col:
+            if args.sort_col in merged.columns:
+                merged = cast(
+                    pd.DataFrame,
+                    merged.sort_values(
+                        args.sort_col,
+                        ascending=not args.reverse,
+                        na_position="last",
+                    ),
+                )
+            else:
+                available = ", ".join(merged.columns.tolist())
+                print(
+                    f"Warning: --sort column '{args.sort_col}' not found. "
+                    f"Available columns: {available}"
+                )
+
+        pd.set_option("display.max_rows", None)
+        pd.set_option("display.max_columns", None)
+        pd.set_option("display.width", 1000)
+        pd.set_option("display.max_colwidth", 40)
+        print("\n--- Available Runs Metadata ---\n")
+        disp_cols = [r for c, r in renames.items() if r in merged.columns]
+        print(cast(pd.DataFrame, merged[disp_cols]).to_string(index=False))
+        sys.exit(0)
+
+    print(f"Loading {len(run_targets)} runs...")
+    rows = []
+    for d, run_eval_subdir, run_ref in run_targets:
+        if not d.exists():
+            print(f"Warning: requested run not found: {d}")
+            continue
+        try:
+            r = load_single_run_metrics(
+                d,
+                eval_subdir=run_eval_subdir,
+                run_ref=run_ref,
+                force_training_refresh=args.training_refresh,
+            )
+        except Exception as e:
+            print(f"Error loading {d}: {e}")
+            continue
+        rows.append(r)
+
+    if not rows:
+        print("No valid runs to process.")
+        sys.exit(1)
+
+    df = pd.DataFrame(rows)
+    _parsed = df["run_id"].map(parse_loss_dataset_arch)
+    df["loss_family"] = _parsed.map(
+        lambda x: x[0] if isinstance(x, tuple) and len(x) > 0 else None
+    )
+    parsed_dataset = _parsed.map(
+        lambda x: x[1] if isinstance(x, tuple) and len(x) > 1 else None
+    )
+    parsed_dataset = cast(
+        pd.Series,
+        parsed_dataset.where(
+            ~parsed_dataset.isin(["cached_latents", "latents", "encoded"]), np.nan
+        ),
+    )
+    df["dataset_module"] = parsed_dataset.fillna(
+        df.get("dataset_from_data_path")
+    ).fillna(df["dataset"].map(normalize_dataset_module))
+    df["arch_segment"] = _parsed.map(
+        lambda x: x[2] if isinstance(x, tuple) and len(x) > 2 else None
+    )
+    df["arch_key"] = df["arch_segment"].map(arch_key_from_processor_segment)
+    df["dataset_label"] = df["dataset_module"].map(dataset_label_from_module)
+    df["model_scale"] = assign_model_scale(df)
+
+    # Construct plot_group (includes run_name to guarantee no multi-run averaging)
+    df["plot_group"] = (
+        df["arch_key"].astype(str)
+        + "__"
+        + df["loss_family"].astype(str)
+        + "__"
+        + df["model_scale"].astype(str)
+        + "__"
+        + df["run_name"].astype(str)
+    )
+
+    # Apply dataset and model filters
+    if args.datasets:
+        df = cast(pd.DataFrame, df[df["dataset_module"].isin(args.datasets)])
+    if args.models:
+        df = cast(pd.DataFrame, df[df["arch_key"].isin(args.models)])
+
+    if cast(pd.DataFrame, df).empty:
+        print("No valid runs remain after applying filters.")
+        sys.exit(1)
+
+    # Styling
+    df = cast(pd.DataFrame, df)
+    if "train_total_s" in df.columns:
+        _train_s = cast(
+            pd.Series,
+            pd.to_numeric(df["train_total_s"], errors="coerce"),
+        )
+        df["train_hrs"] = _train_s / 3600.0
+    styles = build_family_style(
+        df,
+        explicit_groups,
+        custom_label_by_run=custom_label_by_run,
+        uniform_group_color=args.uniform_group_color,
+        uniform_run_hue_color=args.uniform_run_hue_color,
+        group_hues=args.group_hues,
+        color_by_label=args.color_by_label,
+        hue_group_by_run=hue_group_by_run or None,
+    )
+
+    n_ds = df["dataset_label"].nunique()
+    n_mv = df["plot_group"].nunique()
+    print(f"Found {n_ds} datasets and {n_mv} model variants.")
+
+    ds_order = args.dataset_order
+
+    # Derive hue order from --runs order: first unique label seen wins.
+    hu_order: list[str] | None = None
+    if run_order and custom_label_by_run:
+        seen: list[str] = []
+        seen_set: set[str] = set()
+        for run in run_order:
+            label = custom_label_by_run.get(run)
+            if label and label not in seen_set:
+                seen.append(label)
+                seen_set.add(label)
+        if seen:
+            hu_order = seen
+
+    plot_style_kwargs = {
+        "tick_label_scale": args.tick_label_scale,
+        "axis_label_scale": args.axis_label_scale,
+        "legend_font_scale": args.legend_font_scale,
+        "legend_font_size": args.legend_font_size,
+        "figure_scale": args.figure_scale,
+        "short_axis_labels": args.short_axis_labels,
+        "shared_axis_labels": args.shared_axis_labels,
+    }
+    coverage_plot_style_kwargs = {
+        **plot_style_kwargs,
+        "height_scale": 1.0,
+    }
+    coverage_overall_plot_style_kwargs = {
+        **plot_style_kwargs,
+        "height_scale": args.coverage_panel_height_scale,
+    }
+
+    err_metric, cov_metric = _derive_lead_time_metrics(list(args.metrics))
+    if args.lead_time_error_metrics:
+        err_metric = list(args.lead_time_error_metrics)
+    if args.lead_time_coverage_metrics:
+        cov_metric = list(args.lead_time_coverage_metrics)
+    if args.include_ssr_in_coverage and "ssr" not in cov_metric:
+        cov_metric = [*cov_metric, "ssr"]
+    elif not args.include_ssr_in_coverage:
+        cov_metric = [m for m in cov_metric if m != "ssr"]
+    paper_cov_metric = _paper_coverage_metrics(cov_metric)
+
+    write_single_step_results_table(
+        df,
+        out_dir,
+        styles,
+        dataset_order=ds_order,
+        hue_order=hu_order,
+    )
+
+    if args.paper_only:
+        if args.paper_main_figures:
+            plot_paper_overall_coverage_figure(
+                df,
+                results_dir,
+                out_dir,
+                styles,
+                dataset_order=ds_order,
+                hue_order=hu_order,
+            )
+            plot_paper_uq_reliability_figure(
+                df,
+                results_dir,
+                out_dir,
+                styles,
+                paper_cov_metric,
+                dataset_order=ds_order,
+                hue_order=hu_order,
+                panel_labels=args.paper_panel_labels,
+            )
+            plot_paper_lead_time_error_figure(
+                df,
+                results_dir,
+                out_dir,
+                styles,
+                err_metric,
+                error_ylim=error_ylim,
+                dataset_order=ds_order,
+                hue_order=hu_order,
+            )
+            plot_paper_lead_time_summary_figure(
+                df,
+                results_dir,
+                out_dir,
+                styles,
+                dataset_order=ds_order,
+                hue_order=hu_order,
+            )
+        if args.four_ds_ablation:
+            plot_four_ds_ablation_figure(
+                df,
+                results_dir,
+                out_dir,
+                styles,
+                err_metric,
+                paper_cov_metric,
+                error_ylim=error_ylim,
+                dataset_order=ds_order,
+                hue_order=hu_order,
+                panel_labels=args.paper_panel_labels,
+            )
+        if args.one_ds_ablation:
+            plot_one_ds_ablation_figures(
+                df,
+                results_dir,
+                out_dir,
+                styles,
+                err_metric,
+                paper_cov_metric,
+                error_ylim=error_ylim,
+                dataset_order=ds_order,
+                hue_order=hu_order,
+                panel_labels=args.paper_panel_labels,
+            )
+        print("Finished generating paper plots.")
+        return
+
+    # Render overall bars
+    for m in args.metrics:
+        grouped_bar(
+            df,
+            f"overall_{m}",
+            f"Overall {m.upper()}",
+            m.upper(),
+            out_dir,
+            styles,
+            y_scale=_overall_or_window_bar_yscale(m, args.error_yscale),
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            ylim=_overall_or_window_bar_ylim(m, error_ylim),
+            ref_value=_overall_or_window_bar_ref_value(m),
+            **plot_style_kwargs,
+        )
+
+    # Render window bars
+    for m in args.metrics:
+        for w in ROLL_WINDOWS:
+            grouped_bar(
+                df,
+                f"{m}_{w}",
+                f"{m.upper()} in window {w}",
+                m.upper(),
+                out_dir,
+                styles,
+                y_scale=_overall_or_window_bar_yscale(m, args.error_yscale),
+                dataset_order=ds_order,
+                hue_order=hu_order,
+                ylim=_overall_or_window_bar_ylim(m, error_ylim),
+                ref_value=_overall_or_window_bar_ref_value(m),
+                **plot_style_kwargs,
+            )
+
+    # Render Calibration panel
+    plot_coverage_calibration_panel(
+        df,
+        results_dir,
+        out_dir,
+        styles,
+        dataset_order=ds_order,
+        hue_order=hu_order,
+        **coverage_plot_style_kwargs,
+    )
+    if args.coverage_panel_overall_rollout_windows:
+        plot_coverage_calibration_panel(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            window_rows=WINDOW_ROWS_OVERALL_AND_ROLLOUT,
+            name="coverage_calibration_panel_overall_rollout_windows.png",
+            **coverage_plot_style_kwargs,
+        )
+        plot_coverage_calibration_panel(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            window_rows=WINDOW_ROWS_OVERALL_ONLY,
+            name="coverage_calibration_panel_overall_only.png",
+            **coverage_overall_plot_style_kwargs,
+        )
+        plot_coverage_calibration_panel(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            window_rows=WINDOW_ROWS_ROLLOUT_ONLY,
+            name="coverage_calibration_panel_rollout_windows_only.png",
+            **coverage_plot_style_kwargs,
+        )
+
+    # Render efficiency bars (training/inference), if available.
+    for metric, title, ylabel in [
+        ("train_hrs", "Training time total (hours)", "hours"),
+        ("train_mean_epoch_s", "Training time per epoch (seconds)", "seconds"),
+        (
+            "model_latency_ms_per_sample",
+            "Inference latency per sample (ms)",
+            "ms",
+        ),
+        (
+            "model_throughput_samples_per_sec",
+            "Inference throughput (samples/s)",
+            "samples/s",
+        ),
+    ]:
+        is_train_metric = metric in {"train_hrs", "train_mean_epoch_s"}
+        grouped_bar(
+            df,
+            metric,
+            title,
+            ylabel,
+            out_dir,
+            styles,
+            y_scale="linear" if is_train_metric else "auto",
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            **plot_style_kwargs,
+        )
+
+    # Render lead-time panels
+    err_metric, cov_metric = _derive_lead_time_metrics(list(args.metrics))
+
+    # Explicit overrides
+    if args.lead_time_error_metrics:
+        err_metric = list(args.lead_time_error_metrics)
+    if args.lead_time_coverage_metrics:
+        cov_metric = list(args.lead_time_coverage_metrics)
+
+    # SSR is a dimensionless dispersion diagnostic (ideal=1.0) that belongs
+    # alongside the coverage rows in the lead-time coverage panel by default.
+    if args.include_ssr_in_coverage and "ssr" not in cov_metric:
+        cov_metric = [*cov_metric, "ssr"]
+    elif not args.include_ssr_in_coverage:
+        cov_metric = [m for m in cov_metric if m != "ssr"]
+
+    if err_metric:
+        plot_lead_time_panel(
+            df,
+            err_metric,
+            results_dir,
+            out_dir,
+            "lead_time_panel_error.png",
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            error_ylim=error_ylim,
+            yscale=args.error_yscale,
+            **plot_style_kwargs,
+        )
+    if cov_metric:
+        plot_lead_time_panel(
+            df,
+            cov_metric,
+            results_dir,
+            out_dir,
+            "lead_time_panel_coverage.png",
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            **plot_style_kwargs,
+        )
+        if args.lead_time_coverage_delta:
+            delta_metrics = [m for m in cov_metric if m.startswith("coverage_")]
+            if delta_metrics:
+                plot_lead_time_panel(
+                    df,
+                    delta_metrics,
+                    results_dir,
+                    out_dir,
+                    "lead_time_panel_coverage_delta.png",
+                    styles,
+                    dataset_order=ds_order,
+                    hue_order=hu_order,
+                    coverage_delta=True,
+                    **plot_style_kwargs,
+                )
+
+    # Combined lead-time panel (error rows on top, coverage rows below).
+    if args.combined_lead_time and (err_metric or cov_metric):
+        combined_metrics = list(err_metric) + list(cov_metric)
+        plot_lead_time_panel(
+            df,
+            combined_metrics,
+            results_dir,
+            out_dir,
+            "lead_time_panel_combined.png",
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            error_ylim=error_ylim,
+            yscale=args.error_yscale,
+            **plot_style_kwargs,
+        )
+
+    paper_cov_metric = _paper_coverage_metrics(cov_metric)
+    if args.paper_main_figures:
+        plot_paper_overall_coverage_figure(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+        )
+        plot_paper_uq_reliability_figure(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            paper_cov_metric,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            panel_labels=args.paper_panel_labels,
+        )
+        plot_paper_lead_time_error_figure(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            err_metric,
+            error_ylim=error_ylim,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+        )
+        plot_paper_lead_time_summary_figure(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+        )
+    if args.four_ds_ablation:
+        plot_four_ds_ablation_figure(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            err_metric,
+            paper_cov_metric,
+            error_ylim=error_ylim,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            panel_labels=args.paper_panel_labels,
+        )
+    if args.one_ds_ablation:
+        plot_one_ds_ablation_figures(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            err_metric,
+            paper_cov_metric,
+            error_ylim=error_ylim,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            panel_labels=args.paper_panel_labels,
+        )
+
+    # Per-group lead-time panels (SSR, coherence, balancing coverage, physics)
+    group_selection = list(args.metric_groups or [])
+    if "none" in group_selection:
+        group_selection = []
+    elif "all" in group_selection:
+        group_selection = list(METRIC_GROUP_PRESETS.keys())
+    # Dedup while preserving order
+    seen_groups: set[str] = set()
+    ordered_groups: list[str] = []
+    for g in group_selection:
+        if g in METRIC_GROUP_PRESETS and g not in seen_groups:
+            ordered_groups.append(g)
+            seen_groups.add(g)
+    for group_id in ordered_groups:
+        preset = METRIC_GROUP_PRESETS[group_id]
+        group_metrics = cast(list[str], preset["metrics"])
+        group_name = cast(str, preset["name"])
+        group_yscale = cast(str, preset.get("yscale", "log"))
+        if args.error_yscale == "linear" and group_yscale == "log":
+            group_yscale = "linear"
+        group_ref = cast("float | None", preset.get("ref"))
+        plot_lead_time_panel(
+            df,
+            group_metrics,
+            results_dir,
+            out_dir,
+            group_name,
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            error_ylim=None,
+            yscale=group_yscale,
+            ref_value=group_ref,
+            **plot_style_kwargs,
+        )
+
+    # Training curves
+    if args.training_metrics:
+        plot_training_curves(
+            df,
+            list(args.training_metrics),
+            results_dir,
+            out_dir,
+            "training_curves.png",
+            styles,
+            dataset_order=ds_order,
+            hue_order=hu_order,
+            y_scale=args.training_yscale,
+            ylim=training_ylim,
+            force_refresh=args.training_refresh,
+            **plot_style_kwargs,
+        )
+
+    # Composite panel figure(s)
+    panel_kwargs = {
+        "dataset_order": ds_order,
+        "hue_order": hu_order,
+        "overall_metrics": tuple(args.metrics or DEFAULT_PLOT_METRICS),
+        "error_metrics": err_metric or ["vrmse"],
+        "coverage_metrics": cov_metric
+        or ["coverage_0.9", "coverage_0.5", "coverage_0.1"],
+        "lead_time_coverage_delta": args.lead_time_coverage_delta,
+        "training_yscale": args.training_yscale,
+        "training_ylim": training_ylim,
+        "training_refresh": args.training_refresh,
+        "error_ylim": error_ylim,
+        "coverage_ylim": coverage_ylim,
+        "error_yscale": args.error_yscale,
+        **plot_style_kwargs,
+    }
+    if args.panel_figure:
+        plot_panel_figure(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            training_metrics=list(args.training_metrics)
+            if args.training_metrics
+            else ["val_loss", "train_loss"],
+            name="panel_figure.png",
+            **panel_kwargs,
+        )
+    if args.panel_figure_no_training:
+        plot_panel_figure(
+            df,
+            results_dir,
+            out_dir,
+            styles,
+            training_metrics=[],
+            name="panel_figure_no_training.png",
+            **panel_kwargs,
+        )
+
+    print("Finished generating plots.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/autocast/scripts/plot_dataset_comparisons.py
+++ b/src/autocast/scripts/plot_dataset_comparisons.py
@@ -218,6 +218,11 @@ def _is_dispersion_metric(metric: str) -> bool:
     return metric in DISPERSION_METRICS
 
 
+def _is_empirical_coverage_metric(metric: str) -> bool:
+    """Return True for coverage_<level> empirical coverage curves."""
+    return metric.startswith("coverage_")
+
+
 def _overall_or_window_bar_ylim(
     metric: str,
     error_ylim: tuple[float | None, float | None] | None,
@@ -253,13 +258,16 @@ def _overall_or_window_bar_ref_value(metric: str) -> float | None:
 def _derive_lead_time_metrics(metrics: list[str]) -> tuple[list[str], list[str]]:
     """Split scalar plot metrics into error and coverage lead-time rows."""
     err_metric = [
-        m for m in metrics if "coverage" not in m and not _is_dispersion_metric(m)
+        m
+        for m in metrics
+        if not _is_empirical_coverage_metric(m) and not _is_dispersion_metric(m)
     ]
-    cov_metric = [m for m in metrics if "coverage" in m]
+    cov_metric = [m for m in metrics if _is_empirical_coverage_metric(m)]
     dispersion_metric = [m for m in metrics if _is_dispersion_metric(m)]
 
-    # Add common rollout variants if we only provided generic 'coverage'.
-    if "coverage" in metrics and "coverage_0.9" not in cov_metric:
+    # Add common empirical rollout variants if only generic coverage MAE was
+    # requested for scalar summaries.
+    if "coverage" in metrics and not any(m.startswith("coverage_") for m in cov_metric):
         cov_metric.extend(["coverage_0.9", "coverage_0.5"])
         err_metric.append("rmse")
 
@@ -363,9 +371,11 @@ def _apply_optional_ylim(
 
 def _metric_axis_label(metric: str) -> str:
     """Format metric keys as publication-facing axis labels."""
-    if metric.startswith("coverage_"):
+    if _is_empirical_coverage_metric(metric):
         level = metric.split("_", 1)[1]
         return f"COVERAGE {level}"
+    if metric == "coverage":
+        return "Coverage MAE"
     return metric.upper()
 
 
@@ -685,20 +695,73 @@ def _make_run_target(
     )
 
 
+def _is_eval_metrics_dir(path: Path) -> bool:
+    """Return True for eval output dirs, including eval_* variants."""
+    return path.name == DEFAULT_EVAL_SUBDIR or path.name.startswith(
+        f"{DEFAULT_EVAL_SUBDIR}_"
+    )
+
+
+def _eval_sort_key(eval_subdir: str) -> tuple[int, str]:
+    """Sort the default eval first, then postfix variants alphabetically."""
+    return (0 if eval_subdir == DEFAULT_EVAL_SUBDIR else 1, eval_subdir)
+
+
+def _available_eval_subdirs(run_dir: Path) -> list[str]:
+    """Return eval dirs with metrics for a single run directory."""
+    if not run_dir.exists():
+        return []
+    eval_subdirs = []
+    for child in run_dir.iterdir():
+        if (
+            child.is_dir()
+            and _is_eval_metrics_dir(child)
+            and (child / "evaluation_metrics.csv").exists()
+        ):
+            eval_subdirs.append(normalize_eval_subdir(child.name))
+    return sorted(set(eval_subdirs), key=_eval_sort_key)
+
+
+def _select_default_eval_subdir(eval_subdirs: list[str]) -> str:
+    """Pick the eval subdir used for automatic one-row-per-run discovery."""
+    if DEFAULT_EVAL_SUBDIR in eval_subdirs:
+        return DEFAULT_EVAL_SUBDIR
+    return eval_subdirs[0]
+
+
+def _format_available_eval_subdirs(
+    eval_subdirs: list[str],
+    max_items: int = 3,
+) -> str:
+    """Format eval variants compactly for ``--list`` output."""
+    if not eval_subdirs:
+        return ""
+    if len(eval_subdirs) <= max_items:
+        return ", ".join(eval_subdirs)
+    shown = ", ".join(eval_subdirs[:max_items])
+    return f"{shown}, ... (+{len(eval_subdirs) - max_items})"
+
+
 def _discover_run_targets(results_dir: Path) -> list[RunTarget]:
-    """Recursively discover runs with a default eval metrics CSV."""
+    """Recursively discover one default eval target per run."""
     targets = []
-    for metrics_csv in results_dir.rglob("evaluation_metrics.csv"):
-        eval_dir = metrics_csv.parent
-        if eval_dir.name != DEFAULT_EVAL_SUBDIR:
+    for config_file in results_dir.rglob("resolved_config.yaml"):
+        run_dir = config_file.parent
+        eval_subdirs = _available_eval_subdirs(run_dir)
+        if not eval_subdirs:
             continue
-        run_dir = eval_dir.parent
+        eval_subdir = _select_default_eval_subdir(eval_subdirs)
         relative_path = _run_relative_path(results_dir, run_dir, run_id=None)
+        ref = (
+            run_dir.name
+            if eval_subdir == DEFAULT_EVAL_SUBDIR
+            else f"{run_dir.name}::eval={eval_subdir}"
+        )
         targets.append(
             RunTarget(
                 path=run_dir,
-                eval_subdir=DEFAULT_EVAL_SUBDIR,
-                ref=run_dir.name,
+                eval_subdir=eval_subdir,
+                ref=ref,
                 relative_path=relative_path,
             )
         )
@@ -2473,8 +2536,9 @@ def plot_lead_time_panel(  # noqa: PLR0912, PLR0915
     """Plot per-metric, per-dataset lead-time curves as a panel figure.
 
     ``error_ylim`` overrides auto y-limits for non-coverage rows.
-    ``coverage_ylim`` overrides coverage rows; otherwise raw coverage stays
-    fixed at [0, 1] and coverage-delta rows use symmetric auto limits.
+    ``coverage_ylim`` overrides empirical coverage rows; otherwise coverage
+    curves stay fixed at [0, 1] and coverage-delta rows use symmetric auto
+    limits.
     Either bound may be ``None``.
     When ``axes`` is provided, draw into that pre-made grid with shape
     (len(metrics_to_plot), n_datasets).
@@ -2576,7 +2640,7 @@ def plot_lead_time_panel(  # noqa: PLR0912, PLR0915
         for c, ds_label in enumerate(datasets):
             ax = axes[r][c]
             ds = sub[sub["dataset_label"] == ds_label]
-            is_cov = metric == "coverage" or metric.startswith("coverage_")
+            is_cov = _is_empirical_coverage_metric(metric)
             is_ssr = metric == "ssr"
             is_cov_delta = bool(coverage_delta and is_cov)
             cov_target: float | None = None
@@ -4881,13 +4945,15 @@ def main():  # noqa: PLR0912, PLR0915
         print(f"Loading {len(run_targets)} runs...")
         m_rows = []
         for target in run_targets:
-            m_rows.append(
-                load_config_metadata(
-                    target.path,
-                    eval_subdir=target.eval_subdir,
-                    run_ref=target.ref,
-                )
+            row = load_config_metadata(
+                target.path,
+                eval_subdir=target.eval_subdir,
+                run_ref=target.ref,
             )
+            row["available_evals"] = _format_available_eval_subdirs(
+                _available_eval_subdirs(target.path)
+            )
+            m_rows.append(row)
         mdf = pd.DataFrame(m_rows)
 
         if mdf.empty:
@@ -4942,6 +5008,7 @@ def main():  # noqa: PLR0912, PLR0915
 
         show_cols = [
             "run_name",
+            "available_evals",
             "dataset_label",
             "processor",
             "resolution",
@@ -4966,6 +5033,7 @@ def main():  # noqa: PLR0912, PLR0915
 
         renames = {
             "run_name": "Run",
+            "available_evals": "Evals",
             "dataset_label": "Dataset",
             "processor": "Model",
             "resolution": "Resolution",

--- a/src/autocast/scripts/utils.py
+++ b/src/autocast/scripts/utils.py
@@ -359,7 +359,30 @@ class RunCollator:
 
         return info
 
-    def _parse_metrics(self, run_dir: Path) -> dict[str, Any]:
+    def _extract_dataset_from_config(self, config: dict) -> str | None:
+        """Extract dataset name from config (datamodule or dataset).
+
+        Mirrors infer_dataset_from_workdir logic for use when config is already loaded.
+        """
+        datamodule_cfg = config.get("datamodule")
+        if isinstance(datamodule_cfg, str):
+            return datamodule_cfg
+        if isinstance(datamodule_cfg, dict):
+            dataset_name = datamodule_cfg.get("dataset")
+            if isinstance(dataset_name, str) and dataset_name:
+                return dataset_name
+            data_path = datamodule_cfg.get("data_path")
+            if data_path is not None:
+                try:
+                    return Path(str(data_path)).name
+                except (TypeError, ValueError):
+                    pass
+        top_level = config.get("dataset")
+        if isinstance(top_level, str) and top_level:
+            return top_level
+        return None
+
+    def _parse_metrics(self, run_dir: Path) -> dict[str, Any]:  # noqa: PLR0912
         """Parse both evaluation_metrics.csv and rollout_metrics.csv.
 
         Parameters
@@ -374,6 +397,9 @@ class RunCollator:
         """
         metrics: dict[str, Any] = {}
 
+        # Base metric columns: support both scalar and multi-level coverage
+        base_cols = ["mse", "mae", "rmse", "vrmse"]
+
         # Parse overall metrics
         eval_csv = run_dir / "eval" / "evaluation_metrics.csv"
         if eval_csv.exists():
@@ -384,11 +410,20 @@ class RunCollator:
                     (df_eval["window"] == "all") & (df_eval["batch_idx"] == "all")
                 ]
                 if not overall_row.empty:
-                    for col in ["mse", "mae", "rmse", "vrmse", "coverage"]:
+                    for col in base_cols:
                         if col in overall_row.columns:
-                            # Get the scalar value from the first row
                             value = overall_row.iloc[0][col]
                             metrics[f"overall_{col}"] = value
+                    # Coverage: support "coverage" or coverage_0.5, coverage_0.9, etc.
+                    cov_cols_found = [
+                        c
+                        for c in overall_row.columns
+                        if c == "coverage" or c.startswith("coverage_")
+                    ]
+                    for col in cov_cols_found:
+                        value = overall_row.iloc[0][col]
+                        suffix = col.replace("coverage", "", 1) or ""
+                        metrics[f"overall_coverage{suffix}"] = value
             except Exception as e:
                 self.log.warning(
                     "Failed to parse evaluation metrics from %s: %s", eval_csv, e
@@ -403,15 +438,75 @@ class RunCollator:
                 windowed = df_rollout[df_rollout["batch_idx"] == "all"]
                 for _, row in windowed.iterrows():
                     window = str(row["window"])
-                    for col in ["mse", "mae", "rmse", "vrmse", "coverage"]:
+                    for col in base_cols:
                         if col in row.index:
                             metrics[f"{col}_{window}"] = float(row[col])
+                    cov_cols_found = [
+                        c
+                        for c in row.index
+                        if c == "coverage"
+                        or (isinstance(c, str) and c.startswith("coverage_"))
+                    ]
+                    for col in cov_cols_found:
+                        try:
+                            val = row[col]
+                            if not isinstance(col, str):
+                                continue
+                            suffix = col.replace("coverage", "", 1) or ""
+                            metrics[f"coverage{suffix}_{window}"] = float(val)
+                        except (TypeError, ValueError):
+                            pass
             except Exception as e:
                 self.log.warning(
                     "Failed to parse rollout metrics from %s: %s", rollout_csv, e
                 )
 
         return metrics
+
+    def _parse_metadata_csvs(self, run_dir: Path) -> pd.DataFrame:
+        """Parse evaluation/rollout metadata CSVs for a single run.
+
+        Parameters
+        ----------
+        run_dir : Path
+            Path to the run directory.
+
+        Returns
+        -------
+        pd.DataFrame
+            Combined metadata DataFrame for the run. Empty if no metadata CSVs
+            are present or parseable.
+        """
+        metadata_frames: list[pd.DataFrame] = []
+
+        metadata_sources = {
+            "evaluation": run_dir / "eval" / "evaluation_metadata.csv",
+            "rollout": run_dir / "eval" / "rollout_metadata.csv",
+            "benchmark": run_dir / "eval" / "benchmark_metrics.csv",
+        }
+
+        for source_name, csv_path in metadata_sources.items():
+            if not csv_path.exists():
+                continue
+            try:
+                df_source = pd.read_csv(csv_path)
+                if df_source.empty:
+                    continue
+                df_source = df_source.copy()
+                df_source["metadata_source"] = source_name
+                metadata_frames.append(df_source)
+            except Exception as e:
+                self.log.warning("Failed to parse metadata CSV %s: %s", csv_path, e)
+
+        if not metadata_frames:
+            return pd.DataFrame()
+
+        df_metadata = pd.concat(metadata_frames, ignore_index=True)
+        run_metadata = self._extract_run_metadata(run_dir)
+        for key, value in run_metadata.items():
+            df_metadata[key] = value
+
+        return df_metadata
 
     def _process_single_run(self, run_dir: Path) -> dict[str, Any] | None:
         """Process a single run directory, handling errors gracefully.
@@ -437,6 +532,10 @@ class RunCollator:
                     config = yaml.safe_load(f)
                 config_info = self._extract_config_params(config)
                 run_data.update(config_info)
+                # Extract dataset from datamodule config
+                dataset = self._extract_dataset_from_config(config)
+                if dataset:
+                    run_data["dataset"] = dataset
             except Exception as e:
                 self.log.warning("Failed to parse config for %s: %s", run_dir.name, e)
                 # Continue with missing config info
@@ -481,7 +580,8 @@ class RunCollator:
         self,
         output_csv: str | Path = "collated_results.csv",
         save_csv: bool = True,
-    ) -> pd.DataFrame:
+        include_metadata_dataframes: bool = False,
+    ) -> pd.DataFrame | tuple[pd.DataFrame, dict[str, pd.DataFrame]]:
         """Collate results from multiple runs in the outputs directory.
 
         Parameters
@@ -490,11 +590,17 @@ class RunCollator:
             Path where the CSV file will be saved.
         save_csv : bool, default=True
             Whether to save the DataFrame to CSV.
+        include_metadata_dataframes : bool, default=False
+            Whether to also return per-run metadata DataFrames loaded from
+            ``eval/evaluation_metadata.csv`` and ``eval/rollout_metadata.csv``.
 
         Returns
         -------
-        pd.DataFrame
-            DataFrame with columns for run metadata and metrics.
+        pd.DataFrame | tuple[pd.DataFrame, dict[str, pd.DataFrame]]
+            If ``include_metadata_dataframes`` is False, returns the collated
+            metrics DataFrame. If True, returns a tuple of:
+            1) collated metrics DataFrame
+            2) dict mapping run_path -> metadata DataFrame for that run
         """
         # Discover runs
         runs = self._discover_runs()
@@ -502,10 +608,17 @@ class RunCollator:
 
         # Process each run
         results = []
+        metadata_by_run: dict[str, pd.DataFrame] = {}
         for run_dir in runs:
             run_data = self._process_single_run(run_dir)
             if run_data is not None:
                 results.append(run_data)
+
+                if include_metadata_dataframes:
+                    run_path = str(run_dir.relative_to(self.outputs_path))
+                    df_metadata = self._parse_metadata_csvs(run_dir)
+                    if not df_metadata.empty:
+                        metadata_by_run[run_path] = df_metadata
 
         # Create DataFrame
         df = pd.DataFrame(results)
@@ -516,6 +629,9 @@ class RunCollator:
             output_path = Path(output_csv).expanduser().resolve()
             self._save_results(df, output_path)
 
+        if include_metadata_dataframes:
+            return df, metadata_by_run
+
         return df
 
 
@@ -524,7 +640,8 @@ def collate_run_results(
     output_csv: str | Path = "collated_results.csv",
     save_csv: bool = True,
     config_params: dict[str, str] | None = None,
-) -> pd.DataFrame:
+    include_metadata_dataframes: bool = False,
+) -> pd.DataFrame | tuple[pd.DataFrame, dict[str, pd.DataFrame]]:
     """Collate results from multiple runs in the outputs directory.
 
     This is a convenience function that creates a RunCollator instance
@@ -541,11 +658,134 @@ def collate_run_results(
     config_params : dict[str, str] | None, default=None
         Dictionary mapping output column names to config paths (dot notation).
         If None, uses default parameters.
+    include_metadata_dataframes : bool, default=False
+        Whether to also return per-run metadata DataFrames loaded from
+        ``eval/evaluation_metadata.csv`` and ``eval/rollout_metadata.csv``.
 
     Returns
     -------
-    pd.DataFrame
-        DataFrame with columns for run metadata and metrics.
+    pd.DataFrame | tuple[pd.DataFrame, dict[str, pd.DataFrame]]
+        If ``include_metadata_dataframes`` is False, returns the collated
+        metrics DataFrame. If True, returns ``(metrics_df, metadata_by_run)``.
     """
     collator = RunCollator(outputs_dir=outputs_dir, config_params=config_params)
-    return collator.collate(output_csv=output_csv, save_csv=save_csv)
+    return collator.collate(
+        output_csv=output_csv,
+        save_csv=save_csv,
+        include_metadata_dataframes=include_metadata_dataframes,
+    )
+
+
+def flatten_metadata_by_run(
+    metadata_by_run: dict[str, pd.DataFrame],
+) -> pd.DataFrame:
+    """Flatten per-run metadata frames into one wide row per run.
+
+    This helper is intended for notebooks/analysis. It consumes the dict returned
+    by ``RunCollator.collate(include_metadata_dataframes=True)`` and produces a
+    wide DataFrame with columns such as:
+    - training time: ``train_total_s``, ``train_mean_epoch_s``
+    - params: ``params_model_total``, ``params_model_trainable``, etc.
+    - benchmark: ``model_latency_ms_per_sample``, ``model_throughput_samples_per_sec``,
+      ``model_gflops_per_sample``, and analogous ``rollout_*`` fields
+
+    Notes
+    -----
+    - If multiple benchmark rows exist for the same (benchmark_type, metric),
+      values are averaged.
+    - Only rows with ``window == 'meta'`` and ``batch_idx == 'all'`` are used for
+      evaluation/rollout metadata.
+    """
+    rows: list[dict[str, Any]] = []
+    for run_path, df_meta in metadata_by_run.items():
+        if df_meta is None or df_meta.empty:
+            rows.append({"run_path": run_path})
+            continue
+
+        row: dict[str, Any] = {"run_path": run_path}
+
+        # Carry through identifiers when present.
+        for col in ["run_name", "date"]:
+            if col in df_meta.columns:
+                vals = df_meta[col].dropna().unique()
+                if len(vals) > 0:
+                    row[col] = vals[0]
+
+        # evaluation / rollout metadata: long format (category, metric, value)
+        if "metadata_source" in df_meta.columns and "value" in df_meta.columns:
+            mask_base = True
+            if "window" in df_meta.columns:
+                mask_base = mask_base & (df_meta["window"] == "meta")
+            if "batch_idx" in df_meta.columns:
+                mask_base = mask_base & (df_meta["batch_idx"] == "all")
+
+            df_er = df_meta[
+                mask_base
+                & df_meta["metadata_source"].isin(["evaluation", "rollout"])
+                & df_meta["category"].notna()
+                & df_meta["metric"].notna()
+            ].copy()
+            if not df_er.empty:
+                df_er["key"] = (
+                    df_er["metadata_source"].astype(str)
+                    + "_"
+                    + df_er["category"].astype(str)
+                    + "_"
+                    + df_er["metric"].astype(str)
+                )
+                wide = (
+                    df_er.groupby("key", as_index=True)["value"]
+                    .mean(numeric_only=True)
+                    .to_dict()
+                )
+                row.update(wide)
+
+        # benchmark metadata: long-ish format (benchmark_type, metric, value)
+        if (
+            "metadata_source" in df_meta.columns
+            and "benchmark_type" in df_meta.columns
+            and "metric" in df_meta.columns
+            and "value" in df_meta.columns
+        ):
+            df_bench = df_meta[
+                (df_meta["metadata_source"] == "benchmark")
+                & df_meta["benchmark_type"].notna()
+                & df_meta["metric"].notna()
+                & df_meta["value"].notna()
+            ].copy()
+        else:
+            df_bench = pd.DataFrame()
+        if not df_bench.empty:
+            df_bench["key"] = (
+                df_bench["benchmark_type"].astype(str)
+                + "_"
+                + df_bench["metric"].astype(str)
+            )
+            wide = (
+                df_bench.groupby("key", as_index=True)["value"]
+                .mean(numeric_only=True)
+                .to_dict()
+            )
+            row.update(wide)
+
+        rows.append(row)
+
+    df_wide = pd.DataFrame(rows)
+
+    # Friendly aliases for commonly used metrics (if present).
+    rename_map = {
+        "evaluation_runtime_train_total_s": "train_total_s",
+        "evaluation_runtime_train_mean_epoch_s": "train_mean_epoch_s",
+        "evaluation_runtime_train_min_epoch_s": "train_min_epoch_s",
+        "evaluation_runtime_train_max_epoch_s": "train_max_epoch_s",
+        "evaluation_params_model_total": "params_model_total",
+        "evaluation_params_model_trainable": "params_model_trainable",
+        "evaluation_params_encoder_total": "params_encoder_total",
+        "evaluation_params_decoder_total": "params_decoder_total",
+        "evaluation_params_processor_total": "params_processor_total",
+    }
+    df_wide = df_wide.rename(
+        columns={k: v for k, v in rename_map.items() if k in df_wide.columns}
+    )
+
+    return df_wide

--- a/src/autocast/utils/plots.py
+++ b/src/autocast/utils/plots.py
@@ -912,7 +912,7 @@ def plot_coverage(
     title: str = "Coverage plot",
 ):
     """
-    Plot reliability diagram showing expected vs observed coverage.
+    Plot reliability diagram showing nominal vs empirical coverage.
 
     This is a convenience wrapper around MultiCoverage.plot().
 

--- a/tests/metrics/test_coverage.py
+++ b/tests/metrics/test_coverage.py
@@ -42,6 +42,23 @@ def test_multi_alpha_coverage_dict_keys_and_values():
         assert torch.isclose(torch.tensor(value), torch.tensor(1.0))
 
 
+def test_multicoverage_plot_uses_nominal_and_empirical_labels():
+    y_pred: TensorBTSC = torch.ones((2, 3, 4, 4, 5, 6))
+    y_true: TensorBTSC = torch.ones((2, 3, 4, 4, 5))
+
+    metric = MultiCoverage(coverage_levels=[0.5, 0.9])
+    metric.update(y_pred, y_true)
+
+    fig = metric.plot(save_csv=False)
+    ax = fig.axes[0]
+
+    assert ax.get_xlabel() == r"Nominal coverage (1 - $\alpha$)"
+    assert ax.get_ylabel() == "Empirical coverage"
+    legend = ax.get_legend()
+    assert legend is not None
+    assert "Nominal" in [text.get_text() for text in legend.get_texts()]
+
+
 def test_coverage_partial():
     # Setup: 1 batch, 1 time, 4 spatial points, 1 channel, 10 ensemble members
     # y_pred ensemble values: 0, 1, ..., 9
@@ -64,7 +81,7 @@ def test_coverage_partial():
 
     value = Coverage(coverage_level=0.8)(y_pred, y_true)
 
-    # expected coverage: 2 out of 4 -> 0.5
+    # observed coverage: 2 out of 4 -> 0.5
     assert torch.allclose(value, torch.tensor(0.5))
 
 

--- a/tests/scripts/test_eval_encoder_processor_decoder.py
+++ b/tests/scripts/test_eval_encoder_processor_decoder.py
@@ -19,6 +19,7 @@ from autocast.scripts.eval.encoder_processor_decoder import (
     _build_per_timestep_metric_factory,
     _decode_tensor,
     _maybe_swap_to_ambient_datamodule,
+    _metric_window_interval_label,
     _normalize_eval_mode,
     _normalize_per_batch_rows,
     _reindex_per_batch_rows_by_rank,
@@ -38,6 +39,12 @@ from autocast.scripts.eval.encoder_processor_decoder import (
 )
 from autocast.types import Batch, EncodedBatch
 from autocast.utils.plots import _panel_size_for_width
+
+
+def test_metric_window_interval_label_uses_closed_open_notation():
+    assert _metric_window_interval_label(None) == "all"
+    assert _metric_window_interval_label((0, 4)) == "[0:4)"
+    assert _metric_window_interval_label((31, 99)) == "[31:99)"
 
 
 def test_resolve_rollout_batch_limit_falls_back_to_test_limit_when_null():

--- a/tests/scripts/test_plot_dataset_comparisons.py
+++ b/tests/scripts/test_plot_dataset_comparisons.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -639,6 +640,46 @@ def test_format_available_eval_subdirs_truncates_long_lists():
         )
         == "eval, eval_0p50, eval_0p75, ... (+1)"
     )
+
+
+def test_paper_only_skips_single_step_table(monkeypatch, tmp_path: Path):
+    results_dir = tmp_path / "outputs"
+    output_dir = tmp_path / "plots"
+    run_name = "crps_ad64_vit_azula_large_abcd123_ef45678"
+    run_dir = results_dir / run_name
+    eval_dir = run_dir / "eval"
+    eval_dir.mkdir(parents=True)
+    (run_dir / "resolved_config.yaml").write_text(
+        "datamodule:\n  data_path: /tmp/ad64\ntrainer:\n  max_epochs: 1\n"
+    )
+    pd.DataFrame([{"window": "all", "batch_idx": "all", "vrmse": 0.1}]).to_csv(
+        eval_dir / "evaluation_metrics.csv", index=False
+    )
+
+    def fail_table_write(*_args: Any, **_kwargs: Any) -> None:
+        msg = "paper-only mode should not write standard single-step tables"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(pdc, "write_single_step_results_table", fail_table_write)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "autocast-plots",
+            "--results-dir",
+            str(results_dir),
+            "--output-dir",
+            str(output_dir),
+            "--run",
+            run_name,
+            "--paper-only",
+        ],
+    )
+
+    pdc.main()
+
+    assert not (output_dir / "single_step_overall_results.csv").exists()
+    assert not (output_dir / "single_step_overall_results.tex").exists()
 
 
 def test_load_single_run_metrics_uses_cache_before_wandb(

--- a/tests/scripts/test_plot_dataset_comparisons.py
+++ b/tests/scripts/test_plot_dataset_comparisons.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.figure import Figure
+
+from autocast.scripts import plot_dataset_comparisons as pdc
+
+
+def test_default_plot_metrics_include_overall_crps_and_ssr():
+    assert pdc.DEFAULT_PLOT_METRICS == ("vrmse", "coverage", "crps", "ssr")
+
+    err_metric, cov_metric = pdc._derive_lead_time_metrics(
+        list(pdc.DEFAULT_PLOT_METRICS)
+    )
+
+    assert err_metric == ["vrmse", "crps", "rmse"]
+    assert cov_metric == ["coverage", "coverage_0.9", "coverage_0.5", "ssr"]
+
+
+def test_overall_ssr_bars_are_linear_and_ignore_error_ylim():
+    error_ylim = (1e-5, 1.0)
+
+    assert pdc._overall_or_window_bar_yscale("ssr") == "linear"
+    assert pdc._overall_or_window_bar_ylim("ssr", error_ylim) is None
+    assert pdc._overall_or_window_bar_ref_value("ssr") == 1.0
+    assert pdc._overall_or_window_bar_ylim("crps", error_ylim) == error_ylim
+    assert pdc._overall_or_window_bar_ref_value("crps") is None
+
+
+def test_panel_figure_renders_all_requested_overall_metrics(
+    monkeypatch,
+    tmp_path: Path,
+):
+    calls: list[dict[str, Any]] = []
+
+    def fake_grouped_bar(
+        _df_in: pd.DataFrame,
+        metric: str,
+        title: str,
+        _ylabel: str,
+        _out_dir: Path,
+        _styles: dict[str, Any],
+        **kwargs: Any,
+    ) -> None:
+        calls.append(
+            {
+                "metric": metric,
+                "y_scale": kwargs.get("y_scale"),
+                "ylim": kwargs.get("ylim"),
+                "ref_value": kwargs.get("ref_value"),
+            }
+        )
+        kwargs["ax"].set_title(title)
+
+    def noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    def fake_save_fig(fig: Figure, _out_dir: Path, _name: str) -> None:
+        plt.close(fig)
+
+    monkeypatch.setattr(pdc, "grouped_bar", fake_grouped_bar)
+    monkeypatch.setattr(pdc, "plot_training_curves", noop)
+    monkeypatch.setattr(pdc, "plot_coverage_calibration_panel", noop)
+    monkeypatch.setattr(pdc, "plot_lead_time_panel", noop)
+    monkeypatch.setattr(pdc, "save_fig", fake_save_fig)
+
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "run_path": ["run"],
+            "eval_subdir": ["eval"],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+
+    pdc.plot_panel_figure(
+        df,
+        tmp_path,
+        tmp_path,
+        styles,
+        overall_metrics=("vrmse", "coverage", "crps", "ssr"),
+        error_metrics=["vrmse"],
+        coverage_metrics=["coverage_0.9", "ssr"],
+        training_metrics=[],
+        error_ylim=(1e-5, 1.0),
+    )
+
+    assert [c["metric"] for c in calls] == [
+        "overall_vrmse",
+        "overall_coverage",
+        "overall_crps",
+        "overall_ssr",
+    ]
+    assert calls[-1]["y_scale"] == "linear"
+    assert calls[-1]["ylim"] is None
+    assert calls[-1]["ref_value"] == 1.0
+
+
+def test_grouped_bar_draws_requested_reference_line(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "overall_ssr": [0.8],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+    fig, ax = plt.subplots()
+
+    pdc.grouped_bar(
+        df,
+        "overall_ssr",
+        "Overall SSR",
+        "SSR",
+        tmp_path,
+        styles,
+        y_scale="linear",
+        ax=ax,
+        save=False,
+        ref_value=1.0,
+    )
+
+    ref_lines = [
+        line
+        for line in ax.lines
+        if np.asarray(line.get_ydata(), dtype=float).tolist() == [1.0, 1.0]
+        and line.get_linestyle() == ":"
+    ]
+    assert len(ref_lines) == 1
+    plt.close(fig)
+
+
+def test_grouped_bar_can_scale_axis_labels_with_ticks(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "overall_vrmse": [0.1],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+    fig, ax = plt.subplots()
+
+    pdc.grouped_bar(
+        df,
+        "overall_vrmse",
+        "Overall VRMSE",
+        "VRMSE",
+        tmp_path,
+        styles,
+        ax=ax,
+        save=False,
+        tick_label_scale=1.5,
+        axis_label_scale=1.5,
+    )
+
+    assert ax.yaxis.label.get_fontsize() == 15.0
+    assert ax.xaxis.get_ticklabels()[0].get_fontsize() == 15.0
+    plt.close(fig)
+
+
+def test_single_step_results_table_uses_grouped_bar_means():
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD", "AD", "AD"],
+            "plot_group": ["crps", "crps", "fm"],
+            "overall_vrmse": [1.0, 3.0, 2.0],
+            "overall_crps": [0.1, 0.3, 0.2],
+            "overall_ssr": [0.8, 1.0, 1.1],
+            "model_latency_ms_per_sample": [10.0, 14.0, 8.0],
+            "train_total_s": [3600.0, 7200.0, 1800.0],
+            "train_mean_epoch_s": [100.0, 200.0, 50.0],
+        }
+    )
+    styles = {
+        "crps": {"label": "CRPS", "color": "tab:blue"},
+        "fm": {"label": "FM", "color": "tab:orange"},
+    }
+
+    table = pdc.build_single_step_results_table(
+        df,
+        styles,
+        dataset_order=["AD"],
+        hue_order=["CRPS", "FM"],
+    )
+
+    assert table["Model"].tolist() == ["CRPS", "FM"]
+    assert table.loc[0, "VRMSE"] == 2.0
+    assert table.loc[0, "CRPS"] == 0.2
+    assert table.loc[0, "SSR"] == 0.9
+    assert table.loc[0, "Inference latency (ms/sample)"] == 12.0
+    assert "Training time (h)" not in table.columns
+    assert table.loc[0, "Training time (s/epoch)"] == 150.0
+
+
+def test_single_step_results_latex_uses_two_sig_figs(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["crps"],
+            "overall_vrmse": [0.012345],
+            "overall_crps": [0.098765],
+        }
+    )
+    styles = {"crps": {"label": "CRPS", "color": "tab:blue"}}
+
+    pdc.write_single_step_results_table(df, tmp_path, styles)
+
+    tex = (tmp_path / "single_step_overall_results.tex").read_text()
+    assert r"\begin{tabular}{@{}l" in tex
+    assert r"Latency\\(ms/sample)" in tex
+    assert r"\small" not in tex
+    assert "1.2e-02" in tex
+    assert "9.9e-02" in tex
+    assert "0.012345" not in tex
+    assert "0.098765" not in tex
+
+
+def test_single_step_results_latex_midrule_aligns_with_dataset_boundaries():
+    """Booktabs lines: header midrule + one midrule between dataset blocks."""
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD", "AD", "CNS", "CNS"],
+            "plot_group": ["crps", "fm", "crps", "fm"],
+            "overall_vrmse": [0.2, 0.1, 0.3, 0.4],
+            "overall_coverage": [0.05, 0.06, 0.07, 0.08],
+            "overall_crps": [0.05, 0.06, 0.08, 0.07],
+            "overall_ssr": [0.7, 1.2, 1.1, 0.6],
+            "model_latency_ms_per_sample": [12.0, 8.0, 9.0, 11.0],
+            "train_mean_epoch_s": [100.0, 200.0, 150.0, 50.0],
+        }
+    )
+    styles = {
+        "crps": {"label": "CRPS", "color": "tab:blue"},
+        "fm": {"label": "FM", "color": "tab:orange"},
+    }
+    table = pdc.build_single_step_results_table(
+        df,
+        styles,
+        dataset_order=["AD", "CNS"],
+        hue_order=["CRPS", "FM"],
+    )
+    tex = pdc.render_single_step_results_latex(table)
+    assert tex.count(r"\midrule") == 2
+    assert tex.index(r"\toprule") < tex.index(r"\midrule")
+    last_mid = tex.rindex(r"\midrule")
+    assert last_mid < tex.index(r"\bottomrule")
+    assert "\\midrule\nCNS & CRPS" in tex
+
+
+def test_single_step_results_latex_bolds_best_values_by_dataset(tmp_path: Path):
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD", "AD", "CNS", "CNS"],
+            "plot_group": ["crps", "fm", "crps", "fm"],
+            "overall_vrmse": [0.2, 0.1, 0.3, 0.4],
+            "overall_crps": [0.05, 0.06, 0.08, 0.07],
+            "overall_ssr": [0.7, 1.2, 1.1, 0.6],
+            "model_latency_ms_per_sample": [12.0, 8.0, 9.0, 11.0],
+            "train_total_s": [3600.0, 7200.0, 5400.0, 1800.0],
+            "train_mean_epoch_s": [100.0, 200.0, 150.0, 50.0],
+        }
+    )
+    styles = {
+        "crps": {"label": "CRPS", "color": "tab:blue"},
+        "fm": {"label": "FM", "color": "tab:orange"},
+    }
+
+    pdc.write_single_step_results_table(
+        df,
+        tmp_path,
+        styles,
+        dataset_order=["AD", "CNS"],
+        hue_order=["CRPS", "FM"],
+    )
+
+    tex = (tmp_path / "single_step_overall_results.tex").read_text()
+    # siunitx S columns use \bfseries (not \textbf{...}) for detect-weight cells
+    assert r"\bfseries 1.0e-01" in tex
+    assert r"\bfseries 5.0e-02" in tex
+    assert r"\bfseries 1.20" in tex
+    assert r"\bfseries 7.0e-02" in tex
+    assert r"\bfseries 1.10" in tex
+
+
+def test_coverage_calibration_panel_uses_publication_axis_labels(tmp_path: Path):
+    eval_dir = tmp_path / "run1" / "eval"
+    eval_dir.mkdir(parents=True)
+    coverage = pd.DataFrame(
+        {
+            "coverage_level": [0.1, 0.5, 0.9],
+            "observed_mean": [0.05, 0.4, 0.8],
+        }
+    )
+    coverage.to_csv(eval_dir / "test_coverage_window_all.csv", index=False)
+    coverage.to_csv(eval_dir / "rollout_coverage_window_0-4.csv", index=False)
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "run_path": ["run1"],
+            "eval_subdir": ["eval"],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+
+    fig = pdc.plot_coverage_calibration_panel(
+        df,
+        tmp_path,
+        tmp_path,
+        styles,
+        window_rows=["all", "0-4"],
+        save=False,
+    )
+
+    assert isinstance(fig, Figure)
+    axes = fig.axes
+    assert axes[0].get_ylabel() == "Empirical coverage"
+    assert axes[1].get_ylabel() == "Empirical coverage [0:4)"
+    assert axes[1].get_xlabel() == r"Nominal coverage (1 - $\alpha$)"
+    # Perfect-calibration reference: y = x from (0, 0) to (1, 1), drawn first
+    xd = axes[0].lines[0].get_xdata()
+    yd = axes[0].lines[0].get_ydata()
+    assert np.allclose(np.asarray(xd, dtype=float), np.array([0.0, 1.0]))
+    assert np.allclose(np.asarray(yd, dtype=float), np.array([0.0, 1.0]))
+    plt.close(fig)
+
+
+def test_coverage_calibration_panel_can_use_shared_xlabel_and_taller_height(
+    tmp_path: Path,
+):
+    eval_dir = tmp_path / "run1" / "eval"
+    eval_dir.mkdir(parents=True)
+    coverage = pd.DataFrame(
+        {
+            "coverage_level": [0.1, 0.5, 0.9],
+            "observed_mean": [0.05, 0.4, 0.8],
+        }
+    )
+    coverage.to_csv(eval_dir / "test_coverage_window_all.csv", index=False)
+    coverage.to_csv(eval_dir / "rollout_coverage_window_0-4.csv", index=False)
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "run_path": ["run1"],
+            "eval_subdir": ["eval"],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+
+    fig = pdc.plot_coverage_calibration_panel(
+        df,
+        tmp_path,
+        tmp_path,
+        styles,
+        window_rows=["all", "0-4"],
+        shared_axis_labels=True,
+        height_scale=1.5,
+        save=False,
+    )
+
+    assert isinstance(fig, Figure)
+    assert fig.get_size_inches()[1] == 2.3 * 2 * 1.5
+    assert fig.axes[1].get_xlabel() == ""
+    assert r"Nominal coverage (1 - $\alpha$)" in [text.get_text() for text in fig.texts]
+    plt.close(fig)
+
+
+def test_lead_time_coverage_delta_is_proportional(tmp_path: Path):
+    eval_dir = tmp_path / "run1" / "eval"
+    eval_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [[0.25, 0.75]],
+        index=pd.Index(["coverage_0.5"], name="metric"),
+        columns=pd.Index(["0", "1"]),
+    ).to_csv(eval_dir / "rollout_metrics_per_timestep_channel_all.csv")
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "run_path": ["run1"],
+            "eval_subdir": ["eval"],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+
+    fig = pdc.plot_lead_time_panel(
+        df,
+        ["coverage_0.5"],
+        tmp_path,
+        tmp_path,
+        "coverage_delta.png",
+        styles,
+        coverage_delta=True,
+        save=False,
+    )
+
+    assert isinstance(fig, Figure)
+    ax = fig.axes[0]
+    assert ax.get_ylabel() == ""
+    assert r"$\Delta$ empirical coverage (proportional)" in [
+        text.get_text() for text in fig.texts
+    ]
+    assert np.asarray(ax.lines[0].get_ydata(), dtype=float).tolist() == [-0.5, 0.5]
+    plt.close(fig)
+
+
+def test_short_axis_labels_use_compact_shared_coverage_delta(tmp_path: Path):
+    eval_dir = tmp_path / "run1" / "eval"
+    eval_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [[0.25, 0.75]],
+        index=pd.Index(["coverage_0.5"], name="metric"),
+        columns=pd.Index(["0", "1"]),
+    ).to_csv(eval_dir / "rollout_metrics_per_timestep_channel_all.csv")
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "run_path": ["run1"],
+            "eval_subdir": ["eval"],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+
+    fig = pdc.plot_lead_time_panel(
+        df,
+        ["coverage_0.5"],
+        tmp_path,
+        tmp_path,
+        "coverage_delta.png",
+        styles,
+        coverage_delta=True,
+        short_axis_labels=True,
+        save=False,
+    )
+
+    assert isinstance(fig, Figure)
+    assert r"Rel. $\Delta$ empirical coverage" in [
+        text.get_text() for text in fig.texts
+    ]
+    plt.close(fig)
+
+
+def test_lead_time_error_labels_are_uppercase(tmp_path: Path):
+    eval_dir = tmp_path / "run1" / "eval"
+    eval_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [[1.0, 2.0]],
+        index=pd.Index(["vrmse"], name="metric"),
+        columns=pd.Index(["0", "1"]),
+    ).to_csv(eval_dir / "rollout_metrics_per_timestep_channel_all.csv")
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "run_path": ["run1"],
+            "eval_subdir": ["eval"],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+
+    fig = pdc.plot_lead_time_panel(
+        df,
+        ["vrmse"],
+        tmp_path,
+        tmp_path,
+        "lead_time.png",
+        styles,
+        save=False,
+    )
+
+    assert isinstance(fig, Figure)
+    assert fig.axes[0].get_ylabel() == "VRMSE"
+    plt.close(fig)

--- a/tests/scripts/test_plot_dataset_comparisons.py
+++ b/tests/scripts/test_plot_dataset_comparisons.py
@@ -18,8 +18,8 @@ def test_default_plot_metrics_include_overall_crps_and_ssr():
         list(pdc.DEFAULT_PLOT_METRICS)
     )
 
-    assert err_metric == ["vrmse", "crps", "rmse"]
-    assert cov_metric == ["coverage", "coverage_0.9", "coverage_0.5", "ssr"]
+    assert err_metric == ["vrmse", "coverage", "crps", "rmse"]
+    assert cov_metric == ["coverage_0.9", "coverage_0.5", "ssr"]
 
 
 def test_overall_ssr_bars_are_linear_and_ignore_error_ylim():
@@ -446,6 +446,44 @@ def test_lead_time_coverage_ylim_applies_to_standalone_panel(tmp_path: Path):
     plt.close(fig)
 
 
+def test_lead_time_generic_coverage_is_error_metric(tmp_path: Path):
+    eval_dir = tmp_path / "run1" / "eval"
+    eval_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [[0.02, 0.04]],
+        index=pd.Index(["coverage"], name="metric"),
+        columns=pd.Index(["0", "1"]),
+    ).to_csv(eval_dir / "rollout_metrics_per_timestep_channel_all.csv")
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "run_path": ["run1"],
+            "eval_subdir": ["eval"],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+
+    fig = pdc.plot_lead_time_panel(
+        df,
+        ["coverage"],
+        tmp_path,
+        tmp_path,
+        "coverage_mae.png",
+        styles,
+        coverage_ylim=(0.2, 0.8),
+        yscale="linear",
+        save=False,
+    )
+
+    assert isinstance(fig, Figure)
+    ax = fig.axes[0]
+    assert ax.get_ylabel() == "Coverage MAE"
+    assert ax.get_ylim() != (0.2, 0.8)
+    assert np.asarray(ax.lines[0].get_ydata(), dtype=float).tolist() == [0.02, 0.04]
+    plt.close(fig)
+
+
 def test_short_axis_labels_use_compact_shared_coverage_delta(tmp_path: Path):
     eval_dir = tmp_path / "run1" / "eval"
     eval_dir.mkdir(parents=True)
@@ -520,8 +558,10 @@ def test_run_target_preserves_nested_relative_paths(tmp_path: Path):
     results_dir = tmp_path / "outputs"
     run_id = "2026-05-01/crps_ad64_vit_azula_large_abcd123_ef45678"
     run_dir = results_dir / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "resolved_config.yaml").write_text("datamodule: {}\n")
     eval_dir = run_dir / "eval"
-    eval_dir.mkdir(parents=True)
+    eval_dir.mkdir()
     pd.DataFrame([{"window": "all", "batch_idx": "all", "vrmse": 0.1}]).to_csv(
         eval_dir / "evaluation_metrics.csv", index=False
     )
@@ -537,6 +577,68 @@ def test_run_target_preserves_nested_relative_paths(tmp_path: Path):
     assert target.relative_path == run_id
     assert row["run_path"] == run_id
     assert row["run_name"] == "crps_ad64_vit_azula_large_abcd123_ef45678"
+
+
+def test_discover_run_targets_defaults_to_one_eval_per_run(tmp_path: Path):
+    results_dir = tmp_path / "outputs"
+    run_dir = results_dir / "2026-05-01" / "crps_ad64_vit_abcd123_ef45678"
+    run_dir.mkdir(parents=True)
+    (run_dir / "resolved_config.yaml").write_text("datamodule: {}\n")
+    for eval_subdir in [
+        "eval",
+        "eval_best_multiwinkler_from0p25",
+        "eval_encode_once_ode001",
+    ]:
+        eval_dir = run_dir / eval_subdir
+        eval_dir.mkdir()
+        pd.DataFrame([{"window": "all", "batch_idx": "all", "vrmse": 0.1}]).to_csv(
+            eval_dir / "evaluation_metrics.csv", index=False
+        )
+    artifact_eval_dir = results_dir / "plots" / "copied" / "eval_extra"
+    artifact_eval_dir.mkdir(parents=True)
+    pd.DataFrame([{"window": "all", "batch_idx": "all", "vrmse": 0.1}]).to_csv(
+        artifact_eval_dir / "evaluation_metrics.csv", index=False
+    )
+
+    targets = pdc._discover_run_targets(results_dir)
+
+    assert [target.eval_subdir for target in targets] == ["eval"]
+    assert targets[0].relative_path == str(run_dir.relative_to(results_dir))
+    assert targets[0].ref == run_dir.name
+    assert pdc._available_eval_subdirs(run_dir) == [
+        "eval",
+        "eval_best_multiwinkler_from0p25",
+        "eval_encode_once_ode001",
+    ]
+    assert pdc._format_available_eval_subdirs(pdc._available_eval_subdirs(run_dir)) == (
+        "eval, eval_best_multiwinkler_from0p25, eval_encode_once_ode001"
+    )
+
+
+def test_discover_run_targets_uses_eval_postfix_when_default_missing(tmp_path: Path):
+    results_dir = tmp_path / "outputs"
+    run_dir = results_dir / "2026-05-01" / "crps_ad64_vit_abcd123_ef45678"
+    run_dir.mkdir(parents=True)
+    (run_dir / "resolved_config.yaml").write_text("datamodule: {}\n")
+    eval_dir = run_dir / "eval_encode_once_ode001"
+    eval_dir.mkdir()
+    pd.DataFrame([{"window": "all", "batch_idx": "all", "vrmse": 0.1}]).to_csv(
+        eval_dir / "evaluation_metrics.csv", index=False
+    )
+
+    [target] = pdc._discover_run_targets(results_dir)
+
+    assert target.eval_subdir == "eval_encode_once_ode001"
+    assert target.ref == f"{run_dir.name}::eval=eval_encode_once_ode001"
+
+
+def test_format_available_eval_subdirs_truncates_long_lists():
+    assert (
+        pdc._format_available_eval_subdirs(
+            ["eval", "eval_0p50", "eval_0p75", "eval_encode_once"]
+        )
+        == "eval, eval_0p50, eval_0p75, ... (+1)"
+    )
 
 
 def test_load_single_run_metrics_uses_cache_before_wandb(

--- a/tests/scripts/test_plot_dataset_comparisons.py
+++ b/tests/scripts/test_plot_dataset_comparisons.py
@@ -412,6 +412,40 @@ def test_lead_time_coverage_delta_is_proportional(tmp_path: Path):
     plt.close(fig)
 
 
+def test_lead_time_coverage_ylim_applies_to_standalone_panel(tmp_path: Path):
+    eval_dir = tmp_path / "run1" / "eval"
+    eval_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [[0.25, 0.75]],
+        index=pd.Index(["coverage_0.5"], name="metric"),
+        columns=pd.Index(["0", "1"]),
+    ).to_csv(eval_dir / "rollout_metrics_per_timestep_channel_all.csv")
+    df = pd.DataFrame(
+        {
+            "dataset_label": ["AD"],
+            "plot_group": ["model"],
+            "run_path": ["run1"],
+            "eval_subdir": ["eval"],
+        }
+    )
+    styles = {"model": {"color": "black", "label": "model", "linestyle": "-"}}
+
+    fig = pdc.plot_lead_time_panel(
+        df,
+        ["coverage_0.5"],
+        tmp_path,
+        tmp_path,
+        "coverage.png",
+        styles,
+        coverage_ylim=(0.2, 0.8),
+        save=False,
+    )
+
+    assert isinstance(fig, Figure)
+    assert fig.axes[0].get_ylim() == (0.2, 0.8)
+    plt.close(fig)
+
+
 def test_short_axis_labels_use_compact_shared_coverage_delta(tmp_path: Path):
     eval_dir = tmp_path / "run1" / "eval"
     eval_dir.mkdir(parents=True)
@@ -480,3 +514,49 @@ def test_lead_time_error_labels_are_uppercase(tmp_path: Path):
     assert isinstance(fig, Figure)
     assert fig.axes[0].get_ylabel() == "VRMSE"
     plt.close(fig)
+
+
+def test_run_target_preserves_nested_relative_paths(tmp_path: Path):
+    results_dir = tmp_path / "outputs"
+    run_id = "2026-05-01/crps_ad64_vit_azula_large_abcd123_ef45678"
+    run_dir = results_dir / run_id
+    eval_dir = run_dir / "eval"
+    eval_dir.mkdir(parents=True)
+    pd.DataFrame([{"window": "all", "batch_idx": "all", "vrmse": 0.1}]).to_csv(
+        eval_dir / "evaluation_metrics.csv", index=False
+    )
+
+    [target] = pdc._discover_run_targets(results_dir)
+    row = pdc.load_single_run_metrics(
+        target.path,
+        eval_subdir=target.eval_subdir,
+        run_ref=target.ref,
+        run_path=target.relative_path,
+    )
+
+    assert target.relative_path == run_id
+    assert row["run_path"] == run_id
+    assert row["run_name"] == "crps_ad64_vit_azula_large_abcd123_ef45678"
+
+
+def test_load_single_run_metrics_uses_cache_before_wandb(
+    monkeypatch,
+    tmp_path: Path,
+):
+    run_dir = tmp_path / "crps_ad64_vit_azula_large_abcd123_ef45678"
+    eval_dir = run_dir / "eval"
+    eval_dir.mkdir(parents=True)
+    pd.DataFrame([{"window": "all", "batch_idx": "all", "vrmse": 0.1}]).to_csv(
+        eval_dir / "evaluation_metrics.csv", index=False
+    )
+
+    def fail_wandb(*_args: Any, **_kwargs: Any) -> int | None:
+        msg = "W&B should not be queried without force_training_refresh"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(pdc, "_best_winkler_epoch_from_wandb", fail_wandb)
+
+    row = pdc.load_single_run_metrics(run_dir)
+
+    assert row["overall_vrmse"] == 0.1
+    assert "best_winkler_epoch" not in row

--- a/tests/scripts/test_utils.py
+++ b/tests/scripts/test_utils.py
@@ -1,5 +1,6 @@
 """Tests for autocast.scripts.utils module."""
 
+import pandas as pd
 import pytest
 
 from autocast.scripts.utils import RunCollator
@@ -329,3 +330,93 @@ def test_empty_pattern_parts(collator, sample_config):
     matches = collator._find_matching_paths(sample_config, "model.")
     # Should handle gracefully (implementation dependent)
     assert isinstance(matches, list)
+
+
+def test_parse_metadata_csvs_combines_sources(collator, tmp_path):
+    """Metadata parser should read and merge evaluation/rollout metadata CSVs."""
+    run_dir = tmp_path / "outputs" / "2026-02-24" / "test_run"
+    eval_dir = run_dir / "eval"
+    eval_dir.mkdir(parents=True)
+
+    pd.DataFrame(
+        [
+            {
+                "window": "meta",
+                "batch_idx": "all",
+                "category": "runtime",
+                "metric": "total_s",
+                "value": 1.23,
+            },
+        ]
+    ).to_csv(eval_dir / "evaluation_metadata.csv", index=False)
+
+    pd.DataFrame(
+        [
+            {
+                "window": "meta",
+                "batch_idx": "all",
+                "category": "runtime_rollout",
+                "metric": "total_s",
+                "value": 2.34,
+            },
+        ]
+    ).to_csv(eval_dir / "rollout_metadata.csv", index=False)
+
+    parsed = collator._parse_metadata_csvs(run_dir)
+
+    assert not parsed.empty
+    assert "metadata_source" in parsed.columns
+    assert set(parsed["metadata_source"].astype(str).unique()) == {
+        "evaluation",
+        "rollout",
+    }
+    assert "run_path" in parsed.columns
+    assert (parsed["run_name"] == "test_run").all()
+
+
+def test_collate_returns_metadata_dataframes_when_requested(collator, tmp_path):
+    """Collate should optionally return per-run metadata DataFrames."""
+    run_dir = tmp_path / "outputs" / "2026-02-24" / "run_abc"
+    eval_dir = run_dir / "eval"
+    eval_dir.mkdir(parents=True)
+
+    (run_dir / "resolved_config.yaml").write_text(
+        "model: {}\ndatamodule: {}\noptimizer: {}\n"
+    )
+
+    pd.DataFrame(
+        [
+            {
+                "window": "all",
+                "batch_idx": "all",
+                "mse": 0.1,
+                "mae": 0.2,
+                "rmse": 0.3,
+                "vrmse": 0.4,
+                "coverage": 0.5,
+            },
+        ]
+    ).to_csv(eval_dir / "evaluation_metrics.csv", index=False)
+
+    pd.DataFrame(
+        [
+            {
+                "window": "meta",
+                "batch_idx": "all",
+                "category": "runtime_eval",
+                "metric": "total_s",
+                "value": 9.99,
+            },
+        ]
+    ).to_csv(eval_dir / "evaluation_metadata.csv", index=False)
+
+    df_metrics, metadata_by_run = collator.collate(
+        save_csv=False,
+        include_metadata_dataframes=True,
+    )
+
+    assert not df_metrics.empty
+    assert "2026-02-24/run_abc" in metadata_by_run
+    df_metadata = metadata_by_run["2026-02-24/run_abc"]
+    assert not df_metadata.empty
+    assert "metadata_source" in df_metadata.columns

--- a/uv.lock
+++ b/uv.lock
@@ -184,6 +184,8 @@ dependencies = [
     { name = "lightning" },
     { name = "neuraloperator" },
     { name = "nvidia-ml-py" },
+    { name = "openpyxl" },
+    { name = "tabulate" },
     { name = "the-well" },
     { name = "timm" },
     { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
@@ -215,11 +217,13 @@ requires-dist = [
     { name = "lightning", specifier = ">=2.5.6" },
     { name = "neuraloperator", specifier = ">=2.0.0" },
     { name = "nvidia-ml-py", specifier = ">=13.595.45" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.4.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.407" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.4" },
+    { name = "tabulate", specifier = ">=0.10.0" },
     { name = "the-well", specifier = ">=1.1.0" },
     { name = "timm", specifier = ">=0.9" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32'", specifier = ">=2.9.1" },
@@ -595,6 +599,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/81/df4fbe24dff8ba3934af99044188e20a98ed441ad17a274539b74e82e126/einops-0.8.1.tar.gz", hash = "sha256:de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84", size = 54805, upload-time = "2025-02-09T03:17:00.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl", hash = "sha256:919387eb55330f5757c6bea9165c5ff5cfe63a642682ea788a6d472576d81737", size = 64359, upload-time = "2025-02-09T03:17:01.998Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -1621,6 +1634,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "opt-einsum"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2422,6 +2447,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Draft PR for the cleaned plotting CLI work.

This branch is based on 2026-04-20/plots and keeps the plotting CLI,
current plotting shell scripts, and result-collation changes needed for
the plotting workflow. Opened here for initial composition of the
plotting API - a streamlined refactor/reduction for the package would
likely be better (begun on [`plotting-cli-package`](https://github.com/alan-turing-institute/autocast/tree/plotting-cli-package)).

Validation:
- uv run ruff check src/autocast/scripts/plot_dataset_comparisons.py tests/scripts/test_plot_dataset_comparisons.py
- uv run pyright src/autocast/scripts/plot_dataset_comparisons.py tests/scripts/test_plot_dataset_comparisons.py
- uv run pytest tests/metrics/test_coverage.py tests/scripts/test_eval_encoder_processor_decoder.py tests/scripts/test_utils.py tests/scripts/test_plot_dataset_comparisons.py