### PR TITLE
Add wall-clock cosine LR schedule (scheduler_interval: time)

### DIFF
--- a/src/autocast/configs/optimizer/adamw.yaml
+++ b/src/autocast/configs/optimizer/adamw.yaml
@@ -10,7 +10,7 @@ weight_decay: 0.0
 warmup: 0
 scheduler: "cosine"
 # Optional scheduler controls:
-# scheduler_interval: "epoch"     # "epoch" or "step"
+# scheduler_interval: "epoch"     # "epoch", "step", or "time"
 # cosine_epochs: null              # Used when scheduler_interval="epoch"
 # cosine_steps: null               # Used when scheduler_interval="step"
 # cosine_t_max: 1                  # Fallback horizon if trainer values are unavailable
@@ -20,3 +20,10 @@ scheduler: "cosine"
 # 3) cosine_t_max
 # min_lr_ratio: 0.0                # Final LR ratio in [0, 1]
 # scheduler: "cosine_with_restarts"
+#
+# scheduler_interval: "time" anneals the cosine over trainer.max_time
+# (wall-clock) instead of a step/epoch horizon: no timing run needed, the LR
+# reaches min_lr_ratio exactly as the budget runs out, and it self-corrects
+# for throughput. In this mode `warmup` is a fraction of the budget, and the
+# schedule reads Lightning's resume-aware Timer (so it follows max_time across
+# resumes; reset_resume_time_budget resets it too). Requires trainer.max_time.

--- a/src/autocast/models/optimizer_mixin.py
+++ b/src/autocast/models/optimizer_mixin.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import heavyball
 import torch
+from lightning.pytorch.callbacks import Timer
 from lightning.pytorch.utilities.types import OptimizerLRScheduler
 from omegaconf import DictConfig, OmegaConf
 from torch import nn
@@ -40,11 +41,12 @@ class OptimizerMixin(nn.Module):
         return max(min_prob, max_prob * decay ** max(n - flat_start, 0))
 
     def _get_scheduler_interval(self, cfg: dict[str, Any]) -> str:
-        """Return scheduler interval ('epoch' or 'step')."""
+        """Return scheduler interval ('epoch', 'step', or 'time')."""
         interval = str(cfg.get("scheduler_interval", "epoch")).lower()
-        if interval not in {"epoch", "step"}:
+        if interval not in {"epoch", "step", "time"}:
             msg = (
-                f"scheduler_interval must be either 'epoch' or 'step'. Got: {interval}"
+                "scheduler_interval must be 'epoch', 'step', or 'time'. "
+                f"Got: {interval}"
             )
             raise ValueError(msg)
         return interval
@@ -175,6 +177,95 @@ class OptimizerMixin(nn.Module):
             warmup = int(warmup_raw)
         return max(warmup, 0)
 
+    def _resolve_time_warmup(self, cfg: dict[str, Any]) -> float:
+        """Resolve warmup as a fraction of the wall-clock budget.
+
+        With ``scheduler_interval='time'`` warmup is a fraction of
+        ``trainer.max_time`` (a float in ``[0, 1)``); absolute step/epoch
+        counts are meaningless against a wall-clock budget and are rejected.
+        """
+        warmup_cfg = cfg.get("warmup", 0)
+        warmup_raw = 0.0 if warmup_cfg is None else float(warmup_cfg)
+        if not math.isfinite(warmup_raw):
+            msg = f"warmup must be finite. Got: {warmup_raw}"
+            raise ValueError(msg)
+        if not 0.0 <= warmup_raw < 1.0:
+            msg = (
+                "With scheduler_interval='time', warmup must be a fraction in "
+                f"[0, 1) of the wall-clock budget. Got: {warmup_raw}"
+            )
+            raise ValueError(msg)
+        return warmup_raw
+
+    def _find_training_timer(self) -> Timer | None:
+        """Return Lightning's Timer callback if one is installed."""
+        trainer = getattr(self, "trainer", None)
+        callbacks = getattr(trainer, "callbacks", []) if trainer is not None else []
+        return next((cb for cb in callbacks if isinstance(cb, Timer)), None)
+
+    def _require_time_budget(self) -> None:
+        """Ensure a wall-clock budget exists for time-based scheduling.
+
+        ``trainer.max_time`` installs Lightning's ``Timer`` with a duration
+        (``max_time`` itself is not exposed as a trainer attribute). A Timer
+        without a duration, or no Timer at all, means there is no budget to
+        anneal over, so fail loud rather than silently never decaying.
+        """
+        timer = self._find_training_timer()
+        if timer is None or timer.time_remaining() is None:
+            msg = (
+                "scheduler_interval='time' requires a wall-clock budget; set "
+                "trainer.max_time (which installs Lightning's Timer)."
+            )
+            raise ValueError(msg)
+
+    def _training_time_progress(self) -> float:
+        """Fraction in [0, 1] of the wall-clock budget elapsed.
+
+        Reads Lightning's ``Timer`` callback, whose elapsed offset is restored
+        from checkpoints (and cleared by ``reset_resume_time_budget``). The
+        schedule therefore tracks the same clock that enforces ``max_time``: a
+        single-job run anneals over the job; a full-state-resumed run anneals
+        over the cumulative training time. Returns 0.0 (schedule start) if no
+        Timer / budget is available, which only happens before training begins.
+        """
+        timer = self._find_training_timer()
+        if timer is None:
+            return 0.0
+        remaining = timer.time_remaining()
+        if remaining is None:
+            return 0.0
+        elapsed = timer.time_elapsed()
+        budget = elapsed + remaining
+        if budget <= 0.0:
+            return 0.0
+        return min(max(elapsed / budget, 0.0), 1.0)
+
+    def _create_time_cosine(
+        self,
+        optimizer: torch.optim.Optimizer,
+        cfg: dict[str, Any],
+        min_lr_ratio: float,
+    ) -> torch.optim.lr_scheduler.LambdaLR:
+        """Cosine LR annealed over wall-clock time (``trainer.max_time``).
+
+        The lambda ignores the step counter and instead reads elapsed training
+        time from Lightning's ``Timer`` each step, so the LR reaches
+        ``min_lr_ratio`` exactly as the budget is exhausted regardless of
+        throughput. Stepped per optimizer step (see ``configure_optimizers``).
+        """
+        warmup_frac = self._resolve_time_warmup(cfg)
+
+        def lr_lambda(_step: int) -> float:
+            progress = self._training_time_progress()
+            cosine = 0.5 * (1.0 + math.cos(math.pi * progress))
+            scaled = min_lr_ratio + (1.0 - min_lr_ratio) * cosine
+            if warmup_frac > 0.0 and progress < warmup_frac:
+                return (progress / warmup_frac) * scaled
+            return scaled
+
+        return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lr_lambda)
+
     def _create_scheduler(
         self, optimizer: torch.optim.Optimizer, cfg: dict[str, Any]
     ) -> torch.optim.lr_scheduler.LRScheduler:
@@ -188,6 +279,16 @@ class OptimizerMixin(nn.Module):
             raise ValueError(msg)
 
         if scheduler_name in {"cosine", "cosine_with_restarts"}:
+            if scheduler_interval == "time":
+                if scheduler_name == "cosine_with_restarts":
+                    msg = (
+                        "cosine_with_restarts is not supported with "
+                        "scheduler_interval='time'."
+                    )
+                    raise ValueError(msg)
+                self._require_time_budget()
+                return self._create_time_cosine(optimizer, cfg, min_lr_ratio)
+
             horizon = self._resolve_cosine_horizon(cfg, scheduler_interval)
             warmup = self._resolve_warmup(cfg, horizon)
             use_restarts = scheduler_name == "cosine_with_restarts"
@@ -265,11 +366,17 @@ class OptimizerMixin(nn.Module):
                 },
             }
 
+        # Time-based cosine steps per optimizer step (the lambda reads the
+        # wall-clock; Lightning's lr_scheduler only accepts "step"/"epoch").
+        lightning_interval = (
+            "step" if scheduler_interval == "time" else scheduler_interval
+        )
+
         return {
             "optimizer": optimizer,
             "lr_scheduler": {
                 "scheduler": scheduler,
-                "interval": scheduler_interval,
+                "interval": lightning_interval,
                 "frequency": 1,
             },
         }

--- a/tests/models/test_optimizer_mixin.py
+++ b/tests/models/test_optimizer_mixin.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, cast
 
 import pytest
 import torch
+from lightning.pytorch.callbacks import Timer
 from torch import nn
 
 from autocast.models.optimizer_mixin import OptimizerMixin
@@ -163,3 +165,99 @@ class TestCosineSchedulerWithWarmup:
         # Step 0: ~1/51. Step 50: ~51/51 * cos(50/1000 * pi) ~ 0.997. Strict climb.
         assert lrs[0] < lrs[25] < lrs[50]
         assert lrs[50] == pytest.approx(0.997, rel=1e-2)
+
+
+class _FakeTrainer:
+    """Minimal stand-in exposing the callbacks the time-cosine path reads."""
+
+    def __init__(self, timer: Timer | None):
+        self.callbacks = [] if timer is None else [timer]
+
+
+class TestTimeCosineSchedule:
+    """Wall-clock cosine: LR annealed over trainer.max_time via Lightning's Timer."""
+
+    def _build(
+        self, *, warmup: float | int = 0.0, min_lr_ratio: float = 0.0
+    ) -> tuple[torch.optim.lr_scheduler.LambdaLR, Timer]:
+        timer = Timer(duration="00:01:00:00")  # 3600 s budget
+        m = _ToyMixinUser()
+        m.trainer = _FakeTrainer(timer)  # type: ignore[attr-defined]
+        opt = torch.optim.SGD(m.parameters(), lr=1.0)
+        cfg = cast(
+            "Any",
+            {
+                "scheduler": "cosine",
+                "scheduler_interval": "time",
+                "min_lr_ratio": min_lr_ratio,
+                "warmup": warmup,
+            },
+        )
+        sched = m._create_scheduler(opt, cfg)
+        assert isinstance(sched, torch.optim.lr_scheduler.LambdaLR)
+        return sched, timer
+
+    def _lr_at(
+        self,
+        sched: torch.optim.lr_scheduler.LambdaLR,
+        timer: Timer,
+        elapsed_s: int,
+    ) -> float:
+        # start_time is None (training not "started"), so time_elapsed() == _offset.
+        timer._offset = elapsed_s
+        sched.optimizer.step()
+        sched.step()
+        return float(sched.get_last_lr()[0])
+
+    def test_zero_elapsed_is_full_lr(self) -> None:
+        sched, timer = self._build()
+        assert self._lr_at(sched, timer, 0) == pytest.approx(1.0)
+
+    def test_half_budget_is_cosine_half(self) -> None:
+        sched, timer = self._build()
+        # progress 0.5 -> 0.5 * (1 + cos(pi/2)) = 0.5
+        assert self._lr_at(sched, timer, 1800) == pytest.approx(0.5)
+
+    def test_full_budget_hits_floor(self) -> None:
+        sched, timer = self._build(min_lr_ratio=0.1)
+        # progress 1.0 -> cosine 0 -> min_lr_ratio
+        assert self._lr_at(sched, timer, 3600) == pytest.approx(0.1)
+
+    def test_past_budget_clamps_to_floor(self) -> None:
+        sched, timer = self._build()
+        assert self._lr_at(sched, timer, 7200) == pytest.approx(0.0)
+
+    def test_warmup_is_fraction_of_budget(self) -> None:
+        sched, timer = self._build(warmup=0.1)
+        # progress 0.05, within warmup 0.1 -> warm factor 0.5
+        expected = 0.5 * 0.5 * (1.0 + math.cos(math.pi * 0.05))
+        assert self._lr_at(sched, timer, 180) == pytest.approx(expected, rel=1e-4)
+
+    def test_warmup_completes_at_fraction(self) -> None:
+        sched, timer = self._build(warmup=0.1)
+        # progress == warmup -> full cosine, no warm factor
+        expected = 0.5 * (1.0 + math.cos(math.pi * 0.1))
+        assert self._lr_at(sched, timer, 360) == pytest.approx(expected, rel=1e-6)
+
+    def test_requires_time_budget(self) -> None:
+        m = _ToyMixinUser()
+        m.trainer = _FakeTrainer(None)  # type: ignore[attr-defined]  # no Timer
+        opt = torch.optim.SGD(m.parameters(), lr=1.0)
+        cfg = cast("Any", {"scheduler": "cosine", "scheduler_interval": "time"})
+        with pytest.raises(ValueError, match="max_time"):
+            m._create_scheduler(opt, cfg)
+
+    def test_rejects_restarts_in_time_mode(self) -> None:
+        m = _ToyMixinUser()
+        m.trainer = _FakeTrainer(Timer(duration="00:01:00:00"))  # type: ignore[attr-defined]
+        opt = torch.optim.SGD(m.parameters(), lr=1.0)
+        cfg = cast(
+            "Any",
+            {"scheduler": "cosine_with_restarts", "scheduler_interval": "time"},
+        )
+        with pytest.raises(ValueError, match="cosine_with_restarts"):
+            m._create_scheduler(opt, cfg)
+
+    def test_rejects_absolute_warmup_in_time_mode(self) -> None:
+        with pytest.raises(ValueError, match="fraction"):
+            self._build(warmup=100)

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -143,6 +143,46 @@ def test_autoencoder_trainer_fit_bf16_mixed_smoke(
         assert torch.isfinite(p).all(), f"param {name} has NaN/Inf after bf16-mixed fit"
 
 
+def test_autoencoder_trainer_fit_time_cosine_smoke(
+    config_dir: str, toy_batch: Batch, dummy_loader, dummy_datamodule
+):
+    """scheduler_interval='time' wires up and runs under a real max_time Trainer.
+
+    Confirms the wall-clock cosine path finds Lightning's Timer in
+    trainer.callbacks and that the time->step interval mapping in
+    configure_optimizers is accepted by Lightning's scheduler config.
+    """
+    model_cfg = _load_config(config_dir, "model/autoencoder")
+    cfg = _wrap_model_config(model_cfg)
+    with open_dict(cfg):
+        cfg.optimizer = get_optimizer_config(
+            scheduler="cosine", scheduler_interval="time"
+        )
+        cfg.datamodule = {
+            "n_steps_input": toy_batch.input_fields.shape[1],
+            "n_steps_output": toy_batch.output_fields.shape[1],
+        }
+    stats = _stats_from_batch(toy_batch)
+    model = setup_autoencoder_model(cfg, stats, dummy_datamodule)
+
+    trainer = L.Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=1,
+        max_time="00:01:00:00",
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+    )
+    trainer.fit(model, train_dataloaders=dummy_loader, val_dataloaders=dummy_loader)
+
+    for name, p in model.named_parameters():
+        assert torch.isfinite(p).all(), f"param {name} not finite after time-cosine fit"
+
+
 def test_default_trainer_config_omits_clip_and_precision(config_dir: str):
     """Pin trainer/default.yaml to the reproducibility-preserving defaults.
 


### PR DESCRIPTION
## Summary

Lands the wall-clock cosine LR schedule on `main`. The original PR #388 added this feature but was stacked on the `fix-optimizer-config-defaults` branch (#387) rather than `main`. #387 merged into `main` first, then #388 merged into the now-orphaned #387 branch seconds later, so the wall-clock change never actually reached `main`. This PR re-targets the same commit at `main`.

The diff is a clean 4 files (only the wall-clock change). `main` has not touched any of these files since the branch forked, so the merge is conflict-free.

## Changes

- `scheduler_interval: "time"` option for the cosine schedule (LR follows a cosine half-period over a wall-clock duration rather than epochs/steps).
- `optimizer_mixin.py`: time-based scheduler wiring.
- `configs/optimizer/adamw.yaml`: documented the new option.
- Tests in `test_optimizer_mixin.py` and `test_training.py`.

## Test plan

- [ ] CI green
- [ ] Existing epoch/step cosine behaviour unchanged