### PR TITLE
Update mem config for single GPU jobs

### DIFF
--- a/src/autocast/configs/hydra/launcher/slurm.yaml
+++ b/src/autocast/configs/hydra/launcher/slurm.yaml
@@ -3,4 +3,4 @@ timeout_min: 240
 gpus_per_node: 1
 tasks_per_node: 1
 additional_parameters:
-  mem: 216G
+  mem: 115G


### PR DESCRIPTION
This PR reduces the memory allocation for single GPU slurm jobs from 216GB to 115GB for GH200 (see [docs](https://docs.isambard.ac.uk/specs/)).