### PR TITLE
Redo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,43 +5,156 @@
 
 ## Installation
 
-### Prereqiuisites
+### Prerequisites
 
 - [uv](https://github.com/astral-sh/uv): running scripts; managing virtual environments
 - [ffmpeg](https://ffmpeg.org/): optional video generation during evaluation
 
-### Development
-For development, install with [`uv`](https://github.com/astral-sh/uv):
-```bash
-uv sync --extra dev
+### Usage
+
+If you'd just like to use the code in autocast:
+
+```
+# Clone the repo
+git clone git@github.com:alan-turing-institute/autocast.git
+cd autocast
+
+# Install dependencies
+uv sync
 ```
 
-If contributing to the codebase, you can run 
-```bash 
- pre-commit install 
- ```
-This will setup the pre-commit checks so any pushed commits will pass the CI. 
+This will allow you to run `uv run autocast` from within the repository.
+
+### Development
+
+If you want to contribute to the autocast codebase, the following will get you set up:
+
+```bash
+# Clone the repo
+git clone git@github.com:alan-turing-institute/autocast.git
+cd autocast
+
+# Install development dependencies
+uv sync --extra dev
+
+# Set up pre-commit checks, so that any pushed commits pass CI
+uv run pre-commit install
+```
 
 For detailed documentation on the available scripts and configuration system, see [docs/SCRIPTS_AND_CONFIGS.md](docs/SCRIPTS_AND_CONFIGS.md).
 
 ## Quickstart
 
-The `autocast` CLI is built on top of [Hydra](https://hydra.cc/), meaning you can pass configuration overrides directly to the commands.
+`autocast` is primarily meant to be used as a command-line tool.
 
-Train an encoder-decoder stack:
+The `autocast` CLI is built on top of [Hydra](https://hydra.cc/).
+This means that configurations are specified in YAML files and can be composed together to quickly switch between different datasets and model architectures.
+
+### Base configurations and subcommands
+
+The 'base' configurations for datasets and model architectures are stored in `src/autocast/configs`.
+In particular, `autocast` comes with some subcommands for training standard model stacks:
+
+| Command                     | Description                                | Default config                                                                                               |
+| --------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `uv run autocast ae`        | Train an autoencoder                       | [`src/autocast/configs/autoencoder.yaml`](src/autocast/configs/autoencoder.yaml)
+| `uv run autocast processor` | Train a processor (frozen encoder/decoder) | [`src/autocast/configs/processor.yaml`](src/autocast/configs/processor.yaml)                                 |
+| `uv run autocast epd`       | Train an encoder-processor-decoder         | [`src/autocast/configs/encoder_processor_decoder.yaml`](src/autocast/configs/encoder_processor_decoder.yaml) |
+
+Notice that each of these YAML files in turn refer to a number of _other_ YAML files.
+For example, `src/autocast/configs/autoencoder.yaml` specifies (amongst other things)
+
+```yaml
+defaults:
+  - model: autoencoder
+  - logging: wandb
+```
+
+which in turn point to `src/autocast/configs/model/autoencoder.yaml` and `src/autocast/configs/logging/wandb.yaml` respectively.
+In this way, configurations can be built up from smaller pieces in a modular way.
+
+### Adding and overriding configurations
+
+Hydra allows you to add or override any configuration value from the command line.
+See [the Hydra documentation](https://hydra.cc/docs/advanced/override_grammar/basic/) for more details.
+As an example, to _override_ the number of training epochs for the `ae` command, you can run:
 
 ```bash
 uv run autocast ae trainer.max_epochs=5
 ```
 
-Train and evaluate an encoder-processor-decoder stack:
+Note that this only works if the `trainer.max_epochs` key is defined in the default configuration for that command.
+If the key is not defined, you have to prefix it with `+` to tell Hydra to add it:
 
 ```bash
-uv run autocast train-eval datamodule=reaction_diffusion
+uv run autocast ae +trainer.max_epochs=5
 ```
 
-Evaluation writes a CSV of aggregate metrics to `eval.csv_path` and, when `eval.batch_indices` is provided,
-stores rollout animations for the specified test batches.
+If you want to specify the option regardless of whether it is defined in the default config or not, you can use `++`:
+
+```bash
+uv run autocast ae ++trainer.max_epochs=5
+```
+
+### Data modules
+
+By default, these commands all point to their own _data modules_, which specify the dataset and how it gets loaded.
+The data module configurations are stored in `src/autocast/configs/datamodule/`.
+
+`autocast` can read datasets stored in two different formats:
+
+| Format                                                                       | Appropriate setting for `datamodule` | Override...                                                    |
+| ------                                                                       | ------------------------------------ | -----------                                                    |
+| HDF5 files from [The Well](https://polymathic-ai.org/the_well/)              | `datamodule=the_well`                | `datamodule.well_base_path` and `datamodule.well_dataset_name` |
+| `.pt` files from [autosim](https://github.com/alan-turing-institute/autosim) | `datamodule=advection_diffusion`     | `datamodule.data_path`                                         |
+
+For example, let's say that you have used `autosim` to generate a dataset of advection-diffusion simulations.
+We'll keep the size of the spatial grid (`simulator.n`) and the number of trajectories (`dataset.n_...`) small for this example.
+We'll also manually specify the output directory for the generated dataset, so that we can point `autocast` to it later (otherwise `autosim` will automatically generate a directory for you by default):
+
+```bash
+# See the autosim repository for more information on this.
+
+uv run autosim simulator=advection_diffusion \
+    simulator.n=16 dataset.n_train=10 dataset.n_valid=2 dataset.n_test=2 \
+    dataset.output_dir=/path/to/dataset
+```
+
+You can then train an autoencoder on that dataset (with all other settings inherited from that default) with:
+
+```bash
+uv run autocast ae \
+    datamodule=advection_diffusion \
+    datamodule.data_path=/path/to/dataset \
+    +trainer.max_epochs=5
+```
+
+### Making your own configurations
+
+If you find yourself making the same overrides repeatedly, it is probably worth it to make a new YAML configuration that specifies these overrides.
+If they are generally useful for the package, these can stored in `src/autocast/configs/experiments/<myexpt>.yaml` and specified on the command-line with `+experiment=<myexpt>`.
+
+Some of the configurations we used for our experiments are stored in the `local_hydra/local_experiment` folder.
+These are not in the main `src/autocast/configs` folder because they are not meant to be distributed as part of the package.
+These configuration files can, however, still be used by setting `local_experiment=<name>` on the command line.
+
+(This works because `autocast` makes sure to add `local_hydra` to Hydra's search path, allowing you to load configurations from there even though they are outside the package.)
+
+## Running experiments on SLURM
+
+`autocast` supports running experiments on SLURM clusters by adding the `--mode slurm` flag.
+This automatically generates a submission Bash script and submits it to the cluster, so you don't have to worry about writing your own submission scripts.
+
+For example, to run the same autoencoder training as above, but on SLURM, you can run:
+
+```bash
+uv run autocast ae --mode slurm \
+    datamodule=advection_diffusion \
+    datamodule.data_path=/path/to/dataset \
+    +trainer.max_epochs=5
+```
+
+---------------------------------
 
 ## Example pipeline
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ uv sync --extra dev
 uv run pre-commit install
 ```
 
-For detailed documentation on the available scripts and configuration system, see [docs/SCRIPTS_AND_CONFIGS.md](docs/SCRIPTS_AND_CONFIGS.md).
-
-## Quickstart
+## Introduction
 
 `autocast` is primarily meant to be used as a command-line tool.
 
@@ -128,6 +126,21 @@ uv run autocast ae \
     datamodule.data_path=/path/to/dataset \
     +trainer.max_epochs=5
 ```
+
+### Output paths
+
+To specify the output directory for an experiment, you can use the `--workdir` flag:
+
+```bash
+uv run autocast ae \
+    --workdir /path/to/output/directory \
+    datamodule=advection_diffusion \
+    datamodule.data_path=/path/to/dataset \
+    +trainer.max_epochs=5
+```
+
+Or alternatively, specify `--run-group=RUN_GROUP` and `--run-id=RUN_ID` to have `autocast` automatically generate the output directory as `outputs/RUN_GROUP/RUN_ID`.
+If logging to Weights and Biases is enabled, the run ID will also be used for the default W&B run name.
 
 ### Making your own configurations
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ uv run autocast ae \
 
 ### Output paths
 
-To specify the output directory for an experiment, you can use the `--workdir` flag:
+To specify the output directory for an experiment, you can either use the `--workdir` flag:
 
 ```bash
 uv run autocast ae \
@@ -139,8 +139,21 @@ uv run autocast ae \
     +trainer.max_epochs=5
 ```
 
-Or alternatively, specify `--run-group=RUN_GROUP` and `--run-id=RUN_ID` to have `autocast` automatically generate the output directory as `outputs/RUN_GROUP/RUN_ID`.
+or alternatively, specify `--run-group` and `--run-id`
+
+```bash
+uv run autocast ae \
+    --run-group MYGROUP \
+    --run-id MYID \
+    datamodule=advection_diffusion \
+    datamodule.data_path=/path/to/dataset \
+    +trainer.max_epochs=5
+```
+
+and `autocast` will automatically use `outputs/MYGROUP/MYID` as the output directory.
 If logging to Weights and Biases is enabled, the run ID will also be used for the default W&B run name.
+
+`--run-group` defaults to the current date, and `--run-id` defaults to a legacy-style run id (a concatenation of dataset/model/hash/uuid).
 
 ### Making your own configurations
 
@@ -167,156 +180,46 @@ uv run autocast ae --mode slurm \
     +trainer.max_epochs=5
 ```
 
----------------------------------
+## Evaluating models
 
-## Example pipeline
-
-This assumes you have the `reaction_diffusion` dataset stored at the path specified by
-the `AUTOCAST_DATASETS` environment variable.
-
-### Autocast API
-
-#### Core commands and workflow options
-```bash
-uv run autocast ae \
-	datamodule=reaction_diffusion \
-	--run-group rd
-```
-
-Unified workflow CLI supports both local and SLURM launch modes:
-
-```bash
-# Local (default)
-uv run autocast epd \
-	datamodule=reaction_diffusion \
-	--run-group my_label \
-	trainer.max_epochs=5
-
-# SLURM submit-and-exit via sbatch
-uv run autocast epd \
-	--mode slurm \
-	datamodule=reaction_diffusion \
-	--run-group my_label \
-	trainer.max_epochs=5
-```
-
-When `--mode slurm`, `autocast` writes an sbatch script, submits it, and exits
-immediately. Outputs are written under `outputs/<run_group>/<run_id>`.
-
-Resume training from a checkpoint:
-```bash
-uv run autocast epd \
-	datamodule=reaction_diffusion \
-	--workdir outputs/rd/00 \
-	--resume-from outputs/rd/00/encoder_processor_decoder.ckpt
-```
-
-Resume modes (applies to `ae`, `epd`, and `train-eval`):
-- Full-state resume (default): restores model + optimizer/scheduler/trainer loop state.
-- Weights-only resume: restores model weights only (fresh optimizer/trainer state), useful for "train for another N hours" workflows with `trainer.max_time`.
-- Full-state + reset timer budget: keeps optimizer/scheduler state and clears the restored elapsed-time offset for Lightning's `max_time` timer.
-
-```bash
-# Weights-only resume (example for train-eval)
-uv run autocast train-eval \
-	--workdir outputs/rd/00 \
-	--resume-from outputs/rd/00/encoder_processor_decoder.ckpt \
-	trainer.max_time="00:04:00:00" \
-	+train_eval.resume_weights_only=true
-```
-
-If `resume_weights_only=true` is set without a checkpoint, AutoCast raises an error.
-
-If you want to keep optimizer state and still run for a fresh `max_time` window, use:
+To run training plus evaluation in a single command, use the `train-eval` subcommand:
 
 ```bash
 uv run autocast train-eval \
-	--workdir outputs/rd/00 \
-	--resume-from outputs/rd/00/encoder_processor_decoder.ckpt \
-	trainer.max_time="00:04:00:00" \
-	+train_eval.reset_resume_time_budget=true
+    datamodule=advection_diffusion \
+    datamodule.data_path=/path/to/dataset \
+    +trainer.max_epochs=5
 ```
 
-Train + evaluate in one command:
-```bash
-uv run autocast train-eval \
-	datamodule=reaction_diffusion \
-	--run-group rd
-```
+For `train-eval`, evaluation will start only after training has completed successfully (including in `--mode slurm`).
 
-For `train-eval`, evaluation starts only after training has completed successfully
-(including in `--mode slurm`).
+Note that `train-eval` accepts both training and evaluation configuration overrides.
+These must be separated with the `--eval-overrides` flag, which tells Hydra which overrides are meant for training and which are meant for evaluation.
+Overrides _before_ `--eval-overrides` are passed to the training configuration, and overrides _after_ `--eval-overrides` are passed to the evaluation configuration.
 
-To run  `eval` on a previously trained model, set `--workdir` to the run folder containing the configuration and checkpoint to evaluate:
+To run  `eval` on a previously trained model, use the `eval` subcommand and set `--workdir` to the run folder containing the configuration and checkpoint to evaluate:
+
 ```bash
 uv run autocast eval --workdir outputs/rd/00
 ```
 
-#### Configuration and overrides
-Keep private experiment presets in `local_hydra/local_experiment/` and select
-them with `local_experiment=<name>`. YAML files in that folder are ignored by
-git by default.
+## Other useful configuration flags
 
-To load configs from a separate directory (including packaged installs), set:
+### Performing a dry run
 
-```bash
-export AUTOCAST_CONFIG_PATH=/absolute/path/to/configs
-```
+Add `--dry-run` to print the commands that will be executed without actually running them.
 
-Override mapping quick reference:
-- `configs/hydra/launcher/slurm.yaml` key `X` maps to CLI `hydra.launcher.X=...`
-- Use `hydra/launcher=slurm_baskerville` for Baskerville module/setup defaults
-from `local_hydra/hydra/launcher/slurm_baskerville.yaml`.
-- In `autocast train-eval`, positional overrides are train-only.
-- Eval-only overrides go in `--eval-overrides ...`.
-- `--eval-overrides` is a separator: place train overrides before it and eval
-overrides after it.
+### Using multiple GPUs / nodes
 
-Permissions quick reference:
-- Lower-level Hydra training/evaluation scripts use config key `umask` (default `0002` in `encoder_processor_decoder`).
+Multi-GPU and multi-node SLURM runs are supported through distributed presets (found in `src/autocast/configs/distributed/`):
 
-Use `--dry-run` to print resolved commands/scripts without executing.
+- To use 4 GPUs on a single node with DDP, add `++distributed=ddp_4gpu_slurm`
+- To use 8 GPUs across 2 nodes with DDP, add `++distributed=ddp_4gpu_2node_slurm`
+- To use 12 GPUs across 3 nodes with DDP, add `++distributed=ddp_4gpu_2node_slurm ++trainer.num_nodes=3 ++eval.num_nodes=3 ++hydra.launcher.nodes=3`
 
-Launch many prewritten runs from a manifest file:
-```bash
-bash scripts/launch_from_manifest.sh run_manifests/example_runs.txt
-```
+The preset configurations set both Lightning `trainer.devices`/`trainer.num_nodes` and the matching Slurm `hydra.launcher.nodes`/`gpus_per_node`/`tasks_per_node` values.
+For more fine-grained control, you can also explicitly override these configuration values:
 
-Date handling is automatic: if `--run-group` is omitted, current date is used.
-Run naming is also automatic: if `--run-id` is omitted, `autocast` generates
-a legacy-style run id (dataset/model/hash/uuid based) and uses it for both
-the run folder and default `logging.wandb.name`.
-Pass `--run-group` only to override the top-level folder label.
-Backward-compatible aliases remain available: `--run-label` and `--run-name`.
-
-W&B naming behavior:
-- `--run-group` only changes the parent output folder (`outputs/<run_group>/...`).
-- `--run-id` sets the run folder name and, by default, `logging.wandb.name`.
-- Set `logging.wandb.name=...` via Hydra overrides to explicitly name the W&B run.
-
-Workdir/chdir behavior:
-- The workflow wrapper always forwards `--workdir` to Hydra as `hydra.run.dir=<workdir>`.
-- Training configs set `hydra.job.chdir=true`, so script execution runs inside that run directory.
-- Script internals resolve workdir via Hydra runtime output dir (`resolve_hydra_work_dir(...)`), avoiding cwd/path mismatches.
-
-Multi-GPU and multi-node SLURM runs are supported through distributed presets
-under `src/autocast/configs/distributed/`:
-```bash
-uv run autocast epd --mode slurm \
-	datamodule=reaction_diffusion \
-	+distributed=ddp_4gpu_slurm
-```
-
-For a 2-node, 4-GPU-per-node DDP run:
-```bash
-uv run autocast epd --mode slurm \
-	datamodule=reaction_diffusion \
-	+distributed=ddp_4gpu_2node_slurm
-```
-
-The preset sets both Lightning `trainer.devices`/`trainer.num_nodes` and the
-matching Slurm `hydra.launcher.nodes`/`gpus_per_node`/`tasks_per_node` values.
-Equivalent explicit overrides also work, e.g.:
 ```bash
 uv run autocast epd --mode slurm \
 	datamodule=reaction_diffusion \
@@ -325,36 +228,54 @@ uv run autocast epd --mode slurm \
 	hydra.launcher.tasks_per_node=4
 ```
 
-### Experiment Tracking with Weights & Biases
+### Resuming from a checkpoint
 
-AutoCast optionally integrates with [Weights & Biases](https://wandb.ai/) that is
- driven by the Hydra config under `src/autocast/configs/logging/wandb.yaml`.
+The following extra CLI options can be passed to the `ae`, `epd`, and `train-eval` subcommands (or added to configuration files):
 
-Enable logging by passing Hydra config overrides as positional arguments:
+- Resume from a saved checkpoint.
+  The default is to perform a full-state resume, which restores model + optimizer/scheduler/trainer loop state.
 
-```bash
-uv run autocast epd \
-	logging.wandb.enabled=true \
-	logging.wandb.project=autocast-experiments \
-	logging.wandb.name=processor-baseline
-```
+  ```bash
+  --resume-from path/to/encoder_processor_decoder.ckpt
+  ```
 
-To continue an existing W&B run on resume, set both:
-- `logging.wandb.id=<existing_run_id>`
-- `logging.wandb.resume=allow` (or `must`)
+- To additionally reset the timer budget:
 
-Without `id`+`resume`, W&B creates a new run even if `logging.wandb.name` matches.
-Also note:
-- Full-state resume continues Lightning global step/epoch progression.
-- Weights-only resume starts trainer loop counters from zero (new optimizer/trainer state).
+  ```bash
+  --resume-from path/to/encoder_processor_decoder.ckpt ++trainer.max_time="00:04:00:00" ++train_eval.reset_resume_time_budget=true
+  ```
 
-All example notebooks contain a dedicated cell that instantiates a `wandb_logger` via `autocast.logging.create_wandb_logger`. Toggle the `enabled` flag in that cell to control tracking when experimenting interactively.
+- To restore only the model weights and generate a fresh optimizer/trainer state:
+ 
+  ```bash
+  --resume-from path/to/encoder_processor_decoder.ckpt ++trainer.max_time="00:04:00:00" ++train_eval.resume_weights_only=true
+  ```
 
-When `enabled` remains `false` (the default), the logger is skipped entirely, so the stack can be used without a W&B account.
+  In conjunction with `trainer.max_time`, this allows you to continue training with a fresh timer budget.
+  Note that if `resume_weights_only=true` is set without a checkpoint, AutoCast raises an error.
+
+
+### Weights & Biases logging
+
+AutoCast optionally integrates with [Weights & Biases](https://wandb.ai/); this is driven by the Hydra config in [`src/autocast/configs/logging/wandb.yaml`](src/autocast/configs/logging/wandb.yaml).
+
+Logging to W&B can be enabled (or disabled) with `++logging.wandb.enabled=true` (or `false` respectively).
+
+The W&B project name can be set with `++logging.wandb.project=MYPROJECT`.
+
+By default the `--run-id` is used as the W&B run name.
+You can override this with `++logging.wandb.name=MYNAME`.
+
+If you are resuming from a previous run and want to continue logging to the same W&B run, you need to set:
+- `++logging.wandb.id=EXISTING_RUN_ID` (the run ID of the existing W&B run)
+- `++logging.wandb.resume=allow` (or `must`)
+
+Without this combination, W&B will create a new run even if the `logging.wandb.name` matches an existing run name.
 
 ## Direct usage of lower-level Hydra scripts
 
-The `autocast` CLI is a convenient wrapper around the lower-level Hydra scripts in `src/autocast/scripts/`. You can run those directly if you prefer, for example:
+The `autocast` CLI is a convenient wrapper around the lower-level Hydra scripts in `src/autocast/scripts/`.
+Here are some example invocations:
 
 #### Train autoencoder script
 ```bash
@@ -389,23 +310,6 @@ uv run evaluate_encoder_processor_decoder \
 	datamodule.data_path=$AUTOCAST_DATASETS/reaction_diffusion \
 	datamodule.use_simulator=false
 ```
-
-## Running on HPC 
-
-The `autocast` CLI directly supports SLURM submission via `--mode slurm`.
-This section is a quick reference for common HPC usage.
-
-For single-job SLURM usage (`autocast epd --mode slurm` or
-`autocast train-eval --mode slurm`), see the examples above in
-`Example pipeline`.
-
-### Multiple Jobs
-
-Use Hydra multi-run directly for sweeps, e.g.
-`uv run autocast epd --mode slurm datamodule=reaction_diffusion trainer.max_epochs=5,10`.
-
-Or launch prewritten jobs from a manifest:
-`bash scripts/launch_from_manifest.sh run_manifests/example_runs.txt`.
 
 ## Ethical guidance
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you'd just like to use the code in autocast:
 
 ```
 # Clone the repo
-git clone git@github.com:alan-turing-institute/autocast.git
+git clone https://github.com/alan-turing-institute/autocast.git
 cd autocast
 
 # Install dependencies
@@ -31,7 +31,7 @@ If you want to contribute to the autocast codebase, the following will get you s
 
 ```bash
 # Clone the repo
-git clone git@github.com:alan-turing-institute/autocast.git
+git clone https://github.com/alan-turing-institute/autocast.git
 cd autocast
 
 # Install development dependencies
@@ -43,7 +43,7 @@ uv run pre-commit install
 
 ## Introduction
 
-`autocast` is primarily meant to be used as a command-line tool.
+`autocast` is primarily meant to be used as a CLI tool.
 
 The `autocast` CLI is built on top of [Hydra](https://hydra.cc/).
 This means that configurations are specified in YAML files and can be composed together to quickly switch between different datasets and model architectures.
@@ -56,8 +56,10 @@ In particular, `autocast` comes with some subcommands for training standard mode
 | Command                     | Description                                | Default config                                                                                               |
 | --------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `uv run autocast ae`        | Train an autoencoder                       | [`src/autocast/configs/autoencoder.yaml`](src/autocast/configs/autoencoder.yaml)
+| `uv run autocast cache-latents` | Cache latents from an encoder | [`src/autocast/configs/cache_latents.yaml`](src/autocast/configs/cache_latents.yaml)                                 |
 | `uv run autocast processor` | Train a processor (frozen encoder/decoder) | [`src/autocast/configs/processor.yaml`](src/autocast/configs/processor.yaml)                                 |
 | `uv run autocast epd`       | Train an encoder-processor-decoder         | [`src/autocast/configs/encoder_processor_decoder.yaml`](src/autocast/configs/encoder_processor_decoder.yaml) |
+| `uv run autocast eval`       | Evaluate a trained model         | [`src/autocast/configs/eval/encoder_processor_decoder.yaml`](src/autocast/configs/eval/encoder_processor_decoder.yaml) |
 
 Notice that each of these YAML files in turn refer to a number of _other_ YAML files.
 For example, `src/autocast/configs/autoencoder.yaml` specifies (amongst other things)
@@ -103,8 +105,8 @@ The data module configurations are stored in `src/autocast/configs/datamodule/`.
 
 | Format                                                                       | Appropriate setting for `datamodule` | Override...                                                    |
 | ------                                                                       | ------------------------------------ | -----------                                                    |
-| HDF5 files from [The Well](https://polymathic-ai.org/the_well/)              | `datamodule=the_well`                | `datamodule.well_base_path` and `datamodule.well_dataset_name` |
 | `.pt` files from [autosim](https://github.com/alan-turing-institute/autosim) | `datamodule=advection_diffusion`     | `datamodule.data_path`                                         |
+| HDF5 files from [The Well](https://polymathic-ai.org/the_well/)              | `datamodule=the_well`                | `datamodule.well_base_path` and `datamodule.well_dataset_name` |
 
 For example, let's say that you have used `autosim` to generate a dataset of advection-diffusion simulations.
 We'll keep the size of the spatial grid (`simulator.n`) and the number of trajectories (`dataset.n_...`) small for this example.

--- a/README.md
+++ b/README.md
@@ -184,26 +184,21 @@ uv run autocast ae --mode slurm \
 
 ## Evaluating models
 
-To run training plus evaluation in a single command, use the `train-eval` subcommand:
+To run a series of preset evaluation tests on a saved model checkpoint, including single-step predictions and autoregressive rollout, you can use the `eval` subcommand and set `--workdir` to the run folder containing the configuration and model checkpoint to evaluate.
 
 ```bash
-uv run autocast train-eval \
-    datamodule=advection_diffusion \
-    datamodule.data_path=/path/to/dataset \
-    +trainer.max_epochs=5
+uv run autocast eval \
+    --workdir /path/to/outputs
 ```
 
-For `train-eval`, evaluation will start only after training has completed successfully (including in `--mode slurm`).
+Some useful Hydra options for further controlling the evaluation are:
 
-Note that `train-eval` accepts both training and evaluation configuration overrides.
-These must be separated with the `--eval-overrides` flag, which tells Hydra which overrides are meant for training and which are meant for evaluation.
-Overrides _before_ `--eval-overrides` are passed to the training configuration, and overrides _after_ `--eval-overrides` are passed to the evaluation configuration.
+- `autoencoder_checkpoint`: the path to the autoencoder checkpoint to use for evaluation (if applicable).
+  This is used if you trained a standalone processor (i.e., `uv run autocast processor`) in latent space.
+  If you trained a full encoder-processor-decoder stack (i.e., `uv run autocast epd`), the autoencoder is already part of the model checkpoint, so does not need to be supplied separately.
+- `eval.metrics`: a list of metrics to compute during evaluation.
+- `eval.n_members`: the number of members to use for ensemble evaluation. Increasing this allows you to get a smoother estimate of the model's uncertainty.
 
-To run  `eval` on a previously trained model, use the `eval` subcommand and set `--workdir` to the run folder containing the configuration and checkpoint to evaluate:
-
-```bash
-uv run autocast eval --workdir outputs/rd/00
-```
 
 ## Other useful configuration flags
 


### PR DESCRIPTION
View @ https://github.com/alan-turing-institute/autocast/blob/py/readme1/README.md

Some points about my approach:

- I've tried to structure this the way I would usually write docs -- i.e. start with the absolute basics and then layer  things on. This means that when the time comes to transfer it to 'proper' docs it should have the right structure & progression.

- I don't think it's good to make the assumption that the user has set up autocast outputs directory in the same way we have. I think it's better to keep it general, and the user can figure out how to use that to set up their own workflow

  - BTW I still think it's not a good idea to hardcode dataset paths with uuids into the configs. These refer to things that we have generated and shouldn't be part of the package (edit: I opened #400)

- I used `++config=val` for everything, because of the nested configs it's a massive pain to figure out when you need `+config=val` vs when you just need `config=val` and if you specify the wrong one it errors.

- There are bits of information that I cut out, because I think they're minor details that nobody really needs to know about. Things like "Backward-compatible aliases remain available: `--run-label` and `--run-name`."

   The presence of these things is I suppose a holdover from LLM generation because LLMs are really poor at figuring out what is important and what isn't unless you guide it more. (In general, I actually really dislike LLM generated docs because they often explain the wrong things and presuppose the wrong level of reader knowledge.) That said, I reckon some of this information can be usefully added to `AGENTS.md`? I haven't done that yet.