### PR TITLE
Fix detection of `/distributed` config

### DIFF
--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -114,7 +114,7 @@ def _resolve_local_experiment_parent(item: object) -> Path | None:
     if item.startswith("/local_experiment/"):
         rel = item.removeprefix("/local_experiment/")
         return Path.cwd() / "local_hydra" / "local_experiment" / f"{rel}.yaml"
-    if item.startswith("_") or item.startswith("/"):
+    if item.startswith(("_", "/")):
         return None
     return Path.cwd() / "local_hydra" / "local_experiment" / f"{item}.yaml"
 

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -130,10 +130,7 @@ def _extract_distributed_preset_name(
     for item in defaults:
         if not isinstance(item, dict):
             continue
-        val = (
-            item.get("/distributed")
-            or item.get("override /distributed")
-        )
+        val = item.get("/distributed") or item.get("override /distributed")
         if isinstance(val, str) and val:
             return val
     for item in defaults:

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -105,13 +105,18 @@ def _extract_local_experiment_name(overrides: list[str]) -> str | None:
 
 
 def _resolve_local_experiment_parent(item: object) -> Path | None:
-    # Map a defaults-list entry of the form
-    # ``- /local_experiment/<rel/path>`` to its YAML file, so we can
-    # follow the inheritance chain when looking up ``/distributed``.
-    if isinstance(item, str) and item.startswith("/local_experiment/"):
-        rel = item[len("/local_experiment/") :]
+    # Map a defaults-list entry to its YAML file so we can follow the
+    # inheritance chain when looking up ``/distributed``.
+    # Handles both absolute (``/local_experiment/foo``) and relative
+    # (``foo/bar``) references within the local_experiment config group.
+    if not isinstance(item, str):
+        return None
+    if item.startswith("/local_experiment/"):
+        rel = item.removeprefix("/local_experiment/")
         return Path.cwd() / "local_hydra" / "local_experiment" / f"{rel}.yaml"
-    return None
+    if item.startswith("_") or item.startswith("/"):
+        return None
+    return Path.cwd() / "local_hydra" / "local_experiment" / f"{item}.yaml"
 
 
 def _extract_distributed_preset_name(
@@ -125,7 +130,11 @@ def _extract_distributed_preset_name(
     for item in defaults:
         if not isinstance(item, dict):
             continue
-        val = item.get("/distributed") or item.get("distributed")
+        val = (
+            item.get("/distributed")
+            or item.get("distributed")
+            or item.get("override /distributed")
+        )
         if isinstance(val, str) and val:
             return val
     for item in defaults:

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -132,7 +132,6 @@ def _extract_distributed_preset_name(
             continue
         val = (
             item.get("/distributed")
-            or item.get("distributed")
             or item.get("override /distributed")
         )
         if isinstance(val, str) and val:

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -284,6 +284,75 @@ def test_load_preset_launcher_cfg_walks_local_experiment_parent_chain(
     assert launcher_cfg.get("tasks_per_node") == 4
 
 
+def test_load_preset_launcher_cfg_walks_relative_parent_reference(
+    tmp_path: Path, monkeypatch
+):
+    # Child uses a relative reference (no /local_experiment/ prefix) to a
+    # parent that declares /distributed: — the loader must resolve the
+    # relative path from the config group root.
+    local_root = tmp_path / "local_hydra" / "local_experiment"
+    parent_cfg = local_root / "epd" / "base.yaml"
+    parent_cfg.parent.mkdir(parents=True, exist_ok=True)
+    parent_cfg.write_text(
+        "\n".join(
+            [
+                "defaults:",
+                "  - /distributed: ddp_4gpu_slurm",
+                "  - _self_",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    child_cfg = local_root / "epd" / "128x128" / "child.yaml"
+    child_cfg.parent.mkdir(parents=True, exist_ok=True)
+    child_cfg.write_text(
+        "\n".join(
+            [
+                "defaults:",
+                "  - epd/base",
+                "  - _self_",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    launcher_cfg = _load_preset_launcher_cfg(
+        ["local_experiment=epd/128x128/child"]
+    )
+
+    assert launcher_cfg.get("gpus_per_node") == 4
+    assert launcher_cfg.get("tasks_per_node") == 4
+
+
+def test_load_preset_launcher_cfg_recognises_override_distributed(
+    tmp_path: Path, monkeypatch
+):
+    # When a config uses `override /distributed:` (needed when a parent
+    # already set the group), the CLI must still find the preset name.
+    local_root = tmp_path / "local_hydra" / "local_experiment"
+    cfg = local_root / "with_override.yaml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        "\n".join(
+            [
+                "defaults:",
+                "  - override /distributed: ddp_4gpu_2node_slurm",
+                "  - _self_",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    launcher_cfg = _load_preset_launcher_cfg(
+        ["local_experiment=with_override"]
+    )
+
+    assert launcher_cfg.get("nodes") == 2
+    assert launcher_cfg.get("gpus_per_node") == 4
+
+
 def test_load_direct_distributed_launcher_cfg_supports_multinode():
     launcher_cfg = _load_direct_distributed_launcher_cfg(
         ["+distributed=ddp_4gpu_2node_slurm"]

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -317,9 +317,7 @@ def test_load_preset_launcher_cfg_walks_relative_parent_reference(
     )
 
     monkeypatch.chdir(tmp_path)
-    launcher_cfg = _load_preset_launcher_cfg(
-        ["local_experiment=epd/128x128/child"]
-    )
+    launcher_cfg = _load_preset_launcher_cfg(["local_experiment=epd/128x128/child"])
 
     assert launcher_cfg.get("gpus_per_node") == 4
     assert launcher_cfg.get("tasks_per_node") == 4
@@ -345,9 +343,7 @@ def test_load_preset_launcher_cfg_recognises_override_distributed(
     )
 
     monkeypatch.chdir(tmp_path)
-    launcher_cfg = _load_preset_launcher_cfg(
-        ["local_experiment=with_override"]
-    )
+    launcher_cfg = _load_preset_launcher_cfg(["local_experiment=with_override"])
 
     assert launcher_cfg.get("nodes") == 2
     assert launcher_cfg.get("gpus_per_node") == 4


### PR DESCRIPTION
This should fix #406. I haven't yet inspected the actual output of the SLURM scripts, but the newly added tests fail on main and work on this PR.

Edit: I tested #405 and #407 together and it works exactly as intended