### PR TITLE
Add RB core support utilities

### DIFF
--- a/src/autocast/callbacks/__init__.py
+++ b/src/autocast/callbacks/__init__.py
@@ -5,10 +5,12 @@ This package holds Lightning callbacks used across training and evaluation.
 
 from .checkpoint import ProgressModelCheckpoint
 from .ema import EMACallback
+from .grad_norm import GradNormCallback
 from .metrics import ValidationMetricPlotCallback
 
 __all__ = [
     "EMACallback",
+    "GradNormCallback",
     "ProgressModelCheckpoint",
     "ValidationMetricPlotCallback",
 ]

--- a/src/autocast/callbacks/grad_norm.py
+++ b/src/autocast/callbacks/grad_norm.py
@@ -1,0 +1,55 @@
+# ruff: noqa: ARG002
+import torch
+from lightning.pytorch.callbacks import Callback
+
+
+class GradNormCallback(Callback):
+    """Log the global pre-clip gradient norm (and LR) every optimizer step.
+
+    Diagnostic only: it reads ``p.grad`` in ``on_before_optimizer_step``, which
+    Lightning calls after backward (and gradient all-reduce under DDP) but
+    *before* any gradient clipping or the optimizer update. The logged
+    ``grad_norm`` is therefore the true norm the optimizer would act on.
+
+    Use it to attribute ``train_loss`` spikes: a ``grad_norm`` that explodes in
+    lockstep with the loss indicates a stability problem (missing clipping,
+    no warmup, or too-high LR) rather than under-capacity. The callback never
+    touches the gradients, so training dynamics are unchanged.
+    """
+
+    def __init__(self, norm_type: float = 2.0):
+        super().__init__()
+        self.norm_type = float(norm_type)
+
+    def on_before_optimizer_step(self, trainer, pl_module, optimizer):
+        grads = [p.grad.detach() for p in pl_module.parameters() if p.grad is not None]
+        if not grads:
+            return
+        per_param = torch.stack([g.norm(self.norm_type) for g in grads])
+        total = per_param.norm(self.norm_type)
+        pl_module.log(
+            "grad_norm",
+            total,
+            on_step=True,
+            on_epoch=False,
+            prog_bar=False,
+            sync_dist=False,
+        )
+        # Largest single-parameter contribution, to spot one layer blowing up.
+        pl_module.log(
+            "grad_norm_max",
+            per_param.max(),
+            on_step=True,
+            on_epoch=False,
+            prog_bar=False,
+            sync_dist=False,
+        )
+        if optimizer.param_groups:
+            pl_module.log(
+                "lr",
+                float(optimizer.param_groups[0]["lr"]),
+                on_step=True,
+                on_epoch=False,
+                prog_bar=False,
+                sync_dist=False,
+            )

--- a/src/autocast/configs/datamodule/miniwell.yaml
+++ b/src/autocast/configs/datamodule/miniwell.yaml
@@ -13,4 +13,7 @@ stride: 1
 
 # DataLoader configuration
 batch_size: 16
-num_workers: 0  # Use 0 for h5py compatibility
+num_workers: 8
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2

--- a/src/autocast/data/encoded_dataset.py
+++ b/src/autocast/data/encoded_dataset.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Any
 
 import h5py
 import torch
@@ -49,13 +50,35 @@ class MiniWellDataset(Dataset):
         steps: int = 1,
         stride: int = 1,
     ):
-        self.file = h5py.File(file, mode="r")
+        self.file_path = str(file)
+        self._file: h5py.File | None = None
 
-        self.trajectories = self.file["state"].shape[0]  # type: ignore  # noqa: PGH003
-        self.steps_per_trajectory = self.file["state"].shape[1]  # type: ignore  # noqa: PGH003
+        with h5py.File(self.file_path, mode="r") as h5_file:
+            self.trajectories = h5_file["state"].shape[0]  # type: ignore  # noqa: PGH003
+            self.steps_per_trajectory = h5_file["state"].shape[1]  # type: ignore  # noqa: PGH003
 
         self.steps = steps
         self.stride = stride
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Drop process-local HDF5 handles before worker serialization."""
+        state = self.__dict__.copy()
+        state["_file"] = None
+        return state
+
+    def _h5_file(self) -> h5py.File:
+        if self._file is None:
+            self._file = h5py.File(self.file_path, mode="r")
+        return self._file
+
+    def close(self) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def __del__(self) -> None:
+        """Close the process-local HDF5 handle at object teardown."""
+        self.close()
 
     def __len__(self) -> int:  # noqa: D105
         return self.trajectories * (
@@ -69,10 +92,11 @@ class MiniWellDataset(Dataset):
 
         i, j = i // crops_per_trajectory, i % crops_per_trajectory
 
-        state = self.file["state"][  # type: ignore  # noqa: PGH003
+        h5_file = self._h5_file()
+        state = h5_file["state"][  # type: ignore  # noqa: PGH003
             i, slice(j, j + (self.steps - 1) * self.stride + 1, self.stride)
         ]
-        label = self.file["label"][i]  # type: ignore  # noqa: PGH003
+        label = h5_file["label"][i]  # type: ignore  # noqa: PGH003
 
         return {
             "state": torch.as_tensor(state),
@@ -237,8 +261,7 @@ class EncodedDataModule(LightningDataModule):
             n_steps_output: Number of output time steps to predict.
             stride: Stride for stepping through trajectories.
             batch_size: Batch size for dataloaders.
-            num_workers: Number of workers for dataloaders. Default 0 for
-                h5py compatibility.
+            num_workers: Number of workers for dataloaders.
             dataset_cls: Dataset class to use. Defaults to MiniWellInputOutput.
             in_memory: Whether to load the full dataset into memory.
             **dataset_kwargs: Additional kwargs passed to dataset constructor.
@@ -426,6 +449,9 @@ class MiniWellDataModule(LightningDataModule):
         stride: int = 1,
         batch_size: int = 16,
         num_workers: int = 0,
+        pin_memory: bool = True,
+        persistent_workers: bool | None = None,
+        prefetch_factor: int | None = 2,
     ):
         """Initialize the MiniWellDataModule.
 
@@ -436,8 +462,13 @@ class MiniWellDataModule(LightningDataModule):
             n_steps_output: Number of output time steps to predict.
             stride: Stride for stepping through trajectories.
             batch_size: Batch size for dataloaders.
-            num_workers: Number of workers for dataloaders. Default 0 for
-                h5py compatibility.
+            num_workers: Number of workers for dataloaders. Each worker lazily
+                opens its own HDF5 file handle.
+            pin_memory: Whether to pin CPU tensors before transfer to GPU.
+            persistent_workers: Keep worker processes alive between epochs.
+                Defaults to True when num_workers > 0.
+            prefetch_factor: Number of batches loaded in advance per worker.
+                Only used when num_workers > 0.
         """
         super().__init__()
         self.data_path = Path(data_path) if data_path is not None else None
@@ -446,6 +477,11 @@ class MiniWellDataModule(LightningDataModule):
         self.stride = stride
         self.batch_size = batch_size
         self.num_workers = num_workers
+        self.pin_memory = pin_memory
+        self.persistent_workers = (
+            num_workers > 0 if persistent_workers is None else persistent_workers
+        )
+        self.prefetch_factor = prefetch_factor
 
         self.train_dataset: Dataset | None = None
         self.val_dataset: Dataset | None = None
@@ -480,6 +516,17 @@ class MiniWellDataModule(LightningDataModule):
         ]
         return ConcatDataset(datasets)
 
+    def _dataloader_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "num_workers": self.num_workers,
+            "pin_memory": self.pin_memory,
+        }
+        if self.num_workers > 0:
+            kwargs["persistent_workers"] = self.persistent_workers
+            if self.prefetch_factor is not None:
+                kwargs["prefetch_factor"] = self.prefetch_factor
+        return kwargs
+
     def setup(self, stage: str | None = None) -> None:
         """Set up datasets for the given stage."""
         if self.data_path is None:
@@ -509,8 +556,8 @@ class MiniWellDataModule(LightningDataModule):
             self.train_dataset,
             batch_size=self.batch_size,
             shuffle=True,
-            num_workers=self.num_workers,
             collate_fn=collate_encoded_samples,
+            **self._dataloader_kwargs(),
         )
 
     def val_dataloader(self) -> DataLoader:
@@ -524,8 +571,8 @@ class MiniWellDataModule(LightningDataModule):
             self.val_dataset,
             batch_size=self.batch_size,
             shuffle=False,
-            num_workers=self.num_workers,
             collate_fn=collate_encoded_samples,
+            **self._dataloader_kwargs(),
         )
 
     def test_dataloader(self) -> DataLoader:
@@ -539,6 +586,6 @@ class MiniWellDataModule(LightningDataModule):
             self.test_dataset,
             batch_size=self.batch_size,
             shuffle=False,
-            num_workers=self.num_workers,
             collate_fn=collate_encoded_samples,
+            **self._dataloader_kwargs(),
         )

--- a/src/autocast/data/encoded_dataset.py
+++ b/src/autocast/data/encoded_dataset.py
@@ -18,10 +18,13 @@ class EncodedBatchMixin:
     @staticmethod
     def to_sample(data: dict) -> EncodedSample:
         """Convert a dictionary of tensors to a Sample object."""
+        global_cond = data.get("global_cond")
+        if global_cond is None:
+            global_cond = data.get("label")
         return EncodedSample(
             encoded_inputs=data["input_fields"],
             encoded_output_fields=data["output_fields"],
-            global_cond=data.get("label"),
+            global_cond=global_cond,
             encoded_info=data.get("encoded_info", {}),
         )
 

--- a/src/autocast/data/transforms.py
+++ b/src/autocast/data/transforms.py
@@ -1,0 +1,43 @@
+# ruff: noqa: ARG002
+"""Deterministic input transforms for The Well datasets.
+
+These are *transforms* (deterministic, applied to every sample of every split),
+not stochastic data augmentations. They are injected through The Well's
+``WellDataset(transform=...)`` hook -- whose interface happens to be the
+``Augmentation`` base class -- and run on the name->tensor ``constant_scalars``
+dict before The Well flattens it into the conditioning channel dim.
+
+Because they are deterministic, they must be applied identically to *all*
+dataloaders (train/val/test/rollout) so the model sees the same conditioning at
+train and inference time -- unlike a stochastic augmentation, which would be
+train-only.
+"""
+
+from collections.abc import Sequence
+
+from the_well.data import Augmentation
+from the_well.data.datasets import TrajectoryData, TrajectoryMetadata
+
+
+class LogScalars(Augmentation):
+    """Natural-log transform of named constant scalars.
+
+    Applies ``value.log()`` to each constant scalar whose name (case-insensitive)
+    is in ``scalar_names``. This is a deterministic value transform, not a
+    stochastic augmentation: it is meant to be applied to every split. Boundary
+    conditions and non-matching scalars are left untouched.
+    """
+
+    def __init__(self, scalar_names: Sequence[str]) -> None:
+        self.scalar_names = {name.lower() for name in scalar_names}
+
+    def __call__(
+        self, data: TrajectoryData, metadata: TrajectoryMetadata
+    ) -> TrajectoryData:
+        scalars = data.get("constant_scalars")
+        if scalars:
+            for key, value in scalars.items():
+                if key.lower() in self.scalar_names:
+                    scalars[key] = value.log()
+            data["constant_scalars"] = scalars
+        return data

--- a/src/autocast/models/encoder_processor_decoder.py
+++ b/src/autocast/models/encoder_processor_decoder.py
@@ -82,6 +82,7 @@ class EncoderProcessorDecoder(
                 output_fields=batch.output_fields,
                 constant_scalars=batch.constant_scalars,
                 constant_fields=batch.constant_fields,
+                boundary_conditions=batch.boundary_conditions,
             )
         return batch
 

--- a/src/autocast/nn/vit.py
+++ b/src/autocast/nn/vit.py
@@ -1,5 +1,7 @@
 """Temporal ViT backbone with flexible temporal processing methods."""
 
+from collections.abc import Sequence
+
 from azula.nn.vit import ViT
 from torch import nn
 
@@ -28,7 +30,7 @@ class TemporalViTBackbone(TemporalBackboneBase):
         hid_channels: int = 768,
         hid_blocks: int = 12,
         attention_heads: int = 12,
-        patch_size: int = 4,
+        patch_size: int | Sequence[int] = 4,
         spatial: int = 2,
         temporal_method: str = "none",
         temporal_attention_heads: int = 8,
@@ -41,6 +43,11 @@ class TemporalViTBackbone(TemporalBackboneBase):
         ffn_factor: int = 4,
         checkpointing: bool = False,
         use_precomputed_modulation: bool = False,
+        unpatch_size: int | Sequence[int] | None = None,
+        qk_norm: bool = True,
+        rope: bool = False,
+        rpb: bool = True,
+        window_size: int | Sequence[int] | None = None,
     ):
         """Initialize Temporal ViT Backbone.
 
@@ -57,6 +64,7 @@ class TemporalViTBackbone(TemporalBackboneBase):
             hid_blocks: Number of transformer blocks
             attention_heads: Number of attention heads in ViT
             patch_size: Size of patches for ViT
+            unpatch_size: Optional output unpatch size for ViT
             spatial: Spatial dimensionality (2 for 2D)
             temporal_method: Method for temporal processing. Options:
                 - "attention": Multi-head self-attention over time
@@ -68,9 +76,21 @@ class TemporalViTBackbone(TemporalBackboneBase):
             tcn_num_layers: Number of TCN layers
             dropout: Dropout rate in ViT blocks
             ffn_factor: Feedforward network expansion factor in ViT blocks
+            qk_norm: Whether to normalize attention queries and keys
+            rope: Whether to use rotary positional embeddings in attention
+            rpb: Whether to use relative positional bias in attention
+            window_size: Local attention window size. Only None is supported by
+                the installed Azula ViT used here.
             checkpointing: Whether to use gradient checkpointing in ViT
             use_precomputed_modulation: Whether to use precomputed modulation tensors.
         """
+        if window_size is not None:
+            msg = (
+                "TemporalViTBackbone does not support non-null window_size with "
+                "the installed Azula ViT. Use window_size=null for global attention."
+            )
+            raise ValueError(msg)
+
         # Initialize base class with common parameters
         super().__init__(
             in_channels=in_channels,
@@ -97,9 +117,13 @@ class TemporalViTBackbone(TemporalBackboneBase):
             hid_blocks=hid_blocks,
             attention_heads=attention_heads,
             patch_size=patch_size,
+            unpatch_size=unpatch_size,
             spatial=spatial,
             ffn_factor=ffn_factor,
             dropout=dropout,
+            qk_norm=qk_norm,
+            rope=rope,
+            rpb=rpb,
             checkpointing=checkpointing,
         )
 
@@ -117,9 +141,13 @@ class TemporalViTBackbone(TemporalBackboneBase):
                 - hid_blocks: Number of transformer blocks
                 - attention_heads: Number of attention heads in ViT
                 - patch_size: Size of patches for ViT
+                - unpatch_size: Optional output unpatch size for ViT
                 - spatial: Spatial dimensionality (2 for 2D)
                 - ffn_factor: The channel factor in the FFN.
                 - dropout: The dropout rate in :math:`[0, 1]`.
+                - qk_norm: Whether to normalize attention queries and keys.
+                - rope: Whether to use rotary positional embeddings.
+                - rpb: Whether to use relative positional bias.
                 - checkpointing: Whether to use gradient checkpointing or not.
 
         Returns:
@@ -134,8 +162,12 @@ class TemporalViTBackbone(TemporalBackboneBase):
             hid_blocks=kwargs["hid_blocks"],
             attention_heads=kwargs["attention_heads"],
             patch_size=kwargs["patch_size"],
+            unpatch_size=kwargs.get("unpatch_size"),
             spatial=kwargs["spatial"],
             ffn_factor=kwargs.get("ffn_factor", 4),
             dropout=kwargs.get("dropout", 0.0),
+            qk_norm=kwargs.get("qk_norm", True),
+            rope=kwargs.get("rope", False),
+            rpb=kwargs.get("rpb", True),
             checkpointing=kwargs.get("checkpointing", False),
         )

--- a/src/autocast/processors/azula_vit.py
+++ b/src/autocast/processors/azula_vit.py
@@ -27,7 +27,7 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         hidden_dim: int = 768,
         num_heads: int = 12,
         n_layers: int = 6,
-        patch_size: int = 4,
+        patch_size: int | Sequence[int] = 4,
         temporal_method: str = "attention",
         loss_func: nn.Module | None = None,
         n_noise_channels: int | None = None,
@@ -37,6 +37,11 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         checkpointing: bool = False,
         n_steps_input: int = 1,
         n_steps_output: int = 1,
+        dropout: float = 0.0,
+        ffn_factor: int = 4,
+        qk_norm: bool = True,
+        rope: bool = False,
+        rpb: bool = True,
     ):
         super().__init__()
         self.n_spatial_dims = len(spatial_resolution)
@@ -91,6 +96,11 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
             temporal_method=temporal_method,
             temporal_attention_heads=num_heads,
             temporal_attention_hidden_dim=hidden_dim // num_heads,
+            dropout=dropout,
+            ffn_factor=ffn_factor,
+            qk_norm=qk_norm,
+            rope=rope,
+            rpb=rpb,
             checkpointing=checkpointing,
             use_precomputed_modulation=True,
         )

--- a/src/autocast/types/batch.py
+++ b/src/autocast/types/batch.py
@@ -20,6 +20,12 @@ from autocast.types.types import (
 BatchT = TypeVar("BatchT")
 
 
+def _pin_memory_if_available(tensor: Tensor) -> Tensor:
+    if not torch.cuda.is_available():
+        return tensor
+    return tensor.pin_memory()
+
+
 @dataclass
 class Sample:
     """A batch in input data space."""
@@ -106,20 +112,20 @@ class Batch:
     def pin_memory(self) -> "Batch":
         """Pin CPU tensors for faster host-to-device transfer."""
         return Batch(
-            input_fields=self.input_fields.pin_memory(),
-            output_fields=self.output_fields.pin_memory(),
+            input_fields=_pin_memory_if_available(self.input_fields),
+            output_fields=_pin_memory_if_available(self.output_fields),
             constant_scalars=(
-                self.constant_scalars.pin_memory()
+                _pin_memory_if_available(self.constant_scalars)
                 if self.constant_scalars is not None
                 else None
             ),
             constant_fields=(
-                self.constant_fields.pin_memory()
+                _pin_memory_if_available(self.constant_fields)
                 if self.constant_fields is not None
                 else None
             ),
             boundary_conditions=(
-                self.boundary_conditions.pin_memory()
+                _pin_memory_if_available(self.boundary_conditions)
                 if self.boundary_conditions is not None
                 else None
             ),
@@ -175,10 +181,14 @@ class EncodedBatch:
     def pin_memory(self) -> "EncodedBatch":
         """Pin CPU tensors for faster host-to-device transfer."""
         return EncodedBatch(
-            encoded_inputs=self.encoded_inputs.pin_memory(),
-            encoded_output_fields=self.encoded_output_fields.pin_memory(),
+            encoded_inputs=_pin_memory_if_available(self.encoded_inputs),
+            encoded_output_fields=_pin_memory_if_available(self.encoded_output_fields),
             global_cond=(
-                self.global_cond.pin_memory() if self.global_cond is not None else None
+                _pin_memory_if_available(self.global_cond)
+                if self.global_cond is not None
+                else None
             ),
-            encoded_info={k: v.pin_memory() for k, v in self.encoded_info.items()},
+            encoded_info={
+                k: _pin_memory_if_available(v) for k, v in self.encoded_info.items()
+            },
         )

--- a/src/autocast/types/batch.py
+++ b/src/autocast/types/batch.py
@@ -103,6 +103,28 @@ class Batch:
             ),
         )
 
+    def pin_memory(self) -> "Batch":
+        """Pin CPU tensors for faster host-to-device transfer."""
+        return Batch(
+            input_fields=self.input_fields.pin_memory(),
+            output_fields=self.output_fields.pin_memory(),
+            constant_scalars=(
+                self.constant_scalars.pin_memory()
+                if self.constant_scalars is not None
+                else None
+            ),
+            constant_fields=(
+                self.constant_fields.pin_memory()
+                if self.constant_fields is not None
+                else None
+            ),
+            boundary_conditions=(
+                self.boundary_conditions.pin_memory()
+                if self.boundary_conditions is not None
+                else None
+            ),
+        )
+
 
 @dataclass
 class EncodedBatch:
@@ -148,4 +170,15 @@ class EncodedBatch:
                 self.global_cond.to(device) if self.global_cond is not None else None
             ),
             encoded_info={k: v.to(device) for k, v in self.encoded_info.items()},
+        )
+
+    def pin_memory(self) -> "EncodedBatch":
+        """Pin CPU tensors for faster host-to-device transfer."""
+        return EncodedBatch(
+            encoded_inputs=self.encoded_inputs.pin_memory(),
+            encoded_output_fields=self.encoded_output_fields.pin_memory(),
+            global_cond=(
+                self.global_cond.pin_memory() if self.global_cond is not None else None
+            ),
+            encoded_info={k: v.pin_memory() for k, v in self.encoded_info.items()},
         )

--- a/tests/callbacks/test_grad_norm.py
+++ b/tests/callbacks/test_grad_norm.py
@@ -1,0 +1,47 @@
+from typing import Any, cast
+
+import pytest
+import torch
+
+from autocast.callbacks.grad_norm import GradNormCallback
+
+
+class _LoggedModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.zeros(2))
+        self.bias = torch.nn.Parameter(torch.zeros(1))
+        self.logged: dict[str, torch.Tensor | float] = {}
+
+    def log(self, name: str, value: torch.Tensor | float, **_: object) -> None:
+        self.logged[name] = value
+
+
+def test_grad_norm_callback_logs_pre_clip_norms_and_lr() -> None:
+    module = _LoggedModule()
+    module.weight.grad = torch.tensor([3.0, 4.0])
+    module.bias.grad = torch.tensor([12.0])
+    optimizer = torch.optim.SGD(module.parameters(), lr=0.125)
+
+    GradNormCallback().on_before_optimizer_step(
+        trainer=cast(Any, None),
+        pl_module=cast(Any, module),
+        optimizer=optimizer,
+    )
+
+    assert torch.as_tensor(module.logged["grad_norm"]).item() == pytest.approx(13.0)
+    assert torch.as_tensor(module.logged["grad_norm_max"]).item() == pytest.approx(12.0)
+    assert module.logged["lr"] == pytest.approx(0.125)
+
+
+def test_grad_norm_callback_noops_without_gradients() -> None:
+    module = _LoggedModule()
+    optimizer = torch.optim.SGD(module.parameters(), lr=0.125)
+
+    GradNormCallback().on_before_optimizer_step(
+        trainer=cast(Any, None),
+        pl_module=cast(Any, module),
+        optimizer=optimizer,
+    )
+
+    assert module.logged == {}

--- a/tests/data/test_batch_pin_memory.py
+++ b/tests/data/test_batch_pin_memory.py
@@ -1,0 +1,39 @@
+import torch
+
+from autocast.types import Batch, EncodedBatch
+
+
+def test_batch_pin_memory_noops_without_cuda(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    batch = Batch(
+        input_fields=torch.randn(2, 1, 4, 4, 1),
+        output_fields=torch.randn(2, 1, 4, 4, 1),
+        constant_scalars=torch.randn(2, 1),
+        constant_fields=torch.randn(2, 4, 4, 1),
+        boundary_conditions=torch.randn(2, 2),
+    )
+
+    pinned = batch.pin_memory()
+
+    assert pinned.input_fields is batch.input_fields
+    assert pinned.output_fields is batch.output_fields
+    assert pinned.constant_scalars is batch.constant_scalars
+    assert pinned.constant_fields is batch.constant_fields
+    assert pinned.boundary_conditions is batch.boundary_conditions
+
+
+def test_encoded_batch_pin_memory_noops_without_cuda(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    batch = EncodedBatch(
+        encoded_inputs=torch.randn(2, 1, 4, 4, 1),
+        encoded_output_fields=torch.randn(2, 4, 4, 1),
+        global_cond=torch.randn(2, 3),
+        encoded_info={"x": torch.randn(2, 1)},
+    )
+
+    pinned = batch.pin_memory()
+
+    assert pinned.encoded_inputs is batch.encoded_inputs
+    assert pinned.encoded_output_fields is batch.encoded_output_fields
+    assert pinned.global_cond is batch.global_cond
+    assert pinned.encoded_info["x"] is batch.encoded_info["x"]

--- a/tests/data/test_cached_latent_dataset.py
+++ b/tests/data/test_cached_latent_dataset.py
@@ -7,6 +7,7 @@ import torch
 from autocast.data.encoded_dataset import (
     CachedLatentDataset,
     EncodedDataModule,
+    MiniWellDataModule,
     MiniWellInputOutput,
 )
 from autocast.types.batch import EncodedBatch, EncodedSample
@@ -142,6 +143,34 @@ def test_miniwell_input_output_preserves_global_cond(tmp_path):
     assert sample.encoded_output_fields.shape == (3, 4, 5, 3)
     assert sample.global_cond is not None
     assert torch.allclose(sample.global_cond, labels[0])
+
+
+def test_miniwell_datamodule_supports_worker_dataloader(tmp_path):
+    for split in ("train", "valid", "test"):
+        split_dir = tmp_path / split
+        split_dir.mkdir(parents=True)
+        with h5py.File(split_dir / "data.h5", "w") as h5:
+            h5.create_dataset("state", data=torch.randn(2, 6, 3, 4, 5).numpy())
+            h5.create_dataset("label", data=torch.randn(2, 6).numpy())
+
+    dm = MiniWellDataModule(
+        data_path=str(tmp_path),
+        n_steps_input=2,
+        n_steps_output=3,
+        batch_size=2,
+        num_workers=1,
+        pin_memory=False,
+        persistent_workers=False,
+        prefetch_factor=2,
+    )
+
+    batch = next(iter(dm.train_dataloader()))
+
+    assert isinstance(batch, EncodedBatch)
+    assert batch.encoded_inputs.shape == (2, 2, 4, 5, 3)
+    assert batch.encoded_output_fields.shape == (2, 3, 4, 5, 3)
+    assert batch.global_cond is not None
+    assert batch.global_cond.shape == (2, 6)
 
 
 # --- EncodedDataModule with CachedLatentDataset tests ---

--- a/tests/data/test_cached_latent_dataset.py
+++ b/tests/data/test_cached_latent_dataset.py
@@ -1,11 +1,13 @@
 """Tests for CachedLatentDataset and its integration with EncodedDataModule."""
 
+import h5py
 import pytest
 import torch
 
 from autocast.data.encoded_dataset import (
     CachedLatentDataset,
     EncodedDataModule,
+    MiniWellInputOutput,
 )
 from autocast.types.batch import EncodedBatch, EncodedSample
 from autocast.types.collation import collate_encoded_samples
@@ -115,6 +117,31 @@ def test_cached_dataset_collation_produces_encoded_batch(tmp_path):
     assert isinstance(batch, EncodedBatch)
     assert batch.encoded_inputs.shape == (3, 2, *spatial)
     assert batch.encoded_output_fields.shape == (3, 2, *spatial)
+
+
+def test_miniwell_input_output_preserves_global_cond(tmp_path):
+    file_path = tmp_path / "data.h5"
+    state = torch.randn(2, 6, 3, 4, 5)
+    labels = torch.randn(2, 6)
+    with h5py.File(file_path, "w") as h5:
+        h5.create_dataset("state", data=state.numpy())
+        h5.create_dataset("label", data=labels.numpy())
+
+    dataset = MiniWellInputOutput(
+        file_name=str(file_path),
+        n_steps_input=2,
+        n_steps_output=3,
+        steps=5,
+        stride=1,
+    )
+
+    sample = dataset[0]
+
+    assert isinstance(sample, EncodedSample)
+    assert sample.encoded_inputs.shape == (2, 4, 5, 3)
+    assert sample.encoded_output_fields.shape == (3, 4, 5, 3)
+    assert sample.global_cond is not None
+    assert torch.allclose(sample.global_cond, labels[0])
 
 
 # --- EncodedDataModule with CachedLatentDataset tests ---

--- a/tests/data/test_transforms.py
+++ b/tests/data/test_transforms.py
@@ -1,0 +1,36 @@
+import torch
+
+from autocast.data.transforms import LogScalars
+
+
+def test_log_scalars_logs_selected_constant_scalars() -> None:
+    transform = LogScalars(scalar_names=("Rayleigh", "Prandtl", "rho0"))
+    data = {
+        "constant_scalars": {
+            "Rayleigh": torch.tensor([1.0e6]),
+            "Prandtl": torch.tensor([7.0]),
+            "rho0": torch.tensor([3.0]),
+            "T0": torch.tensor([10.0]),
+            "unscaled": torch.tensor([5.0]),
+        }
+    }
+
+    out = transform(data, metadata=None)  # type: ignore  # noqa: PGH003
+    scalars = out["constant_scalars"]
+
+    assert torch.allclose(scalars["Rayleigh"], torch.log(torch.tensor([1.0e6])))
+    assert torch.allclose(scalars["Prandtl"], torch.log(torch.tensor([7.0])))
+    assert torch.allclose(scalars["rho0"], torch.log(torch.tensor([3.0])))
+    assert torch.equal(scalars["T0"], torch.tensor([10.0]))
+    assert torch.equal(scalars["unscaled"], torch.tensor([5.0]))
+
+
+def test_log_scalars_allows_custom_scalar_names() -> None:
+    transform = LogScalars(scalar_names=("custom",))
+    data = {"constant_scalars": {"custom": torch.tensor([4.0])}}
+
+    out = transform(data, metadata=None)  # type: ignore  # noqa: PGH003
+
+    assert torch.allclose(
+        out["constant_scalars"]["custom"], torch.log(torch.tensor([4.0]))
+    )

--- a/tests/models/test_encoder_processor_decoder.py
+++ b/tests/models/test_encoder_processor_decoder.py
@@ -7,6 +7,8 @@ from conftest import CondCaptureProcessor, get_optimizer_config
 from torch import nn
 
 from autocast.decoders.channels_last import ChannelsLast
+from autocast.decoders.identity import IdentityDecoder
+from autocast.encoders.identity import IdentityEncoder
 from autocast.encoders.permute_concat import PermuteConcat
 from autocast.models.encoder_decoder import EncoderDecoder
 from autocast.models.encoder_processor_decoder import EncoderProcessorDecoder
@@ -126,6 +128,90 @@ def test_global_cond_passes_from_encoder_to_processor():
 
     assert processor.last_global_cond is not None
     assert torch.allclose(processor.last_global_cond, constant_scalars)
+
+
+def test_boundary_conditions_pass_from_encoder_to_processor_with_input_noise():
+    batch_size = 2
+    t_steps = 1
+    w = 8
+    h = 8
+    channels = 2
+
+    input_fields = torch.randn(batch_size, t_steps, w, h, channels)
+    output_fields = torch.randn(batch_size, t_steps, w, h, channels)
+    constant_scalars = torch.tensor([[5.0], [7.0]])
+    boundary_conditions = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+
+    batch = Batch(
+        input_fields=input_fields,
+        output_fields=output_fields,
+        constant_scalars=constant_scalars,
+        constant_fields=None,
+        boundary_conditions=boundary_conditions,
+    )
+
+    class ZeroNoise(nn.Module):
+        def forward(self, x: Tensor) -> Tensor:
+            return x
+
+    encoder = PermuteConcat(
+        in_channels=channels, n_steps_input=t_steps, with_constants=False
+    )
+    decoder = ChannelsLast(output_channels=channels, time_steps=t_steps)
+    encoder_decoder = EncoderDecoder(encoder=encoder, decoder=decoder)
+
+    processor = CondCaptureProcessor()
+    model = EncoderProcessorDecoder(
+        encoder_decoder=encoder_decoder,
+        processor=processor,
+        input_noise_injector=ZeroNoise(),  # type: ignore  # noqa: PGH003
+        optimizer_config=get_optimizer_config(),
+    )
+
+    _ = model(batch)
+
+    expected = torch.cat([constant_scalars, boundary_conditions], dim=1)
+    assert processor.last_global_cond is not None
+    assert torch.allclose(processor.last_global_cond, expected)
+
+
+def test_boundary_conditions_pass_with_identity_encoder():
+    batch_size = 2
+    t_steps = 1
+    w = 8
+    h = 8
+    channels = 2
+
+    input_fields = torch.randn(batch_size, t_steps, w, h, channels)
+    output_fields = torch.randn(batch_size, t_steps, w, h, channels)
+    constant_scalars = torch.tensor([[5.0], [7.0]])
+    boundary_conditions = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+
+    batch = Batch(
+        input_fields=input_fields,
+        output_fields=output_fields,
+        constant_scalars=constant_scalars,
+        constant_fields=None,
+        boundary_conditions=boundary_conditions,
+    )
+
+    encoder_decoder = EncoderDecoder(
+        encoder=IdentityEncoder(in_channels=channels),
+        decoder=IdentityDecoder(in_channels=channels),
+    )
+
+    processor = CondCaptureProcessor()
+    model = EncoderProcessorDecoder(
+        encoder_decoder=encoder_decoder,
+        processor=processor,
+        optimizer_config=get_optimizer_config(),
+    )
+
+    _ = model(batch)
+
+    expected = torch.cat([constant_scalars, boundary_conditions], dim=1)
+    assert processor.last_global_cond is not None
+    assert torch.allclose(processor.last_global_cond, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -695,7 +695,9 @@ def test_validation_metric_plot_callback_wandb_log_omits_step(tmp_path: Path):
         )
 
 
-def test_default_trainer_config_tracks_coverage_winkler_without_plots(config_dir: str):
+def test_default_trainer_config_tracks_coverage_winkler_without_plots(
+    config_dir: str,
+):
     trainer_cfg = OmegaConf.load(Path(config_dir) / "trainer" / "default.yaml")
     callbacks = list(trainer_cfg.callbacks)
     monitors = [callback.get("monitor") for callback in callbacks]


### PR DESCRIPTION
## Summary

- Contributes towards #283.
- Add encoded dataset compatibility for both `label` and `global_cond`
  conditioning keys, with process-local HDF5 handles for DataLoader
  workers.
- Preserve boundary-condition tensors through the
  encoder-processor-decoder batch path.
- Extend ViT and Azula ViT configuration options needed by the
  Rayleigh-Benard runs, and remove default validation plotting from the
  trainer config.

## Testing

- Not run in this PR-prep pass.