### PR TITLE
Add RB ambient run configs

### DIFF
--- a/local_hydra/datamodule/rayleigh_benard.yaml
+++ b/local_hydra/datamodule/rayleigh_benard.yaml
@@ -1,0 +1,32 @@
+# Rayleigh-Benard The Well dataset configuration.
+_target_: autocast.data.datamodule.TheWellDataModule
+
+well_dataset_name: rayleigh_benard
+well_base_path: ${oc.env:AUTOCAST_DATASETS,./datasets}
+
+n_steps_input: 1
+n_steps_output: 4
+min_dt_stride: 1
+max_dt_stride: 1
+
+batch_size: 16
+num_workers: 8
+
+use_normalization: true
+normalization_path: ${.well_base_path}/${.well_dataset_name}/stats.yaml
+
+# Deterministic LOLA-style conditioning transform. This runs through
+# WellDataset(transform=...) for every split, including eval/rollout loaders.
+transform:
+  _target_: autocast.data.transforms.LogScalars
+  # Match the LOLA latent cache labels for Rayleigh-Benard:
+  # [log(Rayleigh), log(Prandtl), flattened boundary conditions].
+  scalar_names: [Rayleigh, Prandtl]
+
+autoencoder_mode: false
+max_rollout_steps: 100
+flatten_tensors: true
+cache_small: true
+max_cache_size: 1.0e9
+return_grid: true
+boundary_return_type: padding

--- a/local_hydra/datamodule/rayleigh_benard.yaml
+++ b/local_hydra/datamodule/rayleigh_benard.yaml
@@ -15,7 +15,7 @@ num_workers: 8
 use_normalization: true
 normalization_path: ${.well_base_path}/${.well_dataset_name}/stats.yaml
 
-# Deterministic LOLA-style conditioning transform. This runs through
+# Deterministic conditioning transform. This runs through
 # WellDataset(transform=...) for every split, including eval/rollout loaders.
 transform:
   _target_: autocast.data.transforms.LogScalars

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/crps_vit_azula_large_ambient.yaml
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/crps_vit_azula_large_ambient.yaml
@@ -1,0 +1,70 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: rayleigh_benard
+  - override /encoder@model.encoder: identity
+  - override /decoder@model.decoder: identity
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: the_well_rayleigh_benard_crps_vit_azula_large_ambient
+
+# CRPS directly in ambient Rayleigh-Benard space. Use identity encoder/decoder
+# so constants and boundary conditions are routed through global_cond/AdaLN, as
+# in the CNS identity+global_cond ablation.
+datamodule:
+  batch_size: 32
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  train_in_latent_space: false
+  n_members: 8
+  processor:
+    # Match the LOLA latent token grid: cached RB latents are 16x4 with
+    # patch_size=1, and raw RB is 512x128, so patch_size=32 gives the same
+    # 16x4 token layout. hidden_dim=848, n_layers=16 keeps the trainable
+    # processor close to the ~218M LOLA-scale budget.
+    hidden_dim: 848
+    num_heads: 8
+    n_layers: 16
+    patch_size: 32
+    n_noise_channels: 1024
+    # Route RB constants and boundary conditions through global_cond/AdaLN,
+    # not spatial concatenation.
+    global_cond_channels: auto
+    include_global_cond: true
+  loss_func:
+    _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
+  train_metrics:
+    afcrps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+    afcrps_mae_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSMAETerm
+    afcrps_spread_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSSpreadTerm
+  val_metrics:
+    afcrps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+    afcrps_mae_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSMAETerm
+    afcrps_spread_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSSpreadTerm
+    spread:
+      _target_: autocast.metrics.ensemble.EnsembleSpread
+    multicoverage:
+      _target_: autocast.metrics.MultiCoverage
+    multiwinkler:
+      _target_: autocast.metrics.ensemble.MultiWinkler

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/crps_vit_azula_lola_pixel_ambient.yaml
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/crps_vit_azula_lola_pixel_ambient.yaml
@@ -1,0 +1,76 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: rayleigh_benard
+  - override /encoder@model.encoder: identity
+  - override /decoder@model.decoder: identity
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: the_well_rayleigh_benard_crps_vit_azula_lola_pixel_ambient
+
+# CRPS directly in ambient Rayleigh-Benard space using the pixel-space ViT
+# hyperparameters from LOLA's experiments/configs/surrogate/vit_pixel.yaml.
+datamodule:
+  batch_size: 32
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  train_in_latent_space: false
+  n_members: 8
+  processor:
+    # LOLA's pixel ViT uses patch_size=[1, 16, 16] because its ViT sees
+    # time as an additional spatial axis. AutoCast's AzulaViTProcessor folds
+    # time into channels before the 2D ViT, so the equivalent spatial patching
+    # is [16, 16].
+    hidden_dim: 2048
+    num_heads: 16
+    n_layers: 16
+    ffn_factor: 4
+    patch_size: [16, 16]
+    n_noise_channels: 256
+    qk_norm: true
+    rope: true
+    # LOLA's ViT does not add Azula's relative positional bias path.
+    rpb: false
+    dropout: 0.05
+    checkpointing: true
+    # Route RB constants and boundary conditions through global_cond/AdaLN,
+    # not spatial concatenation.
+    global_cond_channels: auto
+    include_global_cond: true
+  loss_func:
+    _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
+  train_metrics:
+    afcrps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+    afcrps_mae_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSMAETerm
+    afcrps_spread_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSSpreadTerm
+  val_metrics:
+    afcrps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+    afcrps_mae_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSMAETerm
+    afcrps_spread_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSSpreadTerm
+    spread:
+      _target_: autocast.metrics.ensemble.EnsembleSpread
+    multicoverage:
+      _target_: autocast.metrics.MultiCoverage
+    multiwinkler:
+      _target_: autocast.metrics.ensemble.MultiWinkler

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/fm_vit_large_ambient_identity.yaml
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/fm_vit_large_ambient_identity.yaml
@@ -30,6 +30,8 @@ optimizer:
   warmup: 0
 
 model:
+  # Identity encoder/decoder keep FM in normalized ambient RB space while
+  # EncoderWithCond still passes log-scaled scalars and boundary conditions.
   train_in_latent_space: true
   freeze_encoder_decoder: true
   processor:

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/fm_vit_large_ambient_identity.yaml
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/fm_vit_large_ambient_identity.yaml
@@ -1,0 +1,48 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: rayleigh_benard
+  - override /encoder@model.encoder: identity
+  - override /decoder@model.decoder: identity
+  - override /processor@model.processor: flow_matching_vit
+  - override /backbone@model.processor.backbone: vit
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: the_well_rayleigh_benard_fm_vit_large_ambient_identity
+
+# Raw/ambient-space flow matching baseline. Identity encoder/decoder means the
+# processor flow-matching loss is applied directly to normalized RB fields.
+datamodule:
+  batch_size: 256
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 1e-4
+  warmup: 0
+
+model:
+  train_in_latent_space: true
+  freeze_encoder_decoder: true
+  processor:
+    flow_ode_steps: 50
+    backbone:
+      # Match the LOLA latent token grid: cached RB latents are 16x4 with
+      # patch_size=1, and raw RB is 512x128, so patch_size=32 gives the same
+      # 16x4 token layout. The 936x16 ViT stays near the ~218M-parameter LOLA
+      # FM latent processor.
+      hid_channels: 936
+      hid_blocks: 16
+      attention_heads: 8
+      patch_size: 32
+      dropout: 0.05
+      ffn_factor: 4
+  val_metrics: []

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/fm_vit_lola_pixel_ambient_identity.yaml
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/fm_vit_lola_pixel_ambient_identity.yaml
@@ -1,0 +1,55 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: rayleigh_benard
+  - override /encoder@model.encoder: identity
+  - override /decoder@model.decoder: identity
+  - override /processor@model.processor: flow_matching_vit
+  - override /backbone@model.processor.backbone: vit
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: the_well_rayleigh_benard_fm_vit_lola_pixel_ambient_identity
+
+# Raw/ambient-space flow matching baseline using the pixel-space ViT
+# hyperparameters from LOLA's experiments/configs/surrogate/vit_pixel.yaml.
+datamodule:
+  batch_size: 256
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 1e-4
+  warmup: 0
+
+model:
+  train_in_latent_space: true
+  freeze_encoder_decoder: true
+  processor:
+    flow_ode_steps: 50
+    backbone:
+      # LOLA's pixel ViT uses patch_size=[1, 16, 16] because its ViT sees
+      # time as an additional spatial axis. AutoCast's TemporalViTBackbone
+      # folds time into channels before the 2D ViT, so the equivalent spatial
+      # patching is [16, 16].
+      mod_features: 256
+      hid_channels: 2048
+      hid_blocks: 16
+      ffn_factor: 4
+      attention_heads: 16
+      qk_norm: true
+      rope: true
+      # LOLA's ViT does not add Azula's relative positional bias path.
+      rpb: false
+      patch_size: [16, 16]
+      window_size: null
+      dropout: 0.05
+      checkpointing: true
+  val_metrics: []

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/fm_vit_lola_pixel_ambient_identity.yaml
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/fm_vit_lola_pixel_ambient_identity.yaml
@@ -30,6 +30,8 @@ optimizer:
   warmup: 0
 
 model:
+  # Identity encoder/decoder keep FM in normalized ambient RB space while
+  # EncoderWithCond still passes log-scaled scalars and boundary conditions.
   train_in_latent_space: true
   freeze_encoder_decoder: true
   processor:


### PR DESCRIPTION
## Summary

- Add a local Rayleigh-Benard datamodule preset with log-scalar conditioning.
- Add ambient CRPS and flow-matching RB experiment configs that use the shared preset.
- Keep run-specific batch sizes and model settings in the experiment configs while centralizing RB data settings.

## Validation

- `uv run python -m autocast.scripts.train.encoder_processor_decoder --cfg job local_experiment=the_well/rayleigh_benard/crps_vit_azula_large_ambient`
- `uv run python -m autocast.scripts.train.encoder_processor_decoder --cfg job local_experiment=the_well/rayleigh_benard/crps_vit_azula_lola_pixel_ambient`
- `uv run python -m autocast.scripts.train.encoder_processor_decoder --cfg job local_experiment=the_well/rayleigh_benard/fm_vit_large_ambient_identity`
- `uv run python -m autocast.scripts.train.encoder_processor_decoder --cfg job local_experiment=the_well/rayleigh_benard/fm_vit_lola_pixel_ambient_identity`
