### PR TITLE
Add RB comparison workflows

### DIFF
--- a/local_hydra/datamodule/rayleigh_benard.yaml
+++ b/local_hydra/datamodule/rayleigh_benard.yaml
@@ -15,7 +15,7 @@ num_workers: 8
 use_normalization: true
 normalization_path: ${.well_base_path}/${.well_dataset_name}/stats.yaml
 
-# Deterministic LOLA-style conditioning transform. This runs through
+# Deterministic conditioning transform. This runs through
 # WellDataset(transform=...) for every split, including eval/rollout loaders.
 transform:
   _target_: autocast.data.transforms.LogScalars

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/README.md
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/README.md
@@ -5,8 +5,9 @@ reviewable presets. The ambient configs share the local
 `datamodule/rayleigh_benard.yaml` preset so Rayleigh-Benard scalar handling has
 one source of truth.
 
-The historical May comparison branch also contained a large set of SLURM
-submitters for effective-batch, timing, recovery-eval, and `start16` plotting
-runs. Those scripts are intentionally not mirrored here because they encode
-run-specific output paths and overlapping launcher variants. Add curated
-workflow entrypoints separately if they become active maintained workflows.
+The maintained SLURM entrypoints for the active RB comparison matrix live under
+`slurm_scripts/comparison/the_well/rayleigh_benard/`. They intentionally avoid
+mirroring every historical submitter from
+[#369](https://github.com/alan-turing-institute/autocast/pull/369); the scripts
+there are grouped by the two active comparison questions instead of by
+recovered run history.

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/README.md
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/README.md
@@ -11,3 +11,8 @@ mirroring every historical submitter from
 [#369](https://github.com/alan-turing-institute/autocast/pull/369); the scripts
 there are grouped by the two active comparison questions instead of by
 recovered run history.
+
+The ambient FM configs are kept as optional presets for future ablations. They
+complete the ambient/latent method matrix, but are not wired into the maintained
+comparison submitters because ambient-space FM is expected to be substantially
+more expensive than the selected 24h comparison runs.

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/README.md
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/README.md
@@ -1,0 +1,12 @@
+# Rayleigh-Benard run configs
+
+This folder keeps the Rayleigh-Benard experiment configs that are useful as
+reviewable presets. The ambient configs share the local
+`datamodule/rayleigh_benard.yaml` preset so Rayleigh-Benard scalar handling has
+one source of truth.
+
+The historical May comparison branch also contained a large set of SLURM
+submitters for effective-batch, timing, recovery-eval, and `start16` plotting
+runs. Those scripts are intentionally not mirrored here because they encode
+run-specific output paths and overlapping launcher variants. Add curated
+workflow entrypoints separately if they become active maintained workflows.

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/crps_vit_azula_large_latent.yaml
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/crps_vit_azula_large_latent.yaml
@@ -10,7 +10,7 @@ experiment_name: the_well_rayleigh_benard_crps_vit_azula_large_latent
 
 # CRPS directly in the cached LOLA latent space used by the RB FM baseline.
 # Batch 32/GPU with 8 ensemble members gives an effective per-GPU objective
-# batch of 256 for the effective-batch 24h scripts. The older equal-data LOLA
+# batch of 256 for the 24h comparison scripts. The older equal-data LOLA
 # scripts may still add gradient accumulation when matching their 4096-epoch
 # accounting.
 datamodule:

--- a/local_hydra/local_experiment/the_well/rayleigh_benard/crps_vit_azula_large_latent.yaml
+++ b/local_hydra/local_experiment/the_well/rayleigh_benard/crps_vit_azula_large_latent.yaml
@@ -1,0 +1,75 @@
+# @package _global_
+defaults:
+  - /distributed: ddp_4gpu_slurm
+  - override /datamodule: miniwell
+  - override /processor@model.processor: vit_azula_large
+  - override /optimizer: adamw_half
+  - _self_
+
+experiment_name: the_well_rayleigh_benard_crps_vit_azula_large_latent
+
+# CRPS directly in the cached LOLA latent space used by the RB FM baseline.
+# Batch 32/GPU with 8 ensemble members gives an effective per-GPU objective
+# batch of 256 for the effective-batch 24h scripts. The older equal-data LOLA
+# scripts may still add gradient accumulation when matching their 4096-epoch
+# accounting.
+datamodule:
+  data_path: ${oc.env:AUTOCAST_DATASETS,./datasets}/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large/cache/rayleigh_benard
+  n_steps_input: 1
+  n_steps_output: 4
+  stride: 1
+  batch_size: 32
+  num_workers: 8
+  pin_memory: true
+  persistent_workers: true
+  prefetch_factor: 2
+
+float32_matmul_precision: high
+
+logging:
+  wandb:
+    enabled: true
+
+output:
+  skip_test: true
+
+optimizer:
+  learning_rate: 2e-4
+  warmup: 0
+
+model:
+  n_members: 8
+  processor:
+    # Match the ~220M-parameter LOLA FM processor as closely as possible while
+    # keeping the latent patch_size=1 tokenization.
+    hidden_dim: 896
+    num_heads: 8
+    n_layers: 16
+    patch_size: 1
+    n_noise_channels: 1024
+    global_cond_channels: auto
+    include_global_cond: true
+    n_steps_input: ${datamodule.n_steps_input}
+    n_steps_output: ${datamodule.n_steps_output}
+  loss_func:
+    _target_: autocast.losses.ensemble.AlphaFairCRPSLoss
+  train_metrics:
+    afcrps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+    afcrps_mae_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSMAETerm
+    afcrps_spread_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSSpreadTerm
+  val_metrics:
+    afcrps:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPS
+    afcrps_mae_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSMAETerm
+    afcrps_spread_term:
+      _target_: autocast.metrics.ensemble.AlphaFairCRPSSpreadTerm
+    spread:
+      _target_: autocast.metrics.ensemble.EnsembleSpread
+    multicoverage:
+      _target_: autocast.metrics.MultiCoverage
+    multiwinkler:
+      _target_: autocast.metrics.ensemble.MultiWinkler

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/README.md
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/README.md
@@ -18,6 +18,11 @@ branches have all landed on `main`.
 | LOLA 4096-step comparison | FM latent, masked window | `the_well/rayleigh_benard/fm_vit_large_masked_window` |
 | LOLA 4096-step comparison | Diffusion latent | `the_well/rayleigh_benard/diffusion_vit_large_lola` |
 
+Additional ambient FM presets are available under
+`local_hydra/local_experiment/the_well/rayleigh_benard/` for future ablations,
+but are not part of these maintained submitters because they are expected to be
+more computationally expensive than the selected 24h comparison matrix.
+
 ## Entry points
 
 Use `DRY_RUN_ONLY=true` to only emit SLURM dry runs. By default each submitter

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/README.md
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/README.md
@@ -39,3 +39,8 @@ bash slurm_scripts/comparison/the_well/rayleigh_benard/submit_diffusion_eval.sh 
 Each entrypoint also accepts individual run keys, for example
 `submit_24h.sh final crps_latent fm_latent` or
 `submit_diffusion_eval.sh ab_o3`.
+
+For diffusion eval, `EVAL_MAX_ROLLOUT_STEPS` controls the requested rollout
+windows. The script derives `DATAMODULE_MAX_ROLLOUT_STEPS` from that value and
+`EVAL_ROLLOUT_START` so the rollout dataloader exposes enough truth frames for
+the requested horizon.

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/README.md
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/README.md
@@ -1,0 +1,41 @@
+# Rayleigh-Benard comparison submitters
+
+This folder contains the maintained Rayleigh-Benard submitters for the
+post-merge `283/` Rayleigh-Benard stack. Some configs referenced here live on
+parallel `283/` branches today, so these entrypoints are intended for the final
+state after the RB ambient, latent FM, masked FM, diffusion, and latent CRPS
+branches have all landed on `main`.
+
+## Config inventory
+
+| Group | Run | Config |
+| --- | --- | --- |
+| 24h comparison | CRPS ambient, LOLA pixel ViT | `the_well/rayleigh_benard/crps_vit_azula_lola_pixel_ambient` |
+| 24h comparison | CRPS ambient | `the_well/rayleigh_benard/crps_vit_azula_large_ambient` |
+| 24h comparison | CRPS latent | `the_well/rayleigh_benard/crps_vit_azula_large_latent` |
+| 24h comparison | FM latent | `the_well/rayleigh_benard/fm_vit_large` |
+| LOLA 4096-step comparison | FM latent | `the_well/rayleigh_benard/fm_vit_large` |
+| LOLA 4096-step comparison | FM latent, masked window | `the_well/rayleigh_benard/fm_vit_large_masked_window` |
+| LOLA 4096-step comparison | Diffusion latent | `the_well/rayleigh_benard/diffusion_vit_large_lola` |
+
+## Entry points
+
+Use `DRY_RUN_ONLY=true` to only emit SLURM dry runs. By default each submitter
+runs one dry-run submission and then the real submission, matching the existing
+comparison scripts.
+
+```bash
+# Timing probes or final 24h comparison runs.
+bash slurm_scripts/comparison/the_well/rayleigh_benard/submit_24h.sh timing all
+bash slurm_scripts/comparison/the_well/rayleigh_benard/submit_24h.sh final all
+
+# LOLA-equivalent 4096 epoch x 64 train-batch runs.
+bash slurm_scripts/comparison/the_well/rayleigh_benard/submit_lola4096.sh all
+
+# Diffusion eval modes: Euler, AB order 3, and DDPM.
+bash slurm_scripts/comparison/the_well/rayleigh_benard/submit_diffusion_eval.sh all
+```
+
+Each entrypoint also accepts individual run keys, for example
+`submit_24h.sh final crps_latent fm_latent` or
+`submit_diffusion_eval.sh ab_o3`.

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/_common.sh
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/_common.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Shared helpers for curated Rayleigh-Benard comparison submitters.
+
+RB_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RB_REPO_ROOT="$(cd "${RB_SCRIPT_DIR}/../../../.." && pwd)"
+RB_DATASETS_ROOT="${AUTOCAST_DATASETS:-${RB_REPO_ROOT}/datasets}"
+RB_CACHE_DIR="${RB_CACHE_DIR:-${RB_DATASETS_ROOT}/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large/cache/rayleigh_benard}"
+
+RB_EVAL_METRICS_DEFAULT="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,vmse_v2,vrmse_v2,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,spread,skill,ssr,winkler]"
+
+rb_has_hdf5_split() {
+    local split_dir="$1"
+
+    compgen -G "${split_dir}/*.h5" > /dev/null || \
+        compgen -G "${split_dir}/*.hdf5" > /dev/null
+}
+
+rb_require_cache() {
+    local split
+
+    for split in train valid test; do
+        if ! rb_has_hdf5_split "${RB_CACHE_DIR}/${split}"; then
+            echo "Missing ${split}/*.h5 or ${split}/*.hdf5 under ${RB_CACHE_DIR}" >&2
+            exit 1
+        fi
+    done
+}
+
+rb_run_dry_states() {
+    if [[ "${DRY_RUN_ONLY:-false}" == "true" ]]; then
+        printf '%s\n' "true"
+    else
+        printf '%s\n' "true" "false"
+    fi
+}
+
+rb_submit() {
+    local command="$1"
+    local run_dry="$2"
+    shift 2
+
+    local dry_run_arg=()
+    if [[ "${run_dry}" == "true" ]]; then
+        dry_run_arg=(--dry-run)
+    fi
+
+    (
+        cd "${RB_REPO_ROOT}"
+        uv run autocast "${command}" --mode slurm "${dry_run_arg[@]}" "$@"
+    )
+}
+
+rb_print_mode() {
+    local run_dry="$1"
+
+    if [[ "${run_dry}" == "true" ]]; then
+        printf '%s\n' "slurm --dry-run"
+    else
+        printf '%s\n' "slurm"
+    fi
+}

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/_common.sh
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/_common.sh
@@ -7,7 +7,7 @@ RB_REPO_ROOT="$(cd "${RB_SCRIPT_DIR}/../../../.." && pwd)"
 RB_DATASETS_ROOT="${AUTOCAST_DATASETS:-${RB_REPO_ROOT}/datasets}"
 RB_CACHE_DIR="${RB_CACHE_DIR:-${RB_DATASETS_ROOT}/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large/cache/rayleigh_benard}"
 
-RB_EVAL_METRICS_DEFAULT="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,vmse_v2,vrmse_v2,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,energy,spread,skill,ssr,winkler]"
+RB_EVAL_METRICS_DEFAULT="[mse,mae,nmse,nmae,rmse,nrmse,vmse,vrmse,vmse_v2,vrmse_v2,linf,psrmse,psrmse_low,psrmse_mid,psrmse_high,psrmse_tail,pscc,pscc_low,pscc_mid,pscc_high,pscc_tail,crps,fcrps,afcrps,spread,skill,ssr,winkler]"
 
 rb_has_hdf5_split() {
     local split_dir="$1"

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/submit_24h.sh
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/submit_24h.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+MODE="${1:-final}"
+if [[ "${MODE}" != "final" && "${MODE}" != "timing" ]]; then
+    echo "Usage: $0 [timing|final] [all|crps_lola_pixel_ambient crps_ambient crps_latent fm_latent ...]" >&2
+    exit 1
+fi
+shift || true
+
+if (($# == 0)) || [[ "${1:-}" == "all" ]]; then
+    RUN_KEYS=(crps_lola_pixel_ambient crps_ambient crps_latent fm_latent)
+else
+    RUN_KEYS=("$@")
+fi
+
+BUDGET_HOURS="${BUDGET_HOURS:-24}"
+BUDGET_MARGIN="${BUDGET_MARGIN:-0.02}"
+BUDGET_MAX_TIME="${BUDGET_MAX_TIME:-00:23:59:00}"
+TIMEOUT_MIN="${TIMEOUT_MIN:-1439}"
+EFFECTIVE_BATCHES_PER_EPOCH="${EFFECTIVE_BATCHES_PER_EPOCH:-64}"
+CHECK_VAL_EVERY_N_EPOCH="${CHECK_VAL_EVERY_N_EPOCH:-8}"
+DATALOADER_NUM_WORKERS="${DATALOADER_NUM_WORKERS:-8}"
+CPUS_PER_TASK="${CPUS_PER_TASK:-16}"
+LOG_EVERY_N_STEPS="${LOG_EVERY_N_STEPS:-50}"
+TIMING_EPOCHS="${TIMING_EPOCHS:-3}"
+NUM_GPUS="${NUM_GPUS:-4}"
+
+set_run_defaults() {
+    local key="$1"
+
+    EXTRA_OVERRIDES=()
+    USE_CACHE_DIR=false
+
+    case "${key}" in
+        crps_lola_pixel_ambient)
+            METHOD_LABEL="CRPS ambient, LOLA pixel ViT"
+            EXPERIMENT="the_well/rayleigh_benard/crps_vit_azula_lola_pixel_ambient"
+            EXPERIMENT_NAME="the_well_rayleigh_benard_24h_crps_lola_pixel_ambient_b32m8"
+            RUN_ID="rb_24h_crps_lola_pixel_ambient_b32m8"
+            PER_GPU_BATCH_SIZE_DEFAULT=32
+            N_MEMBERS=8
+            DEFAULT_COSINE_EPOCHS=272
+            ;;
+        crps_ambient)
+            METHOD_LABEL="CRPS ambient"
+            EXPERIMENT="the_well/rayleigh_benard/crps_vit_azula_large_ambient"
+            EXPERIMENT_NAME="the_well_rayleigh_benard_24h_crps_ambient_b32m8"
+            RUN_ID="rb_24h_crps_ambient_b32m8"
+            PER_GPU_BATCH_SIZE_DEFAULT=32
+            N_MEMBERS=8
+            DEFAULT_COSINE_EPOCHS=1642
+            ;;
+        crps_latent)
+            METHOD_LABEL="CRPS latent"
+            EXPERIMENT="the_well/rayleigh_benard/crps_vit_azula_large_latent"
+            EXPERIMENT_NAME="the_well_rayleigh_benard_24h_crps_latent_b32m8"
+            RUN_ID="rb_24h_crps_latent_b32m8"
+            PER_GPU_BATCH_SIZE_DEFAULT=32
+            N_MEMBERS=8
+            DEFAULT_COSINE_EPOCHS=2299
+            USE_CACHE_DIR=true
+            ;;
+        fm_latent)
+            METHOD_LABEL="FM latent"
+            EXPERIMENT="the_well/rayleigh_benard/fm_vit_large"
+            EXPERIMENT_NAME="the_well_rayleigh_benard_24h_fm_latent_b256"
+            RUN_ID="rb_24h_fm_latent_b256"
+            PER_GPU_BATCH_SIZE_DEFAULT=256
+            N_MEMBERS=1
+            DEFAULT_COSINE_EPOCHS=2130
+            USE_CACHE_DIR=true
+            ;;
+        *)
+            echo "Unknown 24h run key: ${key}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+resolve_cosine_epochs() {
+    local key="$1"
+    local env_name="COSINE_EPOCHS_${key^^}"
+    local specific_value="${!env_name:-}"
+
+    if [[ -n "${specific_value}" ]]; then
+        printf '%s\n' "${specific_value}"
+    elif [[ -n "${COSINE_EPOCHS:-}" ]]; then
+        printf '%s\n' "${COSINE_EPOCHS}"
+    else
+        printf '%s\n' "${DEFAULT_COSINE_EPOCHS}"
+    fi
+}
+
+submit_one_run() {
+    local key="$1"
+    local run_dry="$2"
+    local mode_label
+    local per_gpu_batch_size
+    local effective_global_batch
+    local effective_units_per_epoch
+    local cosine_epochs
+
+    set_run_defaults "${key}"
+    if [[ "${USE_CACHE_DIR}" == "true" ]]; then
+        rb_require_cache
+    fi
+
+    mode_label="$(rb_print_mode "${run_dry}")"
+    per_gpu_batch_size="${PER_GPU_BATCH_SIZE:-${PER_GPU_BATCH_SIZE_DEFAULT}}"
+    effective_global_batch="$((per_gpu_batch_size * N_MEMBERS * NUM_GPUS))"
+    effective_units_per_epoch="$((effective_global_batch * EFFECTIVE_BATCHES_PER_EPOCH))"
+
+    COMMON_OVERRIDES=(
+        "local_experiment=${EXPERIMENT}"
+        "experiment_name=${EXPERIMENT_NAME}"
+        "datamodule.batch_size=${per_gpu_batch_size}"
+        "datamodule.num_workers=${DATALOADER_NUM_WORKERS}"
+        "datamodule.pin_memory=true"
+        "datamodule.persistent_workers=true"
+        "datamodule.prefetch_factor=2"
+        "logging.wandb.enabled=true"
+        "hydra.launcher.cpus_per_task=${CPUS_PER_TASK}"
+        "hydra.launcher.timeout_min=${TIMEOUT_MIN}"
+    )
+    if [[ "${USE_CACHE_DIR}" == "true" ]]; then
+        COMMON_OVERRIDES+=("datamodule.data_path=${RB_CACHE_DIR}")
+    fi
+
+    echo "Submitting RB 24h comparison ${MODE} run"
+    echo "  mode: ${mode_label}"
+    echo "  method: ${METHOD_LABEL}"
+    echo "  local_experiment: ${EXPERIMENT}"
+    echo "  experiment_name: ${EXPERIMENT_NAME}"
+    echo "  datamodule.batch_size: ${per_gpu_batch_size} per GPU"
+    echo "  effective global batch: ${effective_global_batch}"
+    echo "  effective units/epoch: ${effective_units_per_epoch}"
+
+    if [[ "${MODE}" == "timing" ]]; then
+        rb_submit time-epochs "${run_dry}" \
+            --kind processor \
+            --run-group "timing/rb_24h_comparison" \
+            --run-id "${RUN_ID}" \
+            -n "${TIMING_EPOCHS}" \
+            -b "${BUDGET_HOURS}" \
+            -m "${BUDGET_MARGIN}" \
+            "${COMMON_OVERRIDES[@]}" \
+            "+trainer.limit_train_batches=${EFFECTIVE_BATCHES_PER_EPOCH}" \
+            "+trainer.check_val_every_n_epoch=${CHECK_VAL_EVERY_N_EPOCH}" \
+            "+trainer.num_sanity_val_steps=0" \
+            "+trainer.enable_progress_bar=false"
+    else
+        cosine_epochs="$(resolve_cosine_epochs "${key}")"
+        echo "  cosine_epochs: ${cosine_epochs}"
+        echo "  trainer.max_time: ${BUDGET_MAX_TIME}"
+
+        rb_submit processor "${run_dry}" \
+            --run-id "${EXPERIMENT_NAME}" \
+            "${COMMON_OVERRIDES[@]}" \
+            "optimizer.cosine_epochs=${cosine_epochs}" \
+            "trainer.max_time=${BUDGET_MAX_TIME}" \
+            "trainer.log_every_n_steps=${LOG_EVERY_N_STEPS}" \
+            "+trainer.accumulate_grad_batches=1" \
+            "+trainer.max_epochs=${cosine_epochs}" \
+            "+trainer.limit_train_batches=${EFFECTIVE_BATCHES_PER_EPOCH}" \
+            "+trainer.check_val_every_n_epoch=${CHECK_VAL_EVERY_N_EPOCH}" \
+            "+trainer.num_sanity_val_steps=0" \
+            "+trainer.enable_progress_bar=false" \
+            "trainer.callbacks.0.every_n_train_steps_fraction=0.05" \
+            "+trainer.callbacks.0.every_n_epochs=0" \
+            "trainer.callbacks.0.save_top_k=-1" \
+            "trainer.callbacks.0.filename=\"snapshot-{progress_token}-{epoch:04d}-{step:08d}\""
+    fi
+}
+
+for key in "${RUN_KEYS[@]}"; do
+    while IFS= read -r run_dry; do
+        submit_one_run "${key}" "${run_dry}"
+    done < <(rb_run_dry_states)
+done

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/submit_24h.sh
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/submit_24h.sh
@@ -35,6 +35,8 @@ set_run_defaults() {
 
     EXTRA_OVERRIDES=()
     USE_CACHE_DIR=false
+    TRAIN_COMMAND=processor
+    TIMING_KIND=processor
 
     case "${key}" in
         crps_lola_pixel_ambient)
@@ -45,6 +47,8 @@ set_run_defaults() {
             PER_GPU_BATCH_SIZE_DEFAULT=32
             N_MEMBERS=8
             DEFAULT_COSINE_EPOCHS=272
+            TRAIN_COMMAND=epd
+            TIMING_KIND=epd
             ;;
         crps_ambient)
             METHOD_LABEL="CRPS ambient"
@@ -54,6 +58,8 @@ set_run_defaults() {
             PER_GPU_BATCH_SIZE_DEFAULT=32
             N_MEMBERS=8
             DEFAULT_COSINE_EPOCHS=1642
+            TRAIN_COMMAND=epd
+            TIMING_KIND=epd
             ;;
         crps_latent)
             METHOD_LABEL="CRPS latent"
@@ -136,6 +142,7 @@ submit_one_run() {
     echo "Submitting RB 24h comparison ${MODE} run"
     echo "  mode: ${mode_label}"
     echo "  method: ${METHOD_LABEL}"
+    echo "  train command: ${TRAIN_COMMAND}"
     echo "  local_experiment: ${EXPERIMENT}"
     echo "  experiment_name: ${EXPERIMENT_NAME}"
     echo "  datamodule.batch_size: ${per_gpu_batch_size} per GPU"
@@ -144,7 +151,7 @@ submit_one_run() {
 
     if [[ "${MODE}" == "timing" ]]; then
         rb_submit time-epochs "${run_dry}" \
-            --kind processor \
+            --kind "${TIMING_KIND}" \
             --run-group "timing/rb_24h_comparison" \
             --run-id "${RUN_ID}" \
             -n "${TIMING_EPOCHS}" \
@@ -160,7 +167,7 @@ submit_one_run() {
         echo "  cosine_epochs: ${cosine_epochs}"
         echo "  trainer.max_time: ${BUDGET_MAX_TIME}"
 
-        rb_submit processor "${run_dry}" \
+        rb_submit "${TRAIN_COMMAND}" "${run_dry}" \
             --run-id "${EXPERIMENT_NAME}" \
             "${COMMON_OVERRIDES[@]}" \
             "optimizer.cosine_epochs=${cosine_epochs}" \

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/submit_24h.sh
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/submit_24h.sh
@@ -120,15 +120,17 @@ submit_one_run() {
         "experiment_name=${EXPERIMENT_NAME}"
         "datamodule.batch_size=${per_gpu_batch_size}"
         "datamodule.num_workers=${DATALOADER_NUM_WORKERS}"
-        "datamodule.pin_memory=true"
-        "datamodule.persistent_workers=true"
-        "datamodule.prefetch_factor=2"
         "logging.wandb.enabled=true"
         "hydra.launcher.cpus_per_task=${CPUS_PER_TASK}"
         "hydra.launcher.timeout_min=${TIMEOUT_MIN}"
     )
     if [[ "${USE_CACHE_DIR}" == "true" ]]; then
-        COMMON_OVERRIDES+=("datamodule.data_path=${RB_CACHE_DIR}")
+        COMMON_OVERRIDES+=(
+            "datamodule.data_path=${RB_CACHE_DIR}"
+            "datamodule.pin_memory=true"
+            "datamodule.persistent_workers=true"
+            "datamodule.prefetch_factor=2"
+        )
     fi
 
     echo "Submitting RB 24h comparison ${MODE} run"

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/submit_diffusion_eval.sh
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/submit_diffusion_eval.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+if (($# == 0)) || [[ "${1:-}" == "all" ]]; then
+    EVAL_KEYS=(euler ab_o3 ddpm)
+else
+    EVAL_KEYS=("$@")
+fi
+
+RUN_GLOB="${RUN_GLOB:-outputs/*/the_well_rayleigh_benard_diffusion_vit_large_lola4096}"
+EVAL_BATCH_SIZE="${EVAL_BATCH_SIZE:-1}"
+EVAL_CHUNK_SIZE="${EVAL_CHUNK_SIZE:-8}"
+EVAL_DIAGNOSTIC_MEMBER_INDICES="${EVAL_DIAGNOSTIC_MEMBER_INDICES:-[0]}"
+EVAL_ROLLOUT_MEMBER_RENDER_MODE="${EVAL_ROLLOUT_MEMBER_RENDER_MODE:-both}"
+EVAL_ROLLOUT_START="${EVAL_ROLLOUT_START:-16}"
+EVAL_BENCHMARK_ENABLED="${EVAL_BENCHMARK_ENABLED:-true}"
+EVAL_BENCHMARK_ROLLOUT_ENABLED="${EVAL_BENCHMARK_ROLLOUT_ENABLED:-true}"
+EVAL_AUTOENCODED_TARGET_METRICS="${EVAL_AUTOENCODED_TARGET_METRICS:-true}"
+EVAL_METRICS="${EVAL_METRICS:-${RB_EVAL_METRICS_DEFAULT}}"
+EVAL_SAMPLER_OVERRIDE="${EVAL_SAMPLER:-}"
+EVAL_SAMPLER_STEPS_OVERRIDE="${EVAL_SAMPLER_STEPS:-}"
+EVAL_SAMPLER_ORDER_OVERRIDE="${EVAL_SAMPLER_ORDER:-}"
+EVAL_N_MEMBERS_OVERRIDE="${EVAL_N_MEMBERS:-}"
+EVAL_SUBDIR_OVERRIDE="${EVAL_SUBDIR:-}"
+TIMEOUT_MIN="${TIMEOUT_MIN:-1439}"
+CPUS_PER_TASK="${CPUS_PER_TASK:-8}"
+SLURM_MEM="${SLURM_MEM:-115G}"
+
+find_run_dirs() {
+    local matches=()
+    local match
+
+    shopt -s nullglob
+    matches=( ${RUN_GLOB} )
+    shopt -u nullglob
+
+    if ((${#matches[@]} == 0)); then
+        echo "No matching Rayleigh-Benard diffusion runs found for RUN_GLOB=${RUN_GLOB}" >&2
+        exit 1
+    fi
+
+    for match in "${matches[@]}"; do
+        if [[ -f "${match}/resolved_config.yaml" && -e "${match}/processor.ckpt" ]]; then
+            printf '%s\n' "${match}"
+        else
+            echo "Skipping ${match}: resolved_config.yaml or processor.ckpt missing" >&2
+        fi
+    done
+}
+
+set_eval_defaults() {
+    local key="$1"
+
+    EXTRA_OVERRIDES=()
+
+    case "${key}" in
+        euler)
+            METHOD_LABEL="Euler probability-flow ODE"
+            EVAL_SAMPLER="${EVAL_SAMPLER_OVERRIDE:-euler}"
+            EVAL_SAMPLER_STEPS="${EVAL_SAMPLER_STEPS_OVERRIDE:-50}"
+            EVAL_N_MEMBERS="${EVAL_N_MEMBERS_OVERRIDE:-10}"
+            EVAL_SUBDIR="${EVAL_SUBDIR_OVERRIDE:-eval_encode_once_euler${EVAL_SAMPLER_STEPS}_start${EVAL_ROLLOUT_START}}"
+            ;;
+        ab_o3)
+            METHOD_LABEL="Adams-Bashforth order 3"
+            EVAL_SAMPLER="${EVAL_SAMPLER_OVERRIDE:-ab}"
+            EVAL_SAMPLER_STEPS="${EVAL_SAMPLER_STEPS_OVERRIDE:-16}"
+            EVAL_SAMPLER_ORDER="${EVAL_SAMPLER_ORDER_OVERRIDE:-3}"
+            EVAL_N_MEMBERS="${EVAL_N_MEMBERS_OVERRIDE:-16}"
+            EVAL_SUBDIR="${EVAL_SUBDIR_OVERRIDE:-eval_encode_once_ab${EVAL_SAMPLER_STEPS}_o${EVAL_SAMPLER_ORDER}_start${EVAL_ROLLOUT_START}}"
+            EXTRA_OVERRIDES=("++model.processor.sampler_order=${EVAL_SAMPLER_ORDER}")
+            ;;
+        ddpm)
+            METHOD_LABEL="DDPM stochastic reverse sampler"
+            EVAL_SAMPLER="${EVAL_SAMPLER_OVERRIDE:-ddpm}"
+            EVAL_SAMPLER_STEPS="${EVAL_SAMPLER_STEPS_OVERRIDE:-50}"
+            EVAL_N_MEMBERS="${EVAL_N_MEMBERS_OVERRIDE:-10}"
+            EVAL_SUBDIR="${EVAL_SUBDIR_OVERRIDE:-eval_encode_once_ddpm${EVAL_SAMPLER_STEPS}_start${EVAL_ROLLOUT_START}}"
+            ;;
+        *)
+            echo "Unknown diffusion eval key: ${key}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+submit_one_eval() {
+    local key="$1"
+    local run_dir="$2"
+    local run_dry="$3"
+    local mode_label
+    local run_dir_abs
+    local eval_output_dir
+
+    set_eval_defaults "${key}"
+
+    mode_label="$(rb_print_mode "${run_dry}")"
+    run_dir_abs="$(cd "${run_dir}" && pwd)"
+    eval_output_dir="${run_dir_abs}/${EVAL_SUBDIR}"
+
+    echo "Submitting RB LOLA diffusion eval"
+    echo "  mode: ${mode_label}"
+    echo "  method: ${METHOD_LABEL}"
+    echo "  run_dir: ${run_dir}"
+    echo "  output_subdir: ${EVAL_SUBDIR}"
+    echo "  model.processor.sampler: ${EVAL_SAMPLER}"
+    echo "  model.processor.sampler_steps: ${EVAL_SAMPLER_STEPS}"
+    echo "  eval.n_members: ${EVAL_N_MEMBERS}"
+    echo "  eval.rollout_start: ${EVAL_ROLLOUT_START}"
+
+    rb_submit eval "${run_dry}" \
+        --workdir "${run_dir}" \
+        --output-subdir "${EVAL_SUBDIR}" \
+        "eval.checkpoint=processor.ckpt" \
+        "eval.mode=encode_once" \
+        "model.processor.sampler=${EVAL_SAMPLER}" \
+        "model.processor.sampler_steps=${EVAL_SAMPLER_STEPS}" \
+        "eval.csv_path=${eval_output_dir}/evaluation_metrics.csv" \
+        "eval.video_dir=${eval_output_dir}/videos" \
+        "eval.metrics=${EVAL_METRICS}" \
+        "eval.batch_size=${EVAL_BATCH_SIZE}" \
+        "eval.n_members=${EVAL_N_MEMBERS}" \
+        "+eval.chunk_size=${EVAL_CHUNK_SIZE}" \
+        "eval.rollout_start=${EVAL_ROLLOUT_START}" \
+        "eval.transpose_spatial=true" \
+        "eval.compute_rollout_autoencoded_target_metrics=${EVAL_AUTOENCODED_TARGET_METRICS}" \
+        "eval.rollout_member_indices=${EVAL_DIAGNOSTIC_MEMBER_INDICES}" \
+        "eval.rollout_member_render_mode=${EVAL_ROLLOUT_MEMBER_RENDER_MODE}" \
+        "eval.benchmark.enabled=${EVAL_BENCHMARK_ENABLED}" \
+        "eval.benchmark_rollout.enabled=${EVAL_BENCHMARK_ROLLOUT_ENABLED}" \
+        "hydra.launcher.cpus_per_task=${CPUS_PER_TASK}" \
+        "hydra.launcher.additional_parameters.mem=${SLURM_MEM}" \
+        "hydra.launcher.timeout_min=${TIMEOUT_MIN}" \
+        "${EXTRA_OVERRIDES[@]}"
+}
+
+mapfile -t RUN_DIRS < <(find_run_dirs)
+if ((${#RUN_DIRS[@]} == 0)); then
+    echo "No usable Rayleigh-Benard diffusion runs found." >&2
+    exit 1
+fi
+
+for key in "${EVAL_KEYS[@]}"; do
+    for run_dir in "${RUN_DIRS[@]}"; do
+        while IFS= read -r run_dry; do
+            submit_one_eval "${key}" "${run_dir}" "${run_dry}"
+        done < <(rb_run_dry_states)
+    done
+done

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/submit_diffusion_eval.sh
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/submit_diffusion_eval.sh
@@ -17,6 +17,10 @@ EVAL_CHUNK_SIZE="${EVAL_CHUNK_SIZE:-8}"
 EVAL_DIAGNOSTIC_MEMBER_INDICES="${EVAL_DIAGNOSTIC_MEMBER_INDICES:-[0]}"
 EVAL_ROLLOUT_MEMBER_RENDER_MODE="${EVAL_ROLLOUT_MEMBER_RENDER_MODE:-both}"
 EVAL_ROLLOUT_START="${EVAL_ROLLOUT_START:-16}"
+EVAL_MAX_ROLLOUT_STEPS="${EVAL_MAX_ROLLOUT_STEPS:-46}"
+# With RB n_steps_output=4, 46 rollout windows gives 184 predicted timesteps.
+# Starting at timestep 16 therefore needs 200 truth frames from the datamodule.
+DATAMODULE_MAX_ROLLOUT_STEPS="${DATAMODULE_MAX_ROLLOUT_STEPS:-$((EVAL_ROLLOUT_START + EVAL_MAX_ROLLOUT_STEPS * 4))}"
 EVAL_BENCHMARK_ENABLED="${EVAL_BENCHMARK_ENABLED:-true}"
 EVAL_BENCHMARK_ROLLOUT_ENABLED="${EVAL_BENCHMARK_ROLLOUT_ENABLED:-true}"
 EVAL_AUTOENCODED_TARGET_METRICS="${EVAL_AUTOENCODED_TARGET_METRICS:-true}"
@@ -111,6 +115,8 @@ submit_one_eval() {
     echo "  model.processor.sampler_steps: ${EVAL_SAMPLER_STEPS}"
     echo "  eval.n_members: ${EVAL_N_MEMBERS}"
     echo "  eval.rollout_start: ${EVAL_ROLLOUT_START}"
+    echo "  eval.max_rollout_steps: ${EVAL_MAX_ROLLOUT_STEPS}"
+    echo "  datamodule.max_rollout_steps: ${DATAMODULE_MAX_ROLLOUT_STEPS}"
 
     rb_submit eval "${run_dry}" \
         --workdir "${run_dir}" \
@@ -126,6 +132,8 @@ submit_one_eval() {
         "eval.n_members=${EVAL_N_MEMBERS}" \
         "+eval.chunk_size=${EVAL_CHUNK_SIZE}" \
         "eval.rollout_start=${EVAL_ROLLOUT_START}" \
+        "eval.max_rollout_steps=${EVAL_MAX_ROLLOUT_STEPS}" \
+        "datamodule.max_rollout_steps=${DATAMODULE_MAX_ROLLOUT_STEPS}" \
         "eval.transpose_spatial=true" \
         "eval.compute_rollout_autoencoded_target_metrics=${EVAL_AUTOENCODED_TARGET_METRICS}" \
         "eval.rollout_member_indices=${EVAL_DIAGNOSTIC_MEMBER_INDICES}" \

--- a/slurm_scripts/comparison/the_well/rayleigh_benard/submit_lola4096.sh
+++ b/slurm_scripts/comparison/the_well/rayleigh_benard/submit_lola4096.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/_common.sh"
+
+if (($# == 0)) || [[ "${1:-}" == "all" ]]; then
+    RUN_KEYS=(fm fm_masked diffusion)
+else
+    RUN_KEYS=("$@")
+fi
+
+MAX_EPOCHS="${MAX_EPOCHS:-4096}"
+TRAIN_BATCHES_PER_EPOCH="${TRAIN_BATCHES_PER_EPOCH:-64}"
+DIFFUSION_VAL_BATCHES_PER_EPOCH="${DIFFUSION_VAL_BATCHES_PER_EPOCH:-16}"
+CHECK_VAL_EVERY_N_EPOCH="${CHECK_VAL_EVERY_N_EPOCH:-8}"
+PER_GPU_BATCH_SIZE="${PER_GPU_BATCH_SIZE:-64}"
+NUM_GPUS="${NUM_GPUS:-4}"
+BUDGET_MAX_TIME="${BUDGET_MAX_TIME:-00:23:59:00}"
+TIMEOUT_MIN="${TIMEOUT_MIN:-1439}"
+DATALOADER_NUM_WORKERS="${DATALOADER_NUM_WORKERS:-8}"
+CPUS_PER_TASK="${CPUS_PER_TASK:-16}"
+LOG_EVERY_N_STEPS="${LOG_EVERY_N_STEPS:-64}"
+
+set_run_defaults() {
+    local key="$1"
+
+    EXTRA_OVERRIDES=()
+
+    case "${key}" in
+        fm)
+            METHOD_LABEL="FM latent"
+            EXPERIMENT="the_well/rayleigh_benard/fm_vit_large"
+            EXPERIMENT_NAME="the_well_rayleigh_benard_fm_vit_large_lola4096"
+            ;;
+        fm_masked)
+            METHOD_LABEL="FM latent, masked window"
+            EXPERIMENT="the_well/rayleigh_benard/fm_vit_large_masked_window"
+            EXPERIMENT_NAME="the_well_rayleigh_benard_fm_vit_large_masked_window_lola4096"
+            ;;
+        diffusion)
+            METHOD_LABEL="Diffusion latent"
+            EXPERIMENT="the_well/rayleigh_benard/diffusion_vit_large_lola"
+            EXPERIMENT_NAME="the_well_rayleigh_benard_diffusion_vit_large_lola4096"
+            EXTRA_OVERRIDES=(
+                "trainer.gradient_clip_val=1.0"
+                "+trainer.limit_val_batches=${DIFFUSION_VAL_BATCHES_PER_EPOCH}"
+                "+trainer.check_val_every_n_epoch=1"
+            )
+            ;;
+        *)
+            echo "Unknown LOLA-4096 run key: ${key}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+submit_one_run() {
+    local key="$1"
+    local run_dry="$2"
+    local mode_label
+    local global_batch_size
+    local total_optimizer_steps
+    local val_cadence_steps
+
+    set_run_defaults "${key}"
+    rb_require_cache
+
+    mode_label="$(rb_print_mode "${run_dry}")"
+    global_batch_size="$((PER_GPU_BATCH_SIZE * NUM_GPUS))"
+    total_optimizer_steps="$((MAX_EPOCHS * TRAIN_BATCHES_PER_EPOCH))"
+    val_cadence_steps="$((CHECK_VAL_EVERY_N_EPOCH * TRAIN_BATCHES_PER_EPOCH))"
+
+    echo "Submitting RB LOLA-equivalent 4096 run"
+    echo "  mode: ${mode_label}"
+    echo "  method: ${METHOD_LABEL}"
+    echo "  local_experiment: ${EXPERIMENT}"
+    echo "  experiment_name: ${EXPERIMENT_NAME}"
+    echo "  cache dir: ${RB_CACHE_DIR}"
+    echo "  max_epochs: ${MAX_EPOCHS}"
+    echo "  train batches/epoch: ${TRAIN_BATCHES_PER_EPOCH}"
+    echo "  total optimizer steps: ${total_optimizer_steps}"
+    echo "  datamodule.batch_size: ${PER_GPU_BATCH_SIZE} per GPU"
+    echo "  effective global batch: ${global_batch_size}"
+    if [[ "${key}" != "diffusion" ]]; then
+        echo "  check_val_every_n_epoch: ${CHECK_VAL_EVERY_N_EPOCH}"
+        echo "  validation cadence: every ${val_cadence_steps} train steps"
+    fi
+
+    COMMON_OVERRIDES=(
+        "local_experiment=${EXPERIMENT}"
+        "experiment_name=${EXPERIMENT_NAME}"
+        "datamodule.data_path=${RB_CACHE_DIR}"
+        "datamodule.batch_size=${PER_GPU_BATCH_SIZE}"
+        "datamodule.num_workers=${DATALOADER_NUM_WORKERS}"
+        "datamodule.pin_memory=true"
+        "datamodule.persistent_workers=true"
+        "datamodule.prefetch_factor=2"
+        "logging.wandb.enabled=true"
+        "optimizer.cosine_epochs=${MAX_EPOCHS}"
+        "hydra.launcher.cpus_per_task=${CPUS_PER_TASK}"
+        "hydra.launcher.timeout_min=${TIMEOUT_MIN}"
+        "trainer.max_time=${BUDGET_MAX_TIME}"
+        "trainer.log_every_n_steps=${LOG_EVERY_N_STEPS}"
+        "+trainer.max_epochs=${MAX_EPOCHS}"
+        "+trainer.limit_train_batches=${TRAIN_BATCHES_PER_EPOCH}"
+        "+trainer.enable_progress_bar=false"
+        "+trainer.num_sanity_val_steps=0"
+        "trainer.callbacks.0.every_n_train_steps_fraction=0.05"
+        "+trainer.callbacks.0.every_n_epochs=0"
+        "trainer.callbacks.0.save_top_k=-1"
+        "trainer.callbacks.0.filename=\"snapshot-{progress_token}-{epoch:04d}-{step:08d}\""
+    )
+    if [[ "${key}" != "diffusion" ]]; then
+        COMMON_OVERRIDES+=("+trainer.check_val_every_n_epoch=${CHECK_VAL_EVERY_N_EPOCH}")
+    fi
+
+    rb_submit processor "${run_dry}" \
+        --run-id "${EXPERIMENT_NAME}" \
+        "${COMMON_OVERRIDES[@]}" \
+        "${EXTRA_OVERRIDES[@]}"
+}
+
+for key in "${RUN_KEYS[@]}"; do
+    while IFS= read -r run_dry; do
+        submit_one_run "${key}" "${run_dry}"
+    done < <(rb_run_dry_states)
+done


### PR DESCRIPTION
## Summary

- Add the cached-latent Rayleigh-Benard CRPS experiment config.
- Add curated Rayleigh-Benard comparison submitters for the final 283 stack.
- Document the post-merge run matrix for 24h comparisons, LOLA-equivalent training, and diffusion eval modes.
- Keep historical one-off submitters out of the maintained workflow surface.

## Notes

This PR is intended as the final comparison layer after the RB ambient, latent FM, masked FM, diffusion, and latent CRPS branches have landed. The separate time-epochs workflow branch is intentionally left out.

## Validation

- `bash -n slurm_scripts/comparison/the_well/rayleigh_benard/*.sh`
- `uv run python -m autocast.scripts.train.encoder_processor_decoder --cfg job local_experiment=the_well/rayleigh_benard/crps_vit_azula_large_latent logging.wandb.enabled=false`