### PR TITLE
Remove default validation plots

### DIFF
--- a/src/autocast/configs/trainer/default.yaml
+++ b/src/autocast/configs/trainer/default.yaml
@@ -133,16 +133,6 @@ callbacks:
     save_last: false
     filename: "best-multiwinkler-overall-{epoch:04d}-{val_multiwinkler:.4f}"
     auto_insert_metric_name: false
-  # Plot scalar validation metric histories and custom metric diagnostics
-  # such as the MultiCoverage reliability curve at each validation end.
-  - _target_: autocast.callbacks.metrics.ValidationMetricPlotCallback
-    metric_prefixes: ["val_"]
-    dirname: "validation_metrics"
-    filename: "validation_metrics.png"
-    max_cols: 3
-    save_local: true
-    log_to_logger: true
-    plot_metric_objects: true
   # EMA of model weights. decay=0.999 gives a half-life of ~700 steps,
   # which is a sensible fraction of our shorter runs (FM-ambient ~12k
   # steps) without being wildly reactive on the longest (CRPS-latent

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -695,14 +695,14 @@ def test_validation_metric_plot_callback_wandb_log_omits_step(tmp_path: Path):
         )
 
 
-def test_default_trainer_config_tracks_coverage_winkler_and_plots(config_dir: str):
+def test_default_trainer_config_tracks_coverage_winkler_without_plots(config_dir: str):
     trainer_cfg = OmegaConf.load(Path(config_dir) / "trainer" / "default.yaml")
     callbacks = list(trainer_cfg.callbacks)
     monitors = [callback.get("monitor") for callback in callbacks]
 
     assert "val_multicoverage" in monitors
     assert "val_multiwinkler" in monitors
-    assert any(
+    assert not any(
         callback.get("_target_")
         == "autocast.callbacks.metrics.ValidationMetricPlotCallback"
         for callback in callbacks


### PR DESCRIPTION
## Summary

- Remove the default validation metric plotting callback from trainer defaults.
- Avoid generating redundant local validation plot artifacts when metric history is already covered by W&B.

## Validation

- `git diff --check`
