### PR TITLE
Use Hydra Compose API for SLURM scripts

### DIFF
--- a/src/autocast/scripts/benchmark/encoder_processor_decoder.py
+++ b/src/autocast/scripts/benchmark/encoder_processor_decoder.py
@@ -22,7 +22,7 @@ from autocast.scripts.execution import (
     resolve_hydra_work_dir,
 )
 from autocast.scripts.setup import setup_datamodule, setup_epd_model
-from autocast.scripts.utils import get_default_config_path
+from autocast.scripts.utils import MODULE_CONFIG_NAMES, get_default_config_path
 from autocast.types.batch import Batch
 
 log = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 @hydra.main(
     version_base=None,
     config_path=get_default_config_path(),
-    config_name="encoder_processor_decoder",
+    config_name=MODULE_CONFIG_NAMES[__spec__.name],
 )
 def main(cfg: DictConfig) -> None:
     """Hydra entrypoint for EPD benchmark runs."""

--- a/src/autocast/scripts/cache_latents.py
+++ b/src/autocast/scripts/cache_latents.py
@@ -18,7 +18,7 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from autocast.scripts.data import batch_to_device
 from autocast.scripts.execution import resolve_hydra_work_dir
 from autocast.scripts.setup import setup_autoencoder_components, setup_datamodule
-from autocast.scripts.utils import get_default_config_path
+from autocast.scripts.utils import MODULE_CONFIG_NAMES, get_default_config_path
 from autocast.types.batch import Batch
 
 log = logging.getLogger(__name__)
@@ -216,7 +216,7 @@ def _apply_umask(cfg: DictConfig) -> None:
 @hydra.main(
     version_base=None,
     config_path=get_default_config_path(),
-    config_name="encoder_processor_decoder",
+    config_name=MODULE_CONFIG_NAMES[__spec__.name],
 )
 def main(cfg: DictConfig) -> None:
     """CLI entrypoint for caching latent representations."""

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -73,7 +73,7 @@ from autocast.scripts.setup import (
     setup_processor_model,
 )
 from autocast.scripts.training import apply_float32_matmul_precision
-from autocast.scripts.utils import get_default_config_path
+from autocast.scripts.utils import MODULE_CONFIG_NAMES, get_default_config_path
 from autocast.types.batch import Batch, EncodedBatch
 from autocast.utils import (
     plot_spatiotemporal_snapshots,
@@ -1344,7 +1344,7 @@ def _collect_benchmark_rows(
 @hydra.main(
     version_base=None,
     config_path=get_default_config_path(),
-    config_name="encoder_processor_decoder",
+    config_name=MODULE_CONFIG_NAMES[__spec__.name],
 )
 def main(cfg: DictConfig) -> None:
     """Entry point for CLI-based evaluation."""

--- a/src/autocast/scripts/train/autoencoder.py
+++ b/src/autocast/scripts/train/autoencoder.py
@@ -7,7 +7,7 @@ from omegaconf import DictConfig
 
 from autocast.scripts.execution import resolve_hydra_work_dir
 from autocast.scripts.training import train_autoencoder
-from autocast.scripts.utils import get_default_config_path
+from autocast.scripts.utils import MODULE_CONFIG_NAMES, get_default_config_path
 
 log = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 @hydra.main(
     version_base=None,
     config_path=get_default_config_path(),
-    config_name="autoencoder",
+    config_name=MODULE_CONFIG_NAMES[__spec__.name],
 )
 def main(cfg: DictConfig) -> None:
     """CLI entrypoint for autoencoder training."""

--- a/src/autocast/scripts/train/encoder_processor_decoder.py
+++ b/src/autocast/scripts/train/encoder_processor_decoder.py
@@ -11,7 +11,7 @@ from omegaconf import DictConfig
 from autocast.scripts.execution import resolve_hydra_work_dir
 from autocast.scripts.setup import setup_datamodule, setup_epd_model
 from autocast.scripts.training import run_training
-from autocast.scripts.utils import get_default_config_path
+from autocast.scripts.utils import MODULE_CONFIG_NAMES, get_default_config_path
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ def run_epd_training(
 @hydra.main(
     version_base=None,
     config_path=get_default_config_path(),
-    config_name="encoder_processor_decoder",
+    config_name=MODULE_CONFIG_NAMES[__spec__.name],
 )
 def main(cfg: DictConfig) -> None:
     """CLI entrypoint for training the encoder-processor-decoder."""

--- a/src/autocast/scripts/train/processor.py
+++ b/src/autocast/scripts/train/processor.py
@@ -9,7 +9,7 @@ from omegaconf import DictConfig
 from autocast.scripts.execution import resolve_hydra_work_dir
 from autocast.scripts.setup import setup_datamodule, setup_processor_model
 from autocast.scripts.training import run_training
-from autocast.scripts.utils import get_default_config_path
+from autocast.scripts.utils import MODULE_CONFIG_NAMES, get_default_config_path
 
 log = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 @hydra.main(
     version_base=None,
     config_path=get_default_config_path(),
-    config_name="processor",
+    config_name=MODULE_CONFIG_NAMES[__spec__.name],
 )
 def main(cfg: DictConfig) -> None:
     """CLI entrypoint for training the processor."""

--- a/src/autocast/scripts/train_eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/train_eval/encoder_processor_decoder.py
@@ -11,7 +11,7 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from autocast.scripts.eval.encoder_processor_decoder import run_evaluation
 from autocast.scripts.execution import resolve_hydra_work_dir
 from autocast.scripts.train.encoder_processor_decoder import run_epd_training
-from autocast.scripts.utils import get_default_config_path
+from autocast.scripts.utils import MODULE_CONFIG_NAMES, get_default_config_path
 
 log = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ def _apply_eval_overrides(cfg: DictConfig) -> DictConfig:
 @hydra.main(
     version_base=None,
     config_path=get_default_config_path(),
-    config_name="encoder_processor_decoder",
+    config_name=MODULE_CONFIG_NAMES[__spec__.name],
 )
 def main(cfg: DictConfig) -> None:
     """Hydra entrypoint for single-job train→eval flow."""

--- a/src/autocast/scripts/utils.py
+++ b/src/autocast/scripts/utils.py
@@ -15,6 +15,18 @@ from typing import Any, ClassVar
 import pandas as pd
 import yaml
 
+_EPD = "encoder_processor_decoder"
+
+MODULE_CONFIG_NAMES: dict[str, str] = {
+    "autocast.scripts.train.autoencoder": "autoencoder",
+    "autocast.scripts.train.encoder_processor_decoder": _EPD,
+    "autocast.scripts.train.processor": "processor",
+    "autocast.scripts.eval.encoder_processor_decoder": _EPD,
+    "autocast.scripts.benchmark.encoder_processor_decoder": _EPD,
+    "autocast.scripts.train_eval.encoder_processor_decoder": _EPD,
+    "autocast.scripts.cache_latents": _EPD,
+}
+
 
 def default_run_name(prefix: str = "run") -> str:
     """Generate a short default run name when none is provided."""

--- a/src/autocast/scripts/workflow/constants.py
+++ b/src/autocast/scripts/workflow/constants.py
@@ -13,17 +13,6 @@ BENCHMARK_MODULE = "autocast.scripts.benchmark.encoder_processor_decoder"
 TRAIN_EVAL_MODULE = "autocast.scripts.train_eval.encoder_processor_decoder"
 CACHE_LATENTS_MODULE = "autocast.scripts.cache_latents"
 
-_VALID_CONFIG_NAMES = {"autoencoder", "encoder_processor_decoder", "processor"}
-
-
-def config_name_for_module(module: str) -> str:
-    """Derive the Hydra ``config_name`` for a training/eval module."""
-    stem = module.rsplit(".", 1)[-1]
-    if stem in _VALID_CONFIG_NAMES:
-        return stem
-    return "encoder_processor_decoder"
-
-
 NAMING_DEFAULT_KEYS: set[str] = {
     "processor@model.processor",
     "input_noise_injector@model.input_noise_injector",

--- a/src/autocast/scripts/workflow/constants.py
+++ b/src/autocast/scripts/workflow/constants.py
@@ -13,6 +13,17 @@ BENCHMARK_MODULE = "autocast.scripts.benchmark.encoder_processor_decoder"
 TRAIN_EVAL_MODULE = "autocast.scripts.train_eval.encoder_processor_decoder"
 CACHE_LATENTS_MODULE = "autocast.scripts.cache_latents"
 
+_VALID_CONFIG_NAMES = {"autoencoder", "encoder_processor_decoder", "processor"}
+
+
+def config_name_for_module(module: str) -> str:
+    """Derive the Hydra ``config_name`` for a training/eval module."""
+    stem = module.rsplit(".", 1)[-1]
+    if stem in _VALID_CONFIG_NAMES:
+        return stem
+    return "encoder_processor_decoder"
+
+
 NAMING_DEFAULT_KEYS: set[str] = {
     "processor@model.processor",
     "input_noise_injector@model.input_noise_injector",

--- a/src/autocast/scripts/workflow/helpers.py
+++ b/src/autocast/scripts/workflow/helpers.py
@@ -99,7 +99,7 @@ def ensure_group_writable_parents(target_dir: Path) -> None:
             desired = mode | stat.S_IWGRP | stat.S_ISGID
             if desired != mode:
                 os.chmod(directory, desired)
-        except PermissionError:
+        except OSError:
             continue
 
 

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -76,7 +76,7 @@ def _nested_set(target: dict, dotted_key: str, value: int | str | bool) -> None:
     current[parts[-1]] = value
 
 
-def _compose_launcher_cfg(config_name: str, overrides: list[str]) -> dict:
+def _get_launcher_cfg_via_compose(config_name: str, overrides: list[str]) -> dict:
     """Compose the full Hydra config and extract ``hydra.launcher``.
 
     Uses Hydra's Compose API so that interpolations are resolved against the
@@ -101,7 +101,7 @@ def _resolve_launcher_submission_context(
     overrides: list[str],
 ) -> tuple[dict, list[str]]:
     _, _, module_overrides = extract_launcher_overrides(overrides)
-    launcher_cfg = _compose_launcher_cfg(config_name, overrides)
+    launcher_cfg = _get_launcher_cfg_via_compose(config_name, overrides)
     return launcher_cfg, module_overrides
 
 
@@ -451,7 +451,9 @@ def submit_manifest_via_sbatch(
     # to get the value of `hydra.launcher`, and none of the base config names
     # define that directly (they're only overridden inside e.g. local
     # experiments with `/distributed` overrides).
-    merged_launcher_cfg = _compose_launcher_cfg("encoder_processor_decoder", overrides)
+    merged_launcher_cfg = _get_launcher_cfg_via_compose(
+        "encoder_processor_decoder", overrides
+    )
 
     setup_commands: list[str] = merged_launcher_cfg.get("setup", [])  # type: ignore[assignment]
     if not isinstance(setup_commands, list):

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -110,6 +110,10 @@ def extract_launcher_overrides(
 ) -> tuple[str, dict, list[str]]:
     """Separate ``hydra/launcher`` and ``hydra.launcher.*`` from *overrides*.
 
+    This is necessary because when constructing a SLURM batch script, we don't
+    want to include the launcher-specific overrides inside the commands that
+    are executed (otherwise the job will try to submit another job, and so on.)
+
     Returns ``(launcher_name, launcher_specific_cfg, remaining_overrides)``.
     """
     launcher_name = "slurm"

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -8,9 +8,13 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
+from hydra import compose, initialize_config_dir
 from omegaconf import OmegaConf
 
+from autocast.scripts.utils import get_default_config_path
+from autocast.scripts.workflow.constants import config_name_for_module
 from autocast.scripts.workflow.helpers import (
+    _split_hydra_cli_args,
     ensure_group_writable_parents,
     format_command,
     resolve_umask_from_overrides,
@@ -72,208 +76,31 @@ def _nested_set(target: dict, dotted_key: str, value: int | str | bool) -> None:
     current[parts[-1]] = value
 
 
-def load_launcher_defaults(launcher_name: str) -> dict:
-    """Load launcher YAML defaults by *launcher_name*."""
-    candidate_paths = [
-        Path(__file__).resolve().parents[2]
-        / "configs"
-        / "hydra"
-        / "launcher"
-        / f"{launcher_name}.yaml",
-        Path.cwd() / "local_hydra" / "hydra" / "launcher" / f"{launcher_name}.yaml",
-    ]
-    for path in candidate_paths:
-        if not path.exists():
-            continue
-        cfg = OmegaConf.load(path)
-        loaded = OmegaConf.to_container(cfg, resolve=False)
-        if isinstance(loaded, dict):
-            loaded.pop("defaults", None)
-            return loaded
-    if launcher_name != "slurm":
-        raise ValueError(f"Unable to resolve hydra launcher preset '{launcher_name}'.")
-    return {}
+def _compose_launcher_cfg(config_name: str, overrides: list[str]) -> dict:
+    """Compose the full Hydra config and extract ``hydra.launcher``.
 
-
-def _extract_local_experiment_name(overrides: list[str]) -> str | None:
-    """Return selected local_experiment name from CLI overrides, if any."""
-    for override in overrides:
-        norm = normalized_override(override)
-        if norm.startswith("local_experiment="):
-            return norm.split("=", 1)[1]
-    return None
-
-
-def _resolve_local_experiment_parent(item: object) -> Path | None:
-    # Map a defaults-list entry to its YAML file so we can follow the
-    # inheritance chain when looking up ``/distributed``.
-    # Handles both absolute (``/local_experiment/foo``) and relative
-    # (``foo/bar``) references within the local_experiment config group.
-    if not isinstance(item, str):
-        return None
-    if item.startswith("/local_experiment/"):
-        rel = item.removeprefix("/local_experiment/")
-        return Path.cwd() / "local_hydra" / "local_experiment" / f"{rel}.yaml"
-    if item.startswith(("_", "/")):
-        return None
-    return Path.cwd() / "local_hydra" / "local_experiment" / f"{item}.yaml"
-
-
-def _extract_distributed_preset_name(
-    cfg: dict, seen: set[Path] | None = None
-) -> str | None:
-    if seen is None:
-        seen = set()
-    defaults = cfg.get("defaults")
-    if not isinstance(defaults, list):
-        return None
-    for item in defaults:
-        if not isinstance(item, dict):
-            continue
-        val = item.get("/distributed") or item.get("override /distributed")
-        if isinstance(val, str) and val:
-            return val
-    for item in defaults:
-        parent_path = _resolve_local_experiment_parent(item)
-        if parent_path is None or parent_path in seen or not parent_path.exists():
-            continue
-        seen.add(parent_path)
-        parent_raw = OmegaConf.to_container(OmegaConf.load(parent_path), resolve=False)
-        if not isinstance(parent_raw, dict):
-            continue
-        result = _extract_distributed_preset_name(parent_raw, seen)
-        if result:
-            return result
-    return None
-
-
-def _extract_distributed_override_name(overrides: list[str]) -> str | None:
-    for override in reversed(overrides):
-        norm = normalized_override(override)
-        if norm.startswith(("distributed=", "/distributed=")):
-            value = norm.split("=", 1)[1].strip()
-            return value or None
-    return None
-
-
-def _load_distributed_cfg(name: str) -> dict:
-    cfg_root = Path(__file__).resolve().parents[2] / "configs"
-    candidate_paths = [
-        cfg_root / "distributed" / f"{name}.yaml",
-        Path.cwd() / "local_hydra" / "distributed" / f"{name}.yaml",
-    ]
-    external_config_root = os.environ.get("AUTOCAST_CONFIG_PATH")
-    if external_config_root:
-        candidate_paths.append(
-            Path(external_config_root) / "distributed" / f"{name}.yaml"
-        )
-    for path in candidate_paths:
-        if not path.exists():
-            continue
-        loaded = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
-        return loaded if isinstance(loaded, dict) else {}
-    return {}
-
-
-def _extract_launcher_cfg(cfg: dict) -> dict:
-    hydra_cfg = cfg.get("hydra")
-    if not isinstance(hydra_cfg, dict):
-        return {}
-    launcher_cfg = hydra_cfg.get("launcher")
-    return launcher_cfg if isinstance(launcher_cfg, dict) else {}
-
-
-def _load_launcher_from_file(path: Path) -> dict:
-    if not path.exists():
-        return {}
-    # Do not resolve the whole experiment config here; it may contain
-    # interpolations that are valid only during full Hydra composition
-    # (e.g. model.processor.n_steps_input -> datamodule.n_steps_input).
-    # We only need the hydra.launcher subtree for submission defaults.
-    raw = OmegaConf.to_container(OmegaConf.load(path), resolve=False)
-    if not isinstance(raw, dict):
-        return {}
-    distributed = _extract_distributed_preset_name(raw)
-    merged = (
-        OmegaConf.merge(_load_distributed_cfg(distributed), OmegaConf.create(raw))
-        if distributed
-        else OmegaConf.create(raw)
-    )
-    cfg = OmegaConf.to_container(merged, resolve=False)
-    if not isinstance(cfg, dict):
-        return {}
-    return _extract_launcher_cfg(cfg)
-
-
-def _load_direct_distributed_launcher_cfg(overrides: list[str]) -> dict:
-    distributed = _extract_distributed_override_name(overrides)
-    if distributed is None:
-        return {}
-    return _extract_launcher_cfg(_load_distributed_cfg(distributed))
-
-
-def _load_preset_launcher_cfg(overrides: list[str]) -> dict:
-    """Load ``hydra.launcher`` mapping from selected experiment preset.
-
-    Supports both ``local_experiment=<name>`` and ``experiment=<name>``.
-    ``local_experiment`` has precedence if both are provided.
+    Uses Hydra's Compose API so that interpolations are resolved against the
+    full config tree (including CLI overrides).
     """
-    local_experiment = _extract_local_experiment_name(overrides)
-    if local_experiment:
-        local_cfg_path = (
-            Path.cwd() / "local_hydra" / "local_experiment" / f"{local_experiment}.yaml"
+    config_dir = get_default_config_path()
+    _, compose_overrides = _split_hydra_cli_args(overrides)
+    with initialize_config_dir(config_dir=config_dir, version_base=None):
+        cfg = compose(
+            config_name=config_name,
+            overrides=compose_overrides,
+            return_hydra_config=True,
         )
-        local_launcher_cfg = _load_launcher_from_file(local_cfg_path)
-        if local_launcher_cfg:
-            return local_launcher_cfg
-
-    experiment_name = extract_override_value(overrides, "experiment")
-    if isinstance(experiment_name, str) and experiment_name:
-        experiment_cfg_path = (
-            Path(__file__).resolve().parents[2]
-            / "configs"
-            / "experiment"
-            / f"{experiment_name}.yaml"
-        )
-        experiment_launcher_cfg = _load_launcher_from_file(experiment_cfg_path)
-        if experiment_launcher_cfg:
-            return experiment_launcher_cfg
-
-        external_config_root = os.environ.get("AUTOCAST_CONFIG_PATH")
-        if external_config_root:
-            external_experiment_cfg_path = (
-                Path(external_config_root) / "experiment" / f"{experiment_name}.yaml"
-            )
-            external_experiment_launcher_cfg = _load_launcher_from_file(
-                external_experiment_cfg_path
-            )
-            if external_experiment_launcher_cfg:
-                return external_experiment_launcher_cfg
-
-    return {}
+        launcher = OmegaConf.to_container(cfg.hydra.launcher, resolve=True)
+        return launcher if isinstance(launcher, dict) else {}
 
 
 def _resolve_launcher_submission_context(
+    config_name: str,
     overrides: list[str],
 ) -> tuple[dict, list[str]]:
-    launcher_name, launcher_override_cfg, module_overrides = extract_launcher_overrides(
-        overrides
-    )
-    preset_launcher_cfg = _load_preset_launcher_cfg(overrides)
-    direct_distributed_launcher_cfg = _load_direct_distributed_launcher_cfg(overrides)
-    launcher_cfg = load_launcher_defaults(launcher_name)
-    merged_launcher_cfg = OmegaConf.to_container(
-        OmegaConf.merge(
-            launcher_cfg,
-            preset_launcher_cfg,
-            direct_distributed_launcher_cfg,
-            launcher_override_cfg,
-        ),
-        resolve=True,
-    )
-    if not isinstance(merged_launcher_cfg, dict):
-        merged_launcher_cfg = {}
-    return merged_launcher_cfg, module_overrides
+    _, _, module_overrides = extract_launcher_overrides(overrides)
+    launcher_cfg = _compose_launcher_cfg(config_name, overrides)
+    return launcher_cfg, module_overrides
 
 
 def extract_launcher_overrides(
@@ -465,7 +292,7 @@ def submit_via_sbatch(  # noqa: PLR0915
 ) -> None:
     """Submit *module* as one or more SLURM jobs via ``sbatch``."""
     merged_launcher_cfg, module_overrides = _resolve_launcher_submission_context(
-        overrides
+        config_name_for_module(module), overrides
     )
 
     if dry_run:
@@ -618,21 +445,7 @@ def submit_manifest_via_sbatch(
     """
     umask_value = resolve_umask_from_overrides(overrides)
 
-    launcher_name, launcher_override_cfg, _ = extract_launcher_overrides(overrides)
-    preset_launcher_cfg = _load_preset_launcher_cfg(overrides)
-    direct_distributed_launcher_cfg = _load_direct_distributed_launcher_cfg(overrides)
-    launcher_cfg = load_launcher_defaults(launcher_name)
-    merged_launcher_cfg = OmegaConf.to_container(
-        OmegaConf.merge(
-            launcher_cfg,
-            preset_launcher_cfg,
-            direct_distributed_launcher_cfg,
-            launcher_override_cfg,
-        ),
-        resolve=True,
-    )
-    if not isinstance(merged_launcher_cfg, dict):
-        merged_launcher_cfg = {}
+    merged_launcher_cfg = _compose_launcher_cfg("encoder_processor_decoder", overrides)
 
     setup_commands: list[str] = merged_launcher_cfg.get("setup", [])  # type: ignore[assignment]
     if not isinstance(setup_commands, list):

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -11,8 +11,7 @@ from pathlib import Path
 from hydra import compose, initialize_config_dir
 from omegaconf import OmegaConf
 
-from autocast.scripts.utils import get_default_config_path
-from autocast.scripts.workflow.constants import config_name_for_module
+from autocast.scripts.utils import MODULE_CONFIG_NAMES, get_default_config_path
 from autocast.scripts.workflow.helpers import (
     _split_hydra_cli_args,
     ensure_group_writable_parents,
@@ -298,7 +297,7 @@ def submit_via_sbatch(  # noqa: PLR0915
 ) -> None:
     """Submit *module* as one or more SLURM jobs via ``sbatch``."""
     merged_launcher_cfg, module_overrides = _resolve_launcher_submission_context(
-        config_name_for_module(module), overrides
+        MODULE_CONFIG_NAMES[module], overrides
     )
 
     if dry_run:

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -447,6 +447,10 @@ def submit_manifest_via_sbatch(
     """
     umask_value = resolve_umask_from_overrides(overrides)
 
+    # The config name here doesn't *really* matter because we are just trying
+    # to get the value of `hydra.launcher`, and none of the base config names
+    # define that directly (they're only overridden inside e.g. local
+    # experiments with `/distributed` overrides).
     merged_launcher_cfg = _compose_launcher_cfg("encoder_processor_decoder", overrides)
 
     setup_commands: list[str] = merged_launcher_cfg.get("setup", [])  # type: ignore[assignment]

--- a/src/autocast/scripts/workflow/slurm.py
+++ b/src/autocast/scripts/workflow/slurm.py
@@ -83,6 +83,7 @@ def _compose_launcher_cfg(config_name: str, overrides: list[str]) -> dict:
     full config tree (including CLI overrides).
     """
     config_dir = get_default_config_path()
+    # Remove CLI flags that Hydra doesn't understand.
     _, compose_overrides = _split_hydra_cli_args(overrides)
     with initialize_config_dir(config_dir=config_dir, version_base=None):
         cfg = compose(
@@ -91,6 +92,7 @@ def _compose_launcher_cfg(config_name: str, overrides: list[str]) -> dict:
             return_hydra_config=True,
         )
         launcher = OmegaConf.to_container(cfg.hydra.launcher, resolve=True)
+        # launcher should always be a Dict but this makes type checking happy
         return launcher if isinstance(launcher, dict) else {}
 
 

--- a/tests/scripts/test_config_integration.py
+++ b/tests/scripts/test_config_integration.py
@@ -63,6 +63,21 @@ def test_multinode_distributed_config_sets_trainer_nodes(config_dir: str):
     assert cfg.trainer.strategy == "ddp"
 
 
+def test_distributed_config_sets_launcher(config_dir: str):
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(
+            config_name="encoder_processor_decoder",
+            overrides=["+distributed=ddp_4gpu_2node_slurm"],
+            return_hydra_config=True,
+        )
+    launcher = OmegaConf.to_container(cfg.hydra.launcher, resolve=True)
+    assert isinstance(launcher, dict)
+
+    assert launcher["nodes"] == 2
+    assert launcher["gpus_per_node"] == 4
+    assert launcher["tasks_per_node"] == 4
+
+
 # --- Parametrized tests over component configs ---
 
 

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -43,8 +43,7 @@ from autocast.scripts.workflow.overrides import (
 )
 from autocast.scripts.workflow.slurm import (
     _build_sbatch_command,
-    _load_direct_distributed_launcher_cfg,
-    _load_preset_launcher_cfg,
+    _compose_launcher_cfg,
     _parse_override_scalar,
     _should_use_srun,
     submit_manifest_via_sbatch,
@@ -218,145 +217,47 @@ def test_build_sbatch_command_includes_nodes(tmp_path: Path):
     assert "--nodes=99" not in cmd
 
 
-def test_load_preset_launcher_cfg_ignores_unrelated_interpolation(
-    tmp_path: Path, monkeypatch
-):
-    local_cfg = tmp_path / "local_hydra" / "local_experiment" / "repro.yaml"
-    local_cfg.parent.mkdir(parents=True, exist_ok=True)
-    local_cfg.write_text(
-        "\n".join(
-            [
-                "defaults:",
-                "  - /distributed: ddp_4gpu_slurm",
-                "model:",
-                "  processor:",
-                "    n_steps_input: ${datamodule.n_steps_input}",
-                "hydra:",
-                "  launcher:",
-                "    partition: gpu",
-                "    timeout_min: 120",
-            ]
-        ),
-        encoding="utf-8",
+def test_compose_launcher_cfg_returns_slurm_defaults():
+    launcher_cfg = _compose_launcher_cfg(
+        "encoder_processor_decoder", ["hydra/launcher=slurm"]
     )
 
-    monkeypatch.chdir(tmp_path)
-    launcher_cfg = _load_preset_launcher_cfg(["local_experiment=repro"])
+    assert launcher_cfg.get("timeout_min") == 240
+    assert launcher_cfg.get("gpus_per_node") == 1
+    assert launcher_cfg.get("tasks_per_node") == 1
+
+
+def test_compose_launcher_cfg_with_distributed_override():
+    launcher_cfg = _compose_launcher_cfg(
+        "encoder_processor_decoder", ["+distributed=ddp_4gpu_slurm"]
+    )
+
+    assert launcher_cfg.get("gpus_per_node") == 4
+    assert launcher_cfg.get("tasks_per_node") == 4
+
+
+def test_compose_launcher_cfg_with_multinode_distributed():
+    launcher_cfg = _compose_launcher_cfg(
+        "encoder_processor_decoder", ["+distributed=ddp_4gpu_2node_slurm"]
+    )
+
+    assert launcher_cfg.get("nodes") == 2
+    assert launcher_cfg.get("gpus_per_node") == 4
+    assert launcher_cfg.get("tasks_per_node") == 4
+
+
+def test_compose_launcher_cfg_cli_overrides_win():
+    launcher_cfg = _compose_launcher_cfg(
+        "encoder_processor_decoder",
+        [
+            "hydra/launcher=slurm",
+            "+hydra.launcher.partition=gpu",
+            "hydra.launcher.timeout_min=120",
+        ],
+    )
 
     assert launcher_cfg.get("partition") == "gpu"
     assert launcher_cfg.get("timeout_min") == 120
-
-
-def test_load_preset_launcher_cfg_walks_local_experiment_parent_chain(
-    tmp_path: Path, monkeypatch
-):
-    # Child references a parent local_experiment that declares /distributed:
-    # — the loader must walk the chain so SLURM allocates the right resources.
-    local_root = tmp_path / "local_hydra" / "local_experiment"
-    parent_cfg = local_root / "parent.yaml"
-    parent_cfg.parent.mkdir(parents=True, exist_ok=True)
-    parent_cfg.write_text(
-        "\n".join(
-            [
-                "defaults:",
-                "  - /distributed: ddp_4gpu_slurm",
-                "  - _self_",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    child_cfg = local_root / "child.yaml"
-    child_cfg.write_text(
-        "\n".join(
-            [
-                "defaults:",
-                "  - /local_experiment/parent",
-                "  - _self_",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    monkeypatch.chdir(tmp_path)
-    launcher_cfg = _load_preset_launcher_cfg(["local_experiment=child"])
-
-    assert launcher_cfg.get("gpus_per_node") == 4
-    assert launcher_cfg.get("tasks_per_node") == 4
-
-
-def test_load_preset_launcher_cfg_walks_relative_parent_reference(
-    tmp_path: Path, monkeypatch
-):
-    # Child uses a relative reference (no /local_experiment/ prefix) to a
-    # parent that declares /distributed: — the loader must resolve the
-    # relative path from the config group root.
-    local_root = tmp_path / "local_hydra" / "local_experiment"
-    parent_cfg = local_root / "epd" / "base.yaml"
-    parent_cfg.parent.mkdir(parents=True, exist_ok=True)
-    parent_cfg.write_text(
-        "\n".join(
-            [
-                "defaults:",
-                "  - /distributed: ddp_4gpu_slurm",
-                "  - _self_",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    child_cfg = local_root / "epd" / "128x128" / "child.yaml"
-    child_cfg.parent.mkdir(parents=True, exist_ok=True)
-    child_cfg.write_text(
-        "\n".join(
-            [
-                "defaults:",
-                "  - epd/base",
-                "  - _self_",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    monkeypatch.chdir(tmp_path)
-    launcher_cfg = _load_preset_launcher_cfg(["local_experiment=epd/128x128/child"])
-
-    assert launcher_cfg.get("gpus_per_node") == 4
-    assert launcher_cfg.get("tasks_per_node") == 4
-
-
-def test_load_preset_launcher_cfg_recognises_override_distributed(
-    tmp_path: Path, monkeypatch
-):
-    # When a config uses `override /distributed:` (needed when a parent
-    # already set the group), the CLI must still find the preset name.
-    local_root = tmp_path / "local_hydra" / "local_experiment"
-    cfg = local_root / "with_override.yaml"
-    cfg.parent.mkdir(parents=True, exist_ok=True)
-    cfg.write_text(
-        "\n".join(
-            [
-                "defaults:",
-                "  - override /distributed: ddp_4gpu_2node_slurm",
-                "  - _self_",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    monkeypatch.chdir(tmp_path)
-    launcher_cfg = _load_preset_launcher_cfg(["local_experiment=with_override"])
-
-    assert launcher_cfg.get("nodes") == 2
-    assert launcher_cfg.get("gpus_per_node") == 4
-
-
-def test_load_direct_distributed_launcher_cfg_supports_multinode():
-    launcher_cfg = _load_direct_distributed_launcher_cfg(
-        ["+distributed=ddp_4gpu_2node_slurm"]
-    )
-
-    assert launcher_cfg.get("nodes") == 2
-    assert launcher_cfg.get("gpus_per_node") == 4
-    assert launcher_cfg.get("tasks_per_node") == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -44,7 +44,7 @@ from autocast.scripts.workflow.overrides import (
 )
 from autocast.scripts.workflow.slurm import (
     _build_sbatch_command,
-    _compose_launcher_cfg,
+    _get_launcher_cfg_via_compose,
     _parse_override_scalar,
     _should_use_srun,
     submit_manifest_via_sbatch,
@@ -219,8 +219,8 @@ def test_build_sbatch_command_includes_nodes(tmp_path: Path):
     assert "--nodes=99" not in cmd
 
 
-def test_compose_launcher_cfg_returns_slurm_defaults():
-    launcher_cfg = _compose_launcher_cfg(
+def test_get_launcher_cfg_via_compose_returns_slurm_defaults():
+    launcher_cfg = _get_launcher_cfg_via_compose(
         "encoder_processor_decoder", ["hydra/launcher=slurm"]
     )
 
@@ -229,8 +229,8 @@ def test_compose_launcher_cfg_returns_slurm_defaults():
     assert launcher_cfg.get("tasks_per_node") == 1
 
 
-def test_compose_launcher_cfg_with_distributed_override():
-    launcher_cfg = _compose_launcher_cfg(
+def test_get_launcher_cfg_via_compose_with_distributed_override():
+    launcher_cfg = _get_launcher_cfg_via_compose(
         "encoder_processor_decoder", ["+distributed=ddp_4gpu_slurm"]
     )
 
@@ -238,8 +238,8 @@ def test_compose_launcher_cfg_with_distributed_override():
     assert launcher_cfg.get("tasks_per_node") == 4
 
 
-def test_compose_launcher_cfg_with_multinode_distributed():
-    launcher_cfg = _compose_launcher_cfg(
+def test_get_launcher_cfg_via_compose_with_multinode_distributed():
+    launcher_cfg = _get_launcher_cfg_via_compose(
         "encoder_processor_decoder", ["+distributed=ddp_4gpu_2node_slurm"]
     )
 
@@ -248,8 +248,8 @@ def test_compose_launcher_cfg_with_multinode_distributed():
     assert launcher_cfg.get("tasks_per_node") == 4
 
 
-def test_compose_launcher_cfg_cli_overrides_win():
-    launcher_cfg = _compose_launcher_cfg(
+def test_get_launcher_cfg_via_compose_cli_overrides_win():
+    launcher_cfg = _get_launcher_cfg_via_compose(
         "encoder_processor_decoder",
         [
             "hydra/launcher=slurm",

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -263,7 +263,8 @@ def test_compose_launcher_cfg_cli_overrides_win():
 
 
 def test_submit_via_sbatch_passes_distributed_flags_to_sbatch(tmp_path, monkeypatch):
-    """End-to-end: compose resolves distributed config and sbatch gets the right flags."""
+    """End-to-end: compose resolves distributed config and sbatch gets the
+    right flags."""
     monkeypatch.chdir(tmp_path)
     captured_cmd: list[str] = []
 

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import patch
 
 import pandas as pd
@@ -47,6 +48,7 @@ from autocast.scripts.workflow.slurm import (
     _parse_override_scalar,
     _should_use_srun,
     submit_manifest_via_sbatch,
+    submit_via_sbatch,
 )
 
 
@@ -258,6 +260,33 @@ def test_compose_launcher_cfg_cli_overrides_win():
 
     assert launcher_cfg.get("partition") == "gpu"
     assert launcher_cfg.get("timeout_min") == 120
+
+
+def test_submit_via_sbatch_passes_distributed_flags_to_sbatch(tmp_path, monkeypatch):
+    """End-to-end: compose resolves distributed config and sbatch gets the right flags."""
+    monkeypatch.chdir(tmp_path)
+    captured_cmd: list[str] = []
+
+    def _fake_subprocess_run(cmd, **_kw):
+        captured_cmd.extend(cmd)
+        return CompletedProcess(cmd, 0, stdout="12345\n", stderr="")
+
+    monkeypatch.setattr(
+        "autocast.scripts.workflow.slurm.subprocess.run", _fake_subprocess_run
+    )
+
+    submit_via_sbatch(
+        "autocast.scripts.train.encoder_processor_decoder",
+        [
+            "+distributed=ddp_4gpu_2node_slurm",
+            "hydra/launcher=slurm",
+            f"hydra.run.dir={tmp_path / 'out'}",
+        ],
+    )
+
+    assert "--nodes=2" in captured_cmd
+    assert "--gpus-per-node=4" in captured_cmd
+    assert "--ntasks-per-node=4" in captured_cmd
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`scripts/workflows/slurm.py` had a lot of custom code that attempted to do something LIKE Hydra/OmegaConf's config resolution. Specifically, it parses `distributed` and `local_experiment` and then from those it would try to extract the `hydra.launcher` configuration tree. This was pretty hacky and led to at least two bugs so far (#406, and later on #423), and would have led to even more if anybody tried to do something that *wasn't* explicitly supported. For example, if you started putting `distributed` overrides in anywhere but `local_experiment` this would probably have broken.

As it happens, Hydra gives you a tool to perform config resolution: https://hydra.cc/docs/advanced/compose_api/ Basically, you can feed it the base config name (e.g. `encoder_processor_decoder`) plus CLI overrides, and it generates the full configuration as a dict. You then pluck out `hydra.launcher` from it. This is the new `_get_launcher_cfg_via_compose` function. That lets us completely cut out all of that custom code, and it means that things will behave exactly the same way one expects them to because it uses the same internal Hydra machinery.

There also weren't actually any tests that checked the contents of the submission script that was generated, so this PR also adds one.