### PR TITLE
Make checkpoint progress time-aware for max_time-bounded runs

### DIFF
--- a/src/autocast/callbacks/checkpoint.py
+++ b/src/autocast/callbacks/checkpoint.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import lightning as L
 import torch
-from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.callbacks import ModelCheckpoint, Timer
 
 log = logging.getLogger(__name__)
 
@@ -168,6 +168,45 @@ class ProgressModelCheckpoint(ModelCheckpoint):
         )
 
     def _training_progress_fraction(self, trainer: L.Trainer) -> float:
+        """Fraction of the run completed, in [0, 1].
+
+        A run stops when *any* configured budget is exhausted, so progress
+        toward stopping is the maximum over the time- and step-based fractions.
+        This is what makes the windowed (``start_after_fraction`` /
+        ``stop_after_fraction``) checkpoints fire correctly on time-limited
+        runs: those set a large placeholder ``max_epochs`` and are actually
+        bounded by ``max_time``, so the step/epoch fraction stays near zero for
+        the whole run while the wall-clock fraction is the one that matters.
+        """
+        fractions = [self._step_progress_fraction(trainer)]
+        time_fraction = self._time_progress_fraction(trainer)
+        if time_fraction is not None:
+            fractions.append(time_fraction)
+        return max(fractions)
+
+    def _time_progress_fraction(self, trainer: L.Trainer) -> float | None:
+        """Wall-clock progress in [0, 1] when the run is time-limited, else None.
+
+        A ``Trainer(max_time=...)`` run is bounded by elapsed wall-clock rather
+        than by ``max_epochs``/``max_steps``. Lightning installs a ``Timer``
+        callback for such runs; it owns the authoritative, resume-safe elapsed
+        time and total duration. ``time_remaining`` returns ``None`` for a
+        duration-less Timer, which we treat as "no binding time budget" so the
+        caller falls back to step-based progress.
+        """
+        for callback in getattr(trainer, "callbacks", None) or []:
+            if not isinstance(callback, Timer):
+                continue
+            remaining = callback.time_remaining()
+            if remaining is None:
+                continue
+            elapsed = callback.time_elapsed()
+            total = elapsed + remaining
+            if total > 0:
+                return min(1.0, max(0.0, float(elapsed) / float(total)))
+        return None
+
+    def _step_progress_fraction(self, trainer: L.Trainer) -> float:
         try:
             total_steps = self._resolve_total_training_steps(trainer)
         except ValueError:

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -556,6 +556,86 @@ def test_progress_model_checkpoint_delays_monitored_topk(monkeypatch):
     assert len(calls) == 1
 
 
+def _timer_stub(elapsed_s: float, remaining_s: float | None) -> Timer:
+    """A real ``Timer`` with controlled elapsed/remaining for progress tests."""
+    duration = (
+        None if remaining_s is None else timedelta(seconds=elapsed_s + remaining_s)
+    )
+    timer = Timer(duration=duration)
+    timer.time_elapsed = lambda *_: float(elapsed_s)  # type: ignore[method-assign]
+    timer.time_remaining = lambda *_: remaining_s  # type: ignore[method-assign]
+    return timer
+
+
+def _windowed_callback() -> ProgressModelCheckpoint:
+    return ProgressModelCheckpoint(
+        monitor="val_multicoverage",
+        monitor_optional=True,
+        start_after_fraction=0.25,
+        mode="min",
+        save_top_k=1,
+        filename="best-from0p25-{epoch:04d}",
+    )
+
+
+def test_progress_fraction_uses_time_budget_over_placeholder_max_epochs():
+    """Time-limited run: the step fraction stays ~0 because ``max_epochs`` is a
+    large placeholder, but the wall-clock budget is half spent, so windowed
+    checkpoints must see 0.5 and open the ``start_after_fraction=0.25`` window.
+
+    This is the regression guard for the checkpoint-progress bug: before the
+    fix the ``from0p25``/``0p50``/``0p75`` checkpoints never fired on
+    ``max_time``-bounded runs.
+    """
+    callback = _windowed_callback()
+    timer = _timer_stub(elapsed_s=1800.0, remaining_s=1800.0)  # 50% of budget
+    trainer = _trainer_stub(
+        estimated_stepping_batches=10_000_000,  # placeholder max_epochs => ~0 steps
+        global_step=300,
+        callbacks=[timer],
+    )
+
+    assert callback._training_progress_fraction(
+        cast(L.Trainer, trainer)
+    ) == pytest.approx(0.5)
+    assert callback._monitor_ready(cast(L.Trainer, trainer)) is True
+
+
+def test_progress_fraction_falls_back_to_steps_without_timer():
+    callback = _windowed_callback()
+    trainer = _trainer_stub(estimated_stepping_batches=100, global_step=50)
+
+    assert callback._training_progress_fraction(
+        cast(L.Trainer, trainer)
+    ) == pytest.approx(0.5)
+
+
+def test_progress_fraction_takes_max_of_time_and_steps():
+    """Step-bounded run with a large, non-binding ``max_time`` must use the
+    (larger) step fraction, not the tiny wall-clock fraction."""
+    callback = _windowed_callback()
+    timer = _timer_stub(elapsed_s=60.0, remaining_s=43_140.0)  # ~0.14% of 12h
+    trainer = _trainer_stub(
+        estimated_stepping_batches=100, global_step=50, callbacks=[timer]
+    )
+
+    assert callback._training_progress_fraction(
+        cast(L.Trainer, trainer)
+    ) == pytest.approx(0.5)
+
+
+def test_progress_fraction_ignores_durationless_timer():
+    callback = _windowed_callback()
+    timer = _timer_stub(elapsed_s=1800.0, remaining_s=None)  # no duration set
+    trainer = _trainer_stub(
+        estimated_stepping_batches=100, global_step=50, callbacks=[timer]
+    )
+
+    assert callback._training_progress_fraction(
+        cast(L.Trainer, trainer)
+    ) == pytest.approx(0.5)
+
+
 def test_progress_model_checkpoint_skips_optional_missing_monitor(monkeypatch):
     callback = ProgressModelCheckpoint(
         monitor="val_multicoverage",


### PR DESCRIPTION
## Problem

`ProgressModelCheckpoint` gates its windowed (`start_after_fraction` / `stop_after_fraction`) saves on `global_step / estimated_stepping_batches`. On `max_time`-bounded runs — where `max_epochs` is left at a large placeholder and the run is actually stopped by wall-clock — that denominator is the placeholder step count, so the progress fraction stays near zero for the whole run. As a result the `start_after_fraction` windows (the `from0p25`/`0p50`/`0p75` best-calibration checkpoints) never open, while the `stop_after_fraction` windows (`pre0p25`) never close and save the entire run.

## Fix

Define progress as the maximum of the wall-clock fraction (`elapsed / max_time`, read from Lightning's auto-installed `Timer`) and the existing step/epoch fraction. A run stops when whichever budget is exhausted first, so the max is the true fraction-to-stopping. Step-bounded runs with a non-binding default `max_time` are unaffected (the step fraction dominates). A duration-less `Timer` reports no remaining time and is treated as "no binding time budget", so the caller falls back to step-based progress.

## Tests

- time / step / max precedence
- duration-less-`Timer` fallback to steps
- end-to-end check that the late windows fire under `max_time` with a placeholder `max_epochs`
