### PR TITLE
Add a Heun integrator option for flow-matching sampling

### DIFF
--- a/src/autocast/configs/processor/flow_matching.yaml
+++ b/src/autocast/configs/processor/flow_matching.yaml
@@ -6,4 +6,5 @@ _target_: autocast.processors.flow_matching.FlowMatchingProcessor
 flow_ode_steps: 4
 n_steps_output: null
 n_channels_out: null
+integrator: euler
 

--- a/src/autocast/processors/flow_matching.py
+++ b/src/autocast/processors/flow_matching.py
@@ -10,6 +10,8 @@ from autocast.types import EncodedBatch, Tensor
 class FlowMatchingProcessor(Processor):
     """Processor that wraps a flow-matching generative model."""
 
+    _INTEGRATORS = ("euler", "heun")
+
     def __init__(
         self,
         *,
@@ -17,13 +19,21 @@ class FlowMatchingProcessor(Processor):
         flow_ode_steps: int = 1,
         n_steps_output: int = 4,
         n_channels_out: int = 1,
+        integrator: str = "euler",
     ) -> None:
         # Store core hyperparameters and optional prebuilt backbone.
         super().__init__()
+        if integrator not in self._INTEGRATORS:
+            msg = (
+                "FlowMatchingProcessor integrator must be one of "
+                f"{self._INTEGRATORS}; got {integrator!r}."
+            )
+            raise ValueError(msg)
         self.flow_matching_model = backbone
         self.flow_ode_steps = max(flow_ode_steps, 1)
         self.n_steps_output = n_steps_output
         self.n_channels_out = n_channels_out
+        self.integrator = integrator
 
     def flow_field(
         self, z: Tensor, t: Tensor, x: Tensor, global_cond: Tensor | None = None
@@ -51,7 +61,11 @@ class FlowMatchingProcessor(Processor):
     def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
         """Map inputs states (x) to output states (z) by integrating the flow ODE.
 
-        Starting from noise, Euler-integrate the learned vector field until t=1.
+        Starting from noise, integrate the learned vector field until t=1 with
+        the configured fixed-step scheme: forward Euler (``integrator="euler"``,
+        one field evaluation per step) or Heun's explicit trapezoid method
+        (``integrator="heun"``, two field evaluations per step, second-order
+        accurate).
 
         Args:
             x: Conditioning inputs of shape (B, T_in, *spatial, C_in).
@@ -69,10 +83,15 @@ class FlowMatchingProcessor(Processor):
         z = torch.randn(z_shape, device=device, dtype=dtype)
         t = torch.zeros(batch_size, device=device, dtype=dtype)
 
-        # Simple fixed-step Euler integration over the flow field.
+        # Fixed-step integration over the flow field.
         dt = torch.tensor(1.0 / self.flow_ode_steps, device=device, dtype=dtype)
         for _ in range(self.flow_ode_steps):
-            z = z + dt * self.flow_field(z, t, x, global_cond)
+            if self.integrator == "heun":
+                k1 = self.flow_field(z, t, x, global_cond)
+                k2 = self.flow_field(z + dt * k1, t + dt, x, global_cond)
+                z = z + dt * 0.5 * (k1 + k2)
+            else:
+                z = z + dt * self.flow_field(z, t, x, global_cond)
             t = t + dt
         return z
 

--- a/tests/processors/test_flow_matching.py
+++ b/tests/processors/test_flow_matching.py
@@ -1,4 +1,5 @@
 import itertools
+import math
 
 import lightning as L
 import pytest
@@ -257,3 +258,90 @@ def test_masked_window_context_mask_matches_lola(rho: float):
     expected = expected.permute(0, 2, 3, 4, 1)
 
     assert torch.equal(actual, expected)
+
+
+# ---------------------------------------------------------------------------
+# Integrator option (euler default / heun)
+# ---------------------------------------------------------------------------
+
+
+class _DecayField(torch.nn.Module):
+    """Stub backbone implementing the analytic field f(z, t) = -z.
+
+    The flow ODE dz/dt = -z has the exact solution z(1) = z(0) * exp(-1),
+    giving a closed-form target to test integrator accuracy against.
+    """
+
+    include_time_embedding = True
+
+    def forward(self, z, t=None, cond=None, global_cond=None):  # noqa: ARG002
+        return -z
+
+
+def _decay_processor(integrator: str, steps: int) -> FlowMatchingProcessor:
+    return FlowMatchingProcessor(
+        backbone=_DecayField(),
+        n_steps_output=1,
+        n_channels_out=1,
+        flow_ode_steps=steps,
+        integrator=integrator,
+    )
+
+
+def test_flow_matching_integrator_validation():
+    with pytest.raises(ValueError, match="integrator must be one of"):
+        _decay_processor("rk99", 4)
+
+
+def test_flow_matching_euler_default_unchanged():
+    """integrator='euler' (the default) reproduces the original sampling path
+    bit-for-bit: same RNG consumption, same update rule."""
+    x = torch.randn(3, 1, 2, 2, 1)
+    torch.manual_seed(123)
+    out_default = FlowMatchingProcessor(
+        backbone=_DecayField(), n_steps_output=1, n_channels_out=1, flow_ode_steps=4
+    ).map(x, None)
+    torch.manual_seed(123)
+    out_euler = _decay_processor("euler", 4).map(x, None)
+    assert torch.equal(out_default, out_euler)
+
+
+@pytest.mark.parametrize("integrator", ["euler", "heun"])
+def test_flow_matching_integrator_shapes(integrator):
+    x = torch.randn(2, 1, 4, 4, 2)
+    proc = FlowMatchingProcessor(
+        backbone=_DecayField(),
+        n_steps_output=1,
+        n_channels_out=2,
+        flow_ode_steps=3,
+        integrator=integrator,
+    )
+    out = proc.map(x, None)
+    assert out.shape == (2, 1, 4, 4, 2)
+    assert torch.isfinite(out).all()
+
+
+def test_flow_matching_heun_more_accurate_than_euler_on_decay_field():
+    """On dz/dt = -z (exact factor e^-1), Heun's per-step factor
+    (1 - dt + dt^2/2) is second-order accurate vs Euler's (1 - dt):
+    at 8 steps the Heun endpoint must be strictly closer to the truth."""
+    steps = 8
+    x = torch.randn(4, 1, 2, 2, 1)
+
+    torch.manual_seed(7)
+    z_euler = _decay_processor("euler", steps).map(x, None)
+    torch.manual_seed(7)
+    z_heun = _decay_processor("heun", steps).map(x, None)
+
+    # Recover the shared initial noise draw to compute the exact endpoint.
+    torch.manual_seed(7)
+    z0 = torch.randn(4, 1, 2, 2, 1)
+    exact = z0 * math.exp(-1.0)
+
+    err_euler = (z_euler - exact).abs().max().item()
+    err_heun = (z_heun - exact).abs().max().item()
+    assert err_heun < err_euler
+    # Analytic per-step factors at dt = 1/8.
+    dt = 1.0 / steps
+    assert torch.allclose(z_euler, z0 * (1.0 - dt) ** steps, atol=1e-6)
+    assert torch.allclose(z_heun, z0 * (1.0 - dt + 0.5 * dt * dt) ** steps, atol=1e-6)


### PR DESCRIPTION
## Summary

`FlowMatchingProcessor` gains an `integrator` option: `"euler"` (default) or `"heun"`.

Heun's explicit trapezoid method takes two field evaluations per step and is second-order accurate, making it an eval-time alternative to forward Euler. The ODE-steps sensitivity sweep showed integration error dominates the sampling error at small step counts, where the second-order scheme helps most.

## Details

- `map()` integrates with the configured fixed-step scheme; the `"euler"` path is **byte-identical** to the previous behaviour (default unchanged).
- `integrator` is validated at construction against `{"euler", "heun"}`.
- `flow_matching.yaml` exposes `integrator: euler`.

## Tests

- integrator validation rejects unknown schemes
- the euler default reproduces the original sampling path exactly
- both integrators produce correct output shapes
- on a closed-form linear-decay field, Heun's max error is below Euler's, and each matches its analytic fixed-step expansion
