### PR TITLE
Add a convolutional affine-coupling flow processor

### DIFF
--- a/src/autocast/configs/processor/conv_coupling.yaml
+++ b/src/autocast/configs/processor/conv_coupling.yaml
@@ -1,0 +1,17 @@
+_target_: autocast.processors.conv_coupling.ConvCouplingFlowProcessor
+# Output field dims are auto-filled from the datamodule by scripts/setup.py.
+n_steps_output: null
+n_channels_out: null
+# Conditioning field dims + spatial shape are set per toy in the experiment
+# config (no backbone is mounted; the flow builds its own conv conditioner).
+# spatial_shape must be 2D (H, W); represent 1D fields as [L, 1].
+n_steps_input: 1
+n_channels_in: 1
+spatial_shape: [1, 1]
+global_cond_features: 0
+# Coupling depth/conditioner width — set per toy (scale with field size /
+# correlation length). The per-channel log-scale bound is learned, not fixed.
+transforms: 8
+hidden_channels: 64
+n_blocks: 2
+kernel_size: 3

--- a/src/autocast/processors/__init__.py
+++ b/src/autocast/processors/__init__.py
@@ -1,5 +1,6 @@
 from autocast.processors.azula_vit import AzulaViTProcessor
 from autocast.processors.base import Processor
+from autocast.processors.conv_coupling import ConvCouplingFlowProcessor
 from autocast.processors.flow_matching import FlowMatchingProcessor
 from autocast.processors.flow_matching_masked_window import (
     FlowMatchingMaskedWindowProcessor,
@@ -11,6 +12,7 @@ from autocast.processors.unet import UNetProcessor
 
 __all__ = [
     "AzulaViTProcessor",
+    "ConvCouplingFlowProcessor",
     "FlowMatchingMaskedWindowProcessor",
     "FlowMatchingProcessor",
     "Processor",

--- a/src/autocast/processors/conv_coupling.py
+++ b/src/autocast/processors/conv_coupling.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import cast
+
+import torch
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.types import EncodedBatch, Tensor
+
+_LOG_2PI = math.log(2.0 * math.pi)
+
+
+class _ConvAffineCoupling(nn.Module):
+    """One conditional affine-coupling layer with a convolutional conditioner.
+
+    A spatial checkerboard mask splits the field into a *kept* half ``y_a`` and
+    a *transformed* half ``y_b``. A small CNN reads the kept half (transformed
+    positions zeroed) together with the conditioning field ``x_t`` and emits a
+    per-pixel log-scale ``s`` and shift ``t`` for the transformed half. The map
+    is an exact bijection with a triangular Jacobian, so the log-determinant is
+    just the sum of ``s`` over the transformed positions.
+
+    The data->latent direction (``encode``) is used for the log-likelihood; the
+    latent->data direction (``decode``) is used for sampling. Both run in a
+    single network pass (no autoregressive unrolling).
+    """
+
+    mask: Tensor  # checkerboard split, registered as a buffer in __init__
+
+    def __init__(
+        self,
+        *,
+        channels: int,
+        cond_channels: int,
+        spatial_shape: tuple[int, int],
+        parity: int,
+        hidden_channels: int,
+        n_blocks: int,
+        kernel_size: int,
+        init_scale_bound: float,
+    ) -> None:
+        super().__init__()
+        h, w = spatial_shape
+        # Spatial checkerboard: mask True = kept (conditioning) position.
+        ii = torch.arange(h).view(h, 1)
+        jj = torch.arange(w).view(1, w)
+        mask = ((ii + jj) % 2 == parity).to(torch.float32).view(1, 1, h, w)
+        self.register_buffer("mask", mask)
+
+        pad = kernel_size // 2
+        layers: list[nn.Module] = []
+        in_ch = channels + cond_channels
+        for _ in range(n_blocks):
+            layers += [
+                nn.Conv2d(in_ch, hidden_channels, kernel_size, padding=pad),
+                nn.ReLU(),
+            ]
+            in_ch = hidden_channels
+        # Final conv emits (s, t); zero-initialised so the layer starts as the
+        # identity (s=t=0) for a stable, unit-Jacobian training start.
+        final = nn.Conv2d(in_ch, 2 * channels, kernel_size, padding=pad)
+        nn.init.zeros_(final.weight)
+        if final.bias is not None:
+            nn.init.zeros_(final.bias)
+        layers.append(final)
+        self.net = nn.Sequential(*layers)
+        # Learnable per-channel bound on the log-scale: s = tanh(s_raw) * bound.
+        # It MUST be initialised non-zero. With both the conv (s_raw=0) and the
+        # bound at zero, the scale is a dead saddle -- d s / d s_raw = bound = 0
+        # AND d s / d bound = tanh(s_raw) = 0 -- so neither the scale weights nor
+        # the bound ever receive gradient and the flow can only shift, never
+        # scale (predictive std frozen at the base std of 1). A positive init
+        # keeps the identity start (s = tanh(0) * bound = 0) while making
+        # d s / d s_raw = bound != 0, so the proper NLL can learn the scale.
+        self.log_scale_bound = nn.Parameter(
+            torch.full((1, channels, 1, 1), float(init_scale_bound))
+        )
+
+    def _params(self, kept: Tensor, cond: Tensor) -> tuple[Tensor, Tensor]:
+        """Return (s, t) for the transformed half, masked to those positions."""
+        h = self.net(torch.cat([kept, cond], dim=1))
+        s_raw, t = h.chunk(2, dim=1)
+        # tanh-bound the log-scale, then restrict s and t to transformed cells.
+        s = torch.tanh(s_raw) * self.log_scale_bound
+        free = 1.0 - self.mask
+        return s * free, t * free
+
+    def encode(self, y: Tensor, cond: Tensor) -> tuple[Tensor, Tensor]:
+        """Map data -> latent; return (z, log|det dz/dy|) summed over features."""
+        s, t = self._params(y * self.mask, cond)
+        z = y * self.mask + (1.0 - self.mask) * ((y - t) * torch.exp(-s))
+        ladj = (-s).flatten(1).sum(dim=1)
+        return z, ladj
+
+    def decode(self, z: Tensor, cond: Tensor) -> Tensor:
+        """Map latent -> data (inverse of :meth:`encode`)."""
+        s, t = self._params(z * self.mask, cond)
+        return z * self.mask + (1.0 - self.mask) * (z * torch.exp(s) + t)
+
+
+class ConvCouplingFlowProcessor(Processor):
+    """Convolutional affine-coupling normalizing flow (one-pass exact likelihood).
+
+    A stack of spatial checkerboard affine-coupling layers, each conditioned on
+    the current state ``x_t`` through a CNN, models the one-step predictive
+    density ``p(x_{t+1} | x_t)`` exactly. Unlike the autoregressive flow, both
+    log-likelihood and sampling cost a single forward pass per layer (no
+    sequential dimension unrolling), so scoring is fast for spatial fields.
+
+    The field is handled channels-last as ``(B, T, *spatial, C)`` externally and
+    folded to ``(B, T*C, H, W)`` for the convolutions. Targets spatial fields
+    (1D as an ``[L, 1]`` grid, 2D as ``[H, W]``); scalar fields have no spatial
+    structure and use a flat autoregressive flow instead.
+    """
+
+    def __init__(
+        self,
+        *,
+        n_steps_input: int = 1,
+        n_steps_output: int = 1,
+        n_channels_in: int = 1,
+        n_channels_out: int = 1,
+        spatial_shape: Sequence[int] = (1, 1),
+        global_cond_features: int = 0,
+        transforms: int = 8,
+        hidden_channels: int = 64,
+        n_blocks: int = 2,
+        kernel_size: int = 3,
+        init_scale_bound: float = 2.0,
+    ) -> None:
+        super().__init__()
+        spatial = tuple(int(s) for s in spatial_shape)
+        if len(spatial) != 2:
+            msg = (
+                "ConvCouplingFlowProcessor expects a 2D spatial_shape (H, W); "
+                f"got {spatial}. Represent 1D fields as [L, 1]."
+            )
+            raise ValueError(msg)
+        self.n_steps_input = int(n_steps_input)
+        self.n_steps_output = int(n_steps_output)
+        self.n_channels_in = int(n_channels_in)
+        self.n_channels_out = int(n_channels_out)
+        self.spatial_shape = spatial
+        self.global_cond_features = int(global_cond_features)
+
+        # Conv channel counts: target = T_out * C_out; conditioner = T_in * C_in
+        # plus any global-conditioning features broadcast as constant channels.
+        self.target_channels = self.n_steps_output * self.n_channels_out
+        self.cond_channels = (
+            self.n_steps_input * self.n_channels_in + self.global_cond_features
+        )
+
+        self.layers = nn.ModuleList(
+            _ConvAffineCoupling(
+                channels=self.target_channels,
+                cond_channels=self.cond_channels,
+                spatial_shape=spatial,
+                parity=i % 2,
+                hidden_channels=int(hidden_channels),
+                n_blocks=int(n_blocks),
+                kernel_size=int(kernel_size),
+                init_scale_bound=float(init_scale_bound),
+            )
+            for i in range(int(transforms))
+        )
+
+    # -- layout helpers -------------------------------------------------------
+    def _to_conv(self, field: Tensor, steps: int, channels: int) -> Tensor:
+        """(B, T, H, W, C) channels-last -> (B, T*C, H, W) channels-first."""
+        h, w = self.spatial_shape
+        expected = steps * h * w * channels
+        per_sample = math.prod(field.shape[1:])
+        if per_sample != expected:
+            msg = (
+                "ConvCouplingFlowProcessor received a field with "
+                f"{per_sample} elements per sample but expected {expected} = "
+                f"{steps} (n_steps) x {h} x {w} (spatial_shape) x {channels} "
+                "(n_channels). Check the processor dims against the data."
+            )
+            raise ValueError(msg)
+        x = field.reshape(field.shape[0], steps, h, w, channels)
+        return x.permute(0, 1, 4, 2, 3).reshape(field.shape[0], steps * channels, h, w)
+
+    def _cond(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Build the (B, cond_channels, H, W) conditioning stack from x_t."""
+        cond = self._to_conv(x, self.n_steps_input, self.n_channels_in)
+        if global_cond is not None and self.global_cond_features > 0:
+            h, w = self.spatial_shape
+            g = global_cond.reshape(
+                global_cond.shape[0], self.global_cond_features, 1, 1
+            )
+            cond = torch.cat([cond, g.expand(-1, -1, h, w)], dim=1)
+        return cond
+
+    # -- flow -----------------------------------------------------------------
+    def coupling_layers(self) -> list[_ConvAffineCoupling]:
+        """The coupling layers in order, typed concretely.
+
+        ``nn.ModuleList`` iteration is statically typed as plain ``nn.Module``,
+        which hides ``encode``/``decode``; recover the concrete type here so the
+        flow passes (and tests) read cleanly.
+        """
+        return [cast(_ConvAffineCoupling, layer) for layer in self.layers]
+
+    def _log_prob(self, y_cf: Tensor, cond: Tensor) -> Tensor:
+        z = y_cf
+        ladj = y_cf.new_zeros(y_cf.shape[0])
+        for layer in self.coupling_layers():
+            z, dl = layer.encode(z, cond)
+            ladj = ladj + dl
+        base = (-0.5 * (z**2 + _LOG_2PI)).flatten(1).sum(dim=1)
+        return base + ladj
+
+    def _sample(self, cond: Tensor) -> Tensor:
+        h, w = self.spatial_shape
+        z = torch.randn(
+            cond.shape[0],
+            self.target_channels,
+            h,
+            w,
+            device=cond.device,
+            dtype=cond.dtype,
+        )
+        for layer in reversed(self.coupling_layers()):
+            z = layer.decode(z, cond)
+        return z  # (B, T_out*C_out, H, W)
+
+    # -- Processor API --------------------------------------------------------
+    def forward(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        return self.map(x, global_cond)
+
+    def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Draw one stochastic next-state member, (B, T_out, *spatial, C_out)."""
+        cond = self._cond(x, global_cond)
+        y_cf = self._sample(cond)
+        h, w = self.spatial_shape
+        y = y_cf.reshape(x.shape[0], self.n_steps_output, self.n_channels_out, h, w)
+        return y.permute(0, 1, 3, 4, 2)  # -> (B, T_out, H, W, C_out)
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        """Exact negative log-likelihood of the next state given the current."""
+        cond = self._cond(batch.encoded_inputs, batch.global_cond)
+        y_cf = self._to_conv(
+            batch.encoded_output_fields, self.n_steps_output, self.n_channels_out
+        )
+        log_prob = self._log_prob(y_cf, cond)
+        return -log_prob.mean()

--- a/tests/processors/test_conv_coupling.py
+++ b/tests/processors/test_conv_coupling.py
@@ -1,0 +1,188 @@
+import pytest
+import torch
+
+from autocast.processors.conv_coupling import ConvCouplingFlowProcessor
+from autocast.types import EncodedBatch
+
+# (spatial_shape, n_channels) covering a 2D grid and a 1D field as [L, 1].
+SHAPES = [((8, 8), 2), ((40, 1), 1)]
+
+
+def _batch(b, spatial, channels):
+    h, w = spatial
+    return EncodedBatch(
+        encoded_inputs=torch.randn(b, 1, h, w, channels),
+        encoded_output_fields=torch.randn(b, 1, h, w, channels),
+        global_cond=None,
+        encoded_info={},
+    )
+
+
+def _processor(spatial, channels, transforms=6):
+    return ConvCouplingFlowProcessor(
+        n_steps_input=1,
+        n_steps_output=1,
+        n_channels_in=channels,
+        n_channels_out=channels,
+        spatial_shape=spatial,
+        transforms=transforms,
+        hidden_channels=16,
+        n_blocks=2,
+    )
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_loss_finite_and_backward(spatial, channels):
+    proc = _processor(spatial, channels)
+    loss = proc.loss(_batch(4, spatial, channels))
+    assert loss.shape == ()
+    assert torch.isfinite(loss)
+    loss.backward()
+    grads = [p.grad for p in proc.parameters() if p.grad is not None]
+    assert grads, "no gradients flowed"
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_map_shape_and_finite(spatial, channels):
+    proc = _processor(spatial, channels)
+    h, w = spatial
+    x = torch.randn(3, 1, h, w, channels)
+    y = proc.map(x, None)
+    assert y.shape == (3, 1, h, w, channels)
+    assert torch.isfinite(y).all()
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_bijective_roundtrip(spatial, channels):
+    """encode (data->latent) then decode (latent->data) must recover the field
+    exactly — the property that makes the change-of-variables likelihood exact."""
+    proc = _processor(spatial, channels).eval()
+    # Random (non-identity) parameters so the test is not trivially satisfied
+    # by the zero-init identity start.
+    with torch.no_grad():
+        for p in proc.parameters():
+            p.add_(0.1 * torch.randn_like(p))
+    h, w = spatial
+    y = proc._to_conv(torch.randn(5, 1, h, w, channels), 1, channels)
+    cond = torch.randn(5, channels, h, w)
+    with torch.no_grad():
+        z = y
+        for layer in proc.coupling_layers():
+            z, _ = layer.encode(z, cond)
+        recon = z
+        for layer in reversed(proc.coupling_layers()):
+            recon = layer.decode(recon, cond)
+    # atol=1e-3: with a non-zero scale bound the coupling actually scales, so the
+    # float32 encode/decode round-trip carries ~2e-4 (a real non-bijection is O(1)).
+    assert torch.allclose(recon, y, atol=1e-3), (recon - y).abs().max().item()
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_two_train_steps_decrease(spatial, channels):
+    """Two optimiser steps on a fixed batch reduce the NLL (the loss is real)."""
+    torch.manual_seed(0)
+    proc = _processor(spatial, channels)
+    batch = _batch(8, spatial, channels)
+    opt = torch.optim.Adam(proc.parameters(), lr=1e-3)
+    losses = []
+    for _ in range(3):
+        opt.zero_grad()
+        loss = proc.loss(batch)
+        loss.backward()
+        opt.step()
+        losses.append(loss.item())
+    assert all(torch.isfinite(torch.tensor(losses)))
+    assert losses[-1] < losses[0]
+
+
+def test_requires_2d_spatial_shape():
+    with pytest.raises(ValueError, match="2D spatial_shape"):
+        ConvCouplingFlowProcessor(spatial_shape=(8, 8, 2))
+
+
+def test_loss_rejects_mismatched_field_shape():
+    """A field whose trailing dims don't match (n_steps, *spatial, n_channels)
+    raises a clear error instead of a cryptic reshape failure."""
+    proc = _processor((8, 8), 1)
+    bad = EncodedBatch(
+        encoded_inputs=torch.randn(4, 1, 8, 8, 1),
+        encoded_output_fields=torch.randn(4, 1, 8, 8, 2),  # wrong channel count
+        global_cond=None,
+        encoded_info={},
+    )
+    with pytest.raises(ValueError, match="elements per sample but expected"):
+        proc.loss(bad)
+
+
+def test_scale_bound_initialised_nonzero():
+    """A zero scale bound is a dead saddle: with s = tanh(s_raw) * bound and both
+    s_raw (zero-init conv) and bound at zero, d s / d s_raw = bound = 0 AND
+    d s / d bound = tanh(s_raw) = 0, so neither the scale conv nor the bound ever
+    receive gradient -- the flow can only shift, never scale, freezing the
+    predictive std at the unit base. The bound must start non-zero."""
+    proc = _processor((40, 1), 1)
+    for layer in proc.coupling_layers():
+        assert float(layer.log_scale_bound.detach().abs().min()) > 0.0
+
+
+def test_predictive_std_compresses_below_base():
+    """The flow must be able to compress the unit base toward the data's small
+    one-step residual scale. The old zero-bound saddle froze the scale path,
+    locking the predictive std at the base std of ~1.0 regardless of the data;
+    with the saddle broken the proper NLL learns to compress."""
+    torch.manual_seed(0)
+    resid_std = 0.1
+    proc = _processor((8, 8), 1, transforms=8)
+    x = torch.randn(512, 1, 8, 8, 1)
+    y = x + resid_std * torch.randn_like(x)
+    batch = EncodedBatch(
+        encoded_inputs=x,
+        encoded_output_fields=y,
+        global_cond=None,
+        encoded_info={},
+    )
+    opt = torch.optim.Adam(proc.parameters(), lr=2e-3)
+    for _ in range(600):
+        opt.zero_grad()
+        proc.loss(batch).backward()
+        opt.step()
+    with torch.no_grad():
+        members = torch.stack([proc.map(x[:256], None) for _ in range(32)])
+    pred_std = members.std(dim=0).mean().item()
+    # Frozen-saddle value was ~1.0; a live scale path compresses well below it.
+    assert pred_std < 0.6
+
+
+def test_encode_logdet_matches_numerical_jacobian():
+    """The coupling stack's reported ``log|det dz/dy|`` equals the numerical
+    Jacobian determinant of the data->latent map (the change-of-variables term
+    the likelihood relies on). Run in float64 for a tight tolerance."""
+    torch.manual_seed(0)
+    proc = _processor((4, 4), 1, transforms=3).double().eval()
+    with torch.no_grad():
+        for p in proc.parameters():
+            p.add_(0.2 * torch.randn_like(p))
+    h, w = 4, 4
+    cond = torch.randn(1, 1, h, w, dtype=torch.float64)
+    y0 = proc._to_conv(torch.randn(1, 1, h, w, 1, dtype=torch.float64), 1, 1)
+
+    def encode_all(y_cf):
+        z = y_cf
+        ladj = z.new_zeros(z.shape[0])
+        for layer in proc.coupling_layers():
+            z, dl = layer.encode(z, cond)
+            ladj = ladj + dl
+        return z, ladj
+
+    _, ladj = encode_all(y0)
+
+    def flat_encode(flat):
+        return encode_all(flat.reshape(y0.shape))[0].reshape(-1)
+
+    jac = torch.autograd.functional.jacobian(flat_encode, y0.reshape(-1))
+    _, logabsdet = torch.linalg.slogdet(jac)
+    assert torch.allclose(ladj.reshape(()), logabsdet, atol=1e-6), (
+        ladj.item(),
+        logabsdet.item(),
+    )


### PR DESCRIPTION
## Summary

Adds `ConvCouplingFlowProcessor`, a convolutional affine-coupling normalizing flow that models the one-step predictive density `p(x_{t+1} | x_t)` exactly.

- A stack of spatial checkerboard affine-coupling layers, each conditioned on the current state `x_t` through a small CNN, emits a per-pixel log-scale and shift for the masked half. Each map is an exact bijection with a triangular Jacobian, so its log-determinant is just the sum of the log-scales over the transformed positions.
- Both the log-likelihood and sampling cost a single forward pass per layer — no autoregressive unrolling — so scoring is fast for spatial fields.
- Training uses the exact change-of-variables NLL; `map()` draws a member by sampling the unit Gaussian base and running the inverse coupling maps.

Targets spatial fields (1D as an `[L, 1]` grid, 2D as `[H, W]`). The per-channel log-scale bound is learned rather than fixed, and initialised non-zero to avoid a dead saddle that would otherwise freeze the predictive scale at the unit base.

## Notes

- `loss()` validates the field layout against the configured `(n_steps, spatial_shape, n_channels)` and raises a clear error on a mismatch instead of a cryptic reshape failure.
- Registered as `autocast.processors.conv_coupling.ConvCouplingFlowProcessor`, with a `processor/conv_coupling.yaml` group config whose output dims are auto-filled from the datamodule.

## Testing

- `pytest tests/processors/test_conv_coupling.py` (13 tests): finite loss + backward, the bijective encode/decode round-trip, a numerical log-det-Jacobian check, predictive-scale compression below the unit base, the layout shape guard, and a two-step NLL-decrease check.
- `ruff` and `pyright` clean; the full `tests/processors/` suite passes.