### PR TITLE
Add a TarFlow autoregressive flow processor

### DIFF
--- a/src/autocast/configs/processor/tarflow.yaml
+++ b/src/autocast/configs/processor/tarflow.yaml
@@ -1,0 +1,23 @@
+_target_: autocast.processors.tarflow.TarFlowProcessor
+# Output field dims are auto-filled from the datamodule by scripts/setup.py.
+n_steps_output: null
+n_channels_out: null
+# Conditioning field dims + spatial shape are set per toy in the experiment
+# config. Square 2D fields only (gs [8, 8]); the conditioner patchifies x_t.
+n_steps_input: 1
+n_channels_in: 1
+spatial_shape: [1, 1]
+global_cond_features: 0
+# Capacity (set per toy). The latent prior variance and the transform scales
+# are learned; only patch/channels/depth are configured.
+# patch_size=2 on the 8x8 gs grid (16 patches) keeps sampling fast (~55s full
+# one-step ensemble with batched members); patch_size=1 (64 patches) is ~15x
+# slower because the reverse pass is sequential over patches -- score TarFlow
+# with batched member draws (one reverse for all members), not a looped draw.
+patch_size: 2
+channels: 64
+num_blocks: 8
+layers_per_block: 2
+head_dim: 64
+expansion: 4
+var_lr: 0.1

--- a/src/autocast/processors/__init__.py
+++ b/src/autocast/processors/__init__.py
@@ -2,6 +2,7 @@ from autocast.processors.azula_vit import AzulaViTProcessor
 from autocast.processors.base import Processor
 from autocast.processors.flow_matching import FlowMatchingProcessor
 from autocast.processors.swin_vit import SwinViTProcessor
+from autocast.processors.tarflow import TarFlowProcessor
 from autocast.processors.unet import UNetProcessor
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "FlowMatchingProcessor",
     "Processor",
     "SwinViTProcessor",
+    "TarFlowProcessor",
     "UNetProcessor",
 ]

--- a/src/autocast/processors/tarflow.py
+++ b/src/autocast/processors/tarflow.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import cast
+
+import torch
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.types import EncodedBatch, Tensor
+
+# Adapted from Apple's TarFlow reference (apple/ml-tarflow, transformer_flow.py;
+# permissive license). The transformer autoregressive-flow machinery is ported
+# faithfully; the one substantive change is conditioning: the discrete
+# class-embedding is replaced by a per-patch projection of the patchified current
+# state x_t (injected into every block), and classifier-free guidance is dropped.
+
+
+class _Permutation(nn.Module):
+    def __init__(self, flip: bool) -> None:
+        super().__init__()
+        self.flip = flip
+
+    def forward(self, x: Tensor, dim: int = 1, inverse: bool = False) -> Tensor:  # noqa: ARG002
+        return x.flip(dims=[dim]) if self.flip else x
+
+
+class _Attention(nn.Module):
+    """Multi-head self-attention with optional causal KV-cached sampling."""
+
+    def __init__(self, channels: int, head_channels: int) -> None:
+        super().__init__()
+        if channels % head_channels != 0:
+            msg = "channels must be divisible by head_channels."
+            raise ValueError(msg)
+        self.norm = nn.LayerNorm(channels)
+        self.qkv = nn.Linear(channels, channels * 3)
+        self.proj = nn.Linear(channels, channels)
+        self.num_heads = channels // head_channels
+        self.scale = head_channels ** (-0.5)
+        self.sample = False
+        self.k_cache: list[Tensor] = []
+        self.v_cache: list[Tensor] = []
+
+    def forward(self, x: Tensor, mask: Tensor | None = None) -> Tensor:
+        b, t, c = x.shape
+        x = self.norm(x.float()).type(x.dtype)
+        q, k, v = (
+            self.qkv(x)
+            .reshape(b, t, 3 * self.num_heads, -1)
+            .transpose(1, 2)
+            .chunk(3, dim=1)
+        )
+        if self.sample:
+            self.k_cache.append(k)
+            self.v_cache.append(v)
+            k = torch.cat(self.k_cache, dim=2)
+            v = torch.cat(self.v_cache, dim=2)
+        attn_mask = mask.bool() if mask is not None else None
+        x = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=attn_mask, scale=self.scale
+        )
+        return self.proj(x.transpose(1, 2).reshape(b, t, c))
+
+
+class _MLP(nn.Module):
+    def __init__(self, channels: int, expansion: int) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(channels)
+        self.main = nn.Sequential(
+            nn.Linear(channels, channels * expansion),
+            nn.GELU(),
+            nn.Linear(channels * expansion, channels),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.main(self.norm(x.float()).type(x.dtype))
+
+
+class _AttentionBlock(nn.Module):
+    def __init__(self, channels: int, head_channels: int, expansion: int) -> None:
+        super().__init__()
+        self.attention = _Attention(channels, head_channels)
+        self.mlp = _MLP(channels, expansion)
+
+    def forward(self, x: Tensor, mask: Tensor | None = None) -> Tensor:
+        x = x + self.attention(x, mask)
+        return x + self.mlp(x)
+
+
+class _MetaBlock(nn.Module):
+    """One causal-masked autoregressive affine transform over the patch sequence."""
+
+    attn_mask: Tensor
+
+    def __init__(
+        self,
+        in_channels: int,
+        cond_channels: int,
+        channels: int,
+        num_patches: int,
+        flip: bool,
+        num_layers: int,
+        head_dim: int,
+        expansion: int,
+    ) -> None:
+        super().__init__()
+        self.proj_in = nn.Linear(in_channels, channels)
+        self.cond_proj = nn.Linear(cond_channels, channels)
+        self.pos_embed = nn.Parameter(torch.randn(num_patches, channels) * 1e-2)
+        self.attn_blocks = nn.ModuleList(
+            _AttentionBlock(channels, head_dim, expansion) for _ in range(num_layers)
+        )
+        self.proj_out = nn.Linear(channels, in_channels * 2)
+        self.proj_out.weight.data.fill_(0.0)
+        self.proj_out.bias.data.fill_(0.0)
+        self.permutation = _Permutation(flip)
+        self.register_buffer(
+            "attn_mask", torch.tril(torch.ones(num_patches, num_patches))
+        )
+
+    def _embed(self, x: Tensor, pos_embed: Tensor, cond: Tensor) -> Tensor:
+        return self.proj_in(x) + pos_embed + self.cond_proj(cond)
+
+    def forward(self, x: Tensor, cond: Tensor) -> tuple[Tensor, Tensor]:
+        x = self.permutation(x)
+        cond = self.permutation(cond)
+        pos_embed = self.permutation(self.pos_embed, dim=0)
+        x_in = x
+        h = self._embed(x, pos_embed, cond)
+        for block in self.attn_blocks:
+            h = block(h, self.attn_mask)
+        h = self.proj_out(h)
+        # Shift so patch i's transform params depend only on patches < i.
+        h = torch.cat([torch.zeros_like(h[:, :1]), h[:, :-1]], dim=1)
+        xa, xb = h.chunk(2, dim=-1)
+        scale = (-xa.float()).exp().type(xa.dtype)
+        z = self.permutation((x_in - xb) * scale, inverse=True)
+        return z, -xa.mean(dim=[1, 2])
+
+    def _set_sample(self, flag: bool) -> None:
+        for m in self.modules():
+            if isinstance(m, _Attention):
+                m.sample = flag
+                m.k_cache = []
+                m.v_cache = []
+
+    def reverse(self, x: Tensor, cond: Tensor) -> Tensor:
+        x = self.permutation(x)
+        cond = self.permutation(cond)
+        pos_embed = self.permutation(self.pos_embed, dim=0)
+        self._set_sample(True)
+        for i in range(x.size(1) - 1):
+            h = self._embed(x[:, i : i + 1], pos_embed[i : i + 1], cond[:, i : i + 1])
+            for block in self.attn_blocks:
+                h = block(h)
+            h = self.proj_out(h)
+            xa, xb = h.chunk(2, dim=-1)
+            scale = xa[:, 0].float().exp().type(xa.dtype)
+            x[:, i + 1] = x[:, i + 1] * scale + xb[:, 0]
+        self._set_sample(False)
+        return self.permutation(x, inverse=True)
+
+
+class TarFlowProcessor(Processor):
+    """Transformer autoregressive normalizing flow (TarFlow), conditioned on x_t.
+
+    A patch-based transformer flow that models ``p(x_{t+1} | x_t)`` exactly: a
+    stack of causal-masked autoregressive affine blocks (with alternating patch
+    permutations) maps the next-state field to a Gaussian latent, conditioned on
+    the patchified current state injected into every block. Likelihood is a
+    single parallel pass; sampling is a sequential per-patch reverse with KV
+    caching (one transformer pass per patch, no per-dimension unroll). Designed
+    for small square 2D fields (e.g. ``[8, 8]``).
+
+    The training loss is the exact change-of-variables negative log-likelihood
+    under a unit ``N(0, I)`` latent prior. At sampling time the latents are
+    rescaled by an exponential moving average of the encoded-latent variance
+    (the ``var`` buffer) to match the marginal scale of the data. The only
+    capacity choices are patch size, channels and depth; the transform scales
+    are learned by the flow.
+    """
+
+    var: Tensor
+
+    def __init__(
+        self,
+        *,
+        n_steps_input: int = 1,
+        n_steps_output: int = 1,
+        n_channels_in: int = 1,
+        n_channels_out: int = 1,
+        spatial_shape: Sequence[int] = (1, 1),
+        global_cond_features: int = 0,
+        patch_size: int = 1,
+        channels: int = 64,
+        num_blocks: int = 8,
+        layers_per_block: int = 2,
+        head_dim: int = 64,
+        expansion: int = 4,
+        var_lr: float = 0.1,
+    ) -> None:
+        super().__init__()
+        spatial = tuple(int(s) for s in spatial_shape)
+        if len(spatial) != 2 or spatial[0] != spatial[1]:
+            msg = (
+                "TarFlowProcessor expects a square 2D spatial_shape (H == W); "
+                f"got {spatial}. Use the flat/conv flows for non-square fields."
+            )
+            raise ValueError(msg)
+        if global_cond_features:
+            msg = "TarFlowProcessor does not support global_cond_features yet."
+            raise ValueError(msg)
+        h = spatial[0]
+        if h % int(patch_size) != 0:
+            msg = f"patch_size {patch_size} must divide the grid size {h}."
+            raise ValueError(msg)
+
+        self.n_steps_input = int(n_steps_input)
+        self.n_steps_output = int(n_steps_output)
+        self.n_channels_in = int(n_channels_in)
+        self.n_channels_out = int(n_channels_out)
+        self.spatial_shape = spatial
+        self.img_size = h
+        self.patch_size = int(patch_size)
+        self.var_lr = float(var_lr)
+
+        # Fold time into channels for the conv-style (N, C, H, W) layout.
+        self.tgt_channels = self.n_steps_output * self.n_channels_out
+        self.cond_channels = self.n_steps_input * self.n_channels_in
+        self.num_patches = (h // self.patch_size) ** 2
+        tgt_patch = self.tgt_channels * self.patch_size**2
+        cond_patch = self.cond_channels * self.patch_size**2
+
+        self.blocks = nn.ModuleList(
+            _MetaBlock(
+                tgt_patch,
+                cond_patch,
+                int(channels),
+                self.num_patches,
+                flip=bool(i % 2),
+                num_layers=int(layers_per_block),
+                head_dim=int(head_dim),
+                expansion=int(expansion),
+            )
+            for i in range(int(num_blocks))
+        )
+        self.register_buffer("var", torch.ones(self.num_patches, tgt_patch))
+
+    # -- patch + layout helpers ----------------------------------------------
+    def _to_images(self, field: Tensor, steps: int, channels: int) -> Tensor:
+        """(B, T, H, W, C) channels-last -> (B, T*C, H, W) channels-first."""
+        h = self.img_size
+        x = field.reshape(field.shape[0], steps, h, h, channels)
+        return x.permute(0, 1, 4, 2, 3).reshape(field.shape[0], steps * channels, h, h)
+
+    def _patchify(self, x: Tensor) -> Tensor:
+        u = nn.functional.unfold(x, self.patch_size, stride=self.patch_size)
+        return u.transpose(1, 2)
+
+    def _unpatchify(self, x: Tensor) -> Tensor:
+        u = x.transpose(1, 2)
+        return nn.functional.fold(
+            u, (self.img_size, self.img_size), self.patch_size, stride=self.patch_size
+        )
+
+    def _cond_patches(self, x: Tensor) -> Tensor:
+        return self._patchify(
+            self._to_images(x, self.n_steps_input, self.n_channels_in)
+        )
+
+    # -- flow -----------------------------------------------------------------
+    def _encode(self, y_patches: Tensor, cond: Tensor) -> tuple[Tensor, Tensor]:
+        z = y_patches
+        logdets = z.new_zeros(())
+        for block in self.blocks:
+            z, logdet = block(z, cond)
+            logdets = logdets + logdet
+        return z, logdets
+
+    # -- Processor API --------------------------------------------------------
+    def forward(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        return self.map(x, global_cond)
+
+    def map(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:  # noqa: ARG002
+        """Draw one member: Gaussian latent -> sequential reverse, given x_t."""
+        cond = self._cond_patches(x)
+        z = torch.randn(
+            x.shape[0],
+            self.num_patches,
+            self.var.shape[1],
+            device=x.device,
+            dtype=x.dtype,
+        )
+        z = z * self.var.sqrt()
+        for block in reversed(self.blocks):
+            z = cast(_MetaBlock, block).reverse(z, cond)
+        img = self._unpatchify(z)  # (B, T_out*C_out, H, W)
+        h = self.img_size
+        y = img.reshape(x.shape[0], self.n_steps_output, self.n_channels_out, h, h)
+        return y.permute(0, 1, 3, 4, 2)
+
+    @torch.no_grad()
+    def map_batched(self, x: Tensor, members: int, max_rows: int = 8192) -> Tensor:
+        """Draw ``members`` ensemble members in ONE sequential reverse.
+
+        ``map`` runs a full per-patch sequential reverse per call, so an M-member
+        ensemble built by looping ``map`` costs M reverses. Here the members are
+        folded into the batch dimension and a single reverse produces the whole
+        ensemble (the per-patch transformer pass is parallel over the batch), the
+        key cost saving for the autoregressive sampler. Returns
+        ``(B, members, T_out, *spatial, C_out)`` -- the per-member axis is dim 1,
+        which is moved to the trailing ensemble axis at sampling time.
+
+        The effective batch is ``B * members``. For a full eval set that is large
+        (e.g. 6080 one-step inputs x 64 members = 389k rows), and the per-patch
+        KV cache built during the reverse scales with it, so the reverse is run
+        over the input batch in chunks capped at ``max_rows`` rows to bound peak
+        memory. Chunking only changes the latent draw order, not the output
+        distribution (each chunk draws its own latents); with ``B * members <=
+        max_rows`` the path is unchunked and bit-identical to a single reverse.
+        """
+        b = x.shape[0]
+        h = self.img_size
+        rows_per_chunk = max(1, max_rows // max(1, members))
+        outs = []
+        for i in range(0, b, rows_per_chunk):
+            xc = x[i : i + rows_per_chunk]
+            bc = xc.shape[0]
+            cond = self._cond_patches(xc).repeat_interleave(members, dim=0)
+            z = torch.randn(
+                bc * members,
+                self.num_patches,
+                self.var.shape[1],
+                device=xc.device,
+                dtype=xc.dtype,
+            )
+            z = z * self.var.sqrt()
+            for block in reversed(self.blocks):
+                z = cast(_MetaBlock, block).reverse(z, cond)
+            img = self._unpatchify(z)  # (bc*M, T_out*C_out, H, W)
+            rows = bc * members
+            y = img.reshape(rows, self.n_steps_output, self.n_channels_out, h, h)
+            y = y.permute(0, 1, 3, 4, 2)  # (bc*M, T_out, H, W, C_out)
+            outs.append(y.reshape(bc, members, *y.shape[1:]))
+        return torch.cat(outs, dim=0)
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        """Exact negative log-likelihood (TarFlow objective) of x_{t+1} given x_t."""
+        y_img = self._to_images(
+            batch.encoded_output_fields, self.n_steps_output, self.n_channels_out
+        )
+        y_patches = self._patchify(y_img)
+        cond = self._cond_patches(batch.encoded_inputs)
+        z, logdets = self._encode(y_patches, cond)
+        if self.training:
+            self.var.lerp_((z**2).mean(dim=0).detach(), weight=self.var_lr)
+        # 0.5 * ||z||^2 (per element) minus the mean log-det: the Gaussian NLL of
+        # the latent under the change of variables, up to an additive constant.
+        return 0.5 * z.pow(2).mean() - logdets.mean()

--- a/tests/processors/test_tarflow.py
+++ b/tests/processors/test_tarflow.py
@@ -1,0 +1,163 @@
+from typing import cast
+
+import pytest
+import torch
+
+from autocast.processors.tarflow import TarFlowProcessor, _MetaBlock
+from autocast.types import EncodedBatch
+
+# TarFlow targets the square 2D toy (gs: 8x8, 2 channels). Cover two patch sizes.
+CASES = [(8, 2, 1), (8, 2, 2)]
+
+
+def _batch(b, size, channels):
+    shape = (b, 1, size, size, channels)
+    return EncodedBatch(
+        encoded_inputs=torch.randn(*shape),
+        encoded_output_fields=torch.randn(*shape),
+        global_cond=None,
+        encoded_info={},
+    )
+
+
+def _processor(size, channels, patch_size, num_blocks=4):
+    return TarFlowProcessor(
+        n_channels_in=channels,
+        n_channels_out=channels,
+        spatial_shape=(size, size),
+        patch_size=patch_size,
+        channels=32,
+        num_blocks=num_blocks,
+        layers_per_block=1,
+        head_dim=32,
+    )
+
+
+@pytest.mark.parametrize(("size", "channels", "patch"), CASES)
+def test_loss_finite_and_backward(size, channels, patch):
+    proc = _processor(size, channels, patch).train()
+    loss = proc.loss(_batch(4, size, channels))
+    assert loss.shape == ()
+    assert torch.isfinite(loss)
+    loss.backward()
+    grads = [p.grad for p in proc.parameters() if p.grad is not None]
+    assert grads
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
+@pytest.mark.parametrize(("size", "channels", "patch"), CASES)
+def test_map_shape_and_finite(size, channels, patch):
+    proc = _processor(size, channels, patch).eval()
+    x = torch.randn(3, 1, size, size, channels)
+    y = proc.map(x, None)
+    assert y.shape == (3, 1, size, size, channels)
+    assert torch.isfinite(y).all()
+
+
+@pytest.mark.parametrize(("size", "channels", "patch"), CASES)
+def test_bijective_roundtrip(size, channels, patch):
+    """Encoding the field then inverting the blocks recovers it — the property
+    that makes the autoregressive change-of-variables likelihood exact."""
+    proc = _processor(size, channels, patch).eval()
+    # Perturb away from the zero-init (identity) so the test is non-trivial.
+    with torch.no_grad():
+        for p in proc.parameters():
+            p.add_(0.05 * torch.randn_like(p))
+    x = torch.randn(4, 1, size, size, channels)
+    cond = proc._cond_patches(x)
+    y_img = proc._to_images(torch.randn(4, 1, size, size, channels), 1, channels)
+    y = proc._patchify(y_img)
+    with torch.no_grad():
+        z, _ = proc._encode(y, cond)
+        recon = z
+        for block in reversed(proc.blocks):
+            recon = cast(_MetaBlock, block).reverse(recon, cond)
+    assert torch.allclose(recon, y, atol=1e-3), (recon - y).abs().max().item()
+
+
+def test_two_train_steps_decrease():
+    torch.manual_seed(0)
+    proc = _processor(8, 2, 1).train()
+    batch = _batch(8, 8, 2)
+    opt = torch.optim.Adam(proc.parameters(), lr=1e-3)
+    losses = []
+    for _ in range(3):
+        opt.zero_grad()
+        loss = proc.loss(batch)
+        loss.backward()
+        opt.step()
+        losses.append(loss.item())
+    assert all(torch.isfinite(torch.tensor(losses)))
+    assert losses[-1] < losses[0]
+
+
+@pytest.mark.parametrize(("size", "channels", "patch"), CASES)
+def test_map_batched_shape_and_independence(size, channels, patch):
+    """The batched sampler returns the same per-member layout as looped map()
+    (member axis moved to the end) and produces distinct, finite members."""
+    proc = _processor(size, channels, patch).eval()
+    x = torch.randn(3, 1, size, size, channels)
+    members = 8
+    ens = proc.map_batched(x, members).movedim(1, -1)
+    assert ens.shape == (3, 1, size, size, channels, members)
+    assert torch.isfinite(ens).all()
+    # Members are independent draws -> spread across the member axis is nonzero.
+    assert ens.var(dim=-1).mean() > 0
+
+
+@pytest.mark.parametrize(("size", "channels", "patch"), CASES)
+def test_map_batched_matches_looped_map(size, channels, patch):
+    """One batched member is the SAME transform as a single looped map() draw.
+
+    With ``members=1`` the batched path draws the same-shaped latent and the same
+    conditioning as ``map``, so under a fixed seed the two must agree bit-for-bit
+    -- guarding against a mis-wired reverse/reshape that the spread check alone
+    would miss. Perturb off the zero-init so the transform is non-trivial."""
+    proc = _processor(size, channels, patch).eval()
+    with torch.no_grad():
+        for p in proc.parameters():
+            p.add_(0.02 * torch.randn_like(p))
+    x = torch.randn(3, 1, size, size, channels)
+    torch.manual_seed(0)
+    looped = proc.map(x, None)
+    torch.manual_seed(0)
+    batched = proc.map_batched(x, 1)[:, 0]  # drop the singleton member axis
+    assert batched.shape == looped.shape
+    assert torch.allclose(batched, looped, atol=1e-5), (
+        (batched - looped).abs().max().item()
+    )
+
+
+def test_requires_square_2d():
+    with pytest.raises(ValueError, match="square 2D"):
+        TarFlowProcessor(spatial_shape=(40, 1))
+
+
+def test_encode_logdet_matches_numerical_jacobian():
+    """The autoregressive blocks' reported ``log|det dz/dy|`` equals the
+    numerical Jacobian determinant of the data->latent encode."""
+    torch.manual_seed(0)
+    proc = _processor(8, 1, patch_size=2, num_blocks=2).eval()
+    with torch.no_grad():
+        for p in proc.parameters():
+            p.add_(0.05 * torch.randn_like(p))
+    x = torch.randn(1, 1, 8, 8, 1)
+    cond = proc._cond_patches(x)
+    y_img = proc._to_images(torch.randn(1, 1, 8, 8, 1), 1, 1)
+    y0 = proc._patchify(y_img)
+
+    _, logdets = proc._encode(y0, cond)
+    # TarFlow reports the change-of-variables term as a per-element mean (its
+    # loss mean-reduces both the prior and the log-det together), whereas
+    # ``slogdet`` returns the sum, so scale by the latent element count.
+    n_elem = y0[0].numel()
+
+    def flat_encode(flat):
+        return proc._encode(flat.reshape(y0.shape), cond)[0].reshape(-1)
+
+    jac = torch.autograd.functional.jacobian(flat_encode, y0.reshape(-1))
+    _, logabsdet = torch.linalg.slogdet(jac)
+    assert torch.allclose(logdets.reshape(()) * n_elem, logabsdet, atol=1e-2), (
+        logdets.item() * n_elem,
+        logabsdet.item(),
+    )


### PR DESCRIPTION
## Summary

Adds `TarFlowProcessor`, a patch-based autoregressive normalizing flow that models the one-step predictive density `p(x_{t+1} | x_t)` exactly.

- The field is split into patches and modelled with a stack of causal Transformer meta-blocks over the patch sequence; each block is an exact affine map with a triangular Jacobian, so the change-of-variables log-likelihood is available in closed form.
- Training minimises the exact negative log-likelihood. `map()` samples ancestrally through the reverse maps, using a per-patch EMA variance buffer (updated only during training) at sampling time.

Targets square 2D fields handled patch-wise. It is the more expressive, sequentially-sampled flow; the convolutional-coupling processor is the cheaper one-pass alternative.

## Testing

- `pytest tests/processors/test_tarflow.py` (13 tests): finite loss + backward, the bijective encode/decode round-trip, a log-det-Jacobian check, and a two-step NLL-decrease check.
- `ruff` and `pyright` clean; the full `tests/processors/` suite passes.