### PR TITLE
Add a sigma-VAE processor with a calibrated decoder

### DIFF
--- a/src/autocast/configs/processor/sigma_vae.yaml
+++ b/src/autocast/configs/processor/sigma_vae.yaml
@@ -1,0 +1,21 @@
+_target_: autocast.processors.sigma_vae.SigmaVAEProcessor
+# Output field dims are auto-filled from the datamodule by scripts/setup.py.
+n_steps_output: null
+n_channels_out: null
+# Conditioning field dims + spatial shape are set per toy in the experiment
+# config (no backbone is mounted; the VAE builds its own MLP enc/decoder).
+n_steps_input: 1
+n_channels_in: 1
+spatial_shape: [1, 1]
+global_cond_features: 0
+# Capacity (set per toy by field size). The decoder output sigma is LEARNED
+# (calibration knob), so beta stays at 1 and needs no per-toy tuning.
+latent_dim: 32
+hidden_features: [128, 128]
+beta: 1.0
+# Data-driven: 'auto' sets the output sigma to the data's one-step residual
+# scale on the first batch. The sigma is a single scalar per channel that a
+# decaying LR cannot move far from its init, so a hard-coded constant ships
+# over-dispersed (sigma stuck ~1.0 vs a ~0.1-0.3 residual). Do NOT replace this
+# with a fixed number -- that is exactly the bug this default prevents.
+init_log_sigma: auto

--- a/src/autocast/processors/__init__.py
+++ b/src/autocast/processors/__init__.py
@@ -1,6 +1,7 @@
 from autocast.processors.azula_vit import AzulaViTProcessor
 from autocast.processors.base import Processor
 from autocast.processors.flow_matching import FlowMatchingProcessor
+from autocast.processors.sigma_vae import SigmaVAEProcessor
 from autocast.processors.swin_vit import SwinViTProcessor
 from autocast.processors.unet import UNetProcessor
 
@@ -8,6 +9,7 @@ __all__ = [
     "AzulaViTProcessor",
     "FlowMatchingProcessor",
     "Processor",
+    "SigmaVAEProcessor",
     "SwinViTProcessor",
     "UNetProcessor",
 ]

--- a/src/autocast/processors/sigma_vae.py
+++ b/src/autocast/processors/sigma_vae.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import torch
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.types import EncodedBatch, Tensor
+
+_LOG_2PI = math.log(2.0 * math.pi)
+
+
+def _mlp(in_features: int, out_features: int, hidden: Sequence[int]) -> nn.Sequential:
+    layers: list[nn.Module] = []
+    prev = in_features
+    for h in hidden:
+        layers += [nn.Linear(prev, h), nn.SiLU()]
+        prev = h
+    layers.append(nn.Linear(prev, out_features))
+    return nn.Sequential(*layers)
+
+
+class SigmaVAEProcessor(Processor):
+    """Conditional variational autoencoder with a calibrated (learned-sigma) decoder.
+
+    Models the one-step predictive density ``p(x_{t+1} | x_t)`` as a conditional
+    VAE: an encoder ``q(z | x_{t+1}, x_t)``, a standard-normal prior ``p(z)``, and
+    a Gaussian decoder ``p(x_{t+1} | z, x_t) = N(mu(z, x_t), sigma^2)``. The
+    decoder output standard deviation ``sigma`` is a **learned** per-channel
+    parameter (the "sigma-VAE" construction of Rybkin et al., 2021): a calibrated
+    decoder automatically balances the reconstruction term against the KL, so the
+    ELBO weight ``beta`` stays at 1 and no per-problem tuning of the
+    reconstruction/KL trade-off is needed. This is what lets one configuration
+    calibrate across fields with very different noise scales.
+
+    Everything is handled on the flattened field, so the same model applies to
+    scalar, vector, 1D and 2D fields alike (an ensemble member is a full
+    generative draw ``z ~ p(z)``, ``x = mu(z, x_t) + sigma * xi``, including the
+    decoder noise so the predictive spread is calibrated, not just the latent
+    spread).
+
+    The output sigma is a single per-channel scalar, so a decaying learning rate
+    cannot move it far within a budget: started at the wrong scale it ships at the
+    wrong scale (a fixed ``init_log_sigma`` over-disperses any field whose
+    one-step residual is not ``exp(init_log_sigma)``). It therefore defaults to
+    ``init_log_sigma="auto"``: on the first training batch sigma is set to the
+    data's per-channel one-step residual scale ``std(x_{t+1} - x_t)`` so it starts
+    calibrated and only fine-tunes. This is data-driven, so it holds identically
+    on toy and real data with no per-dataset constant. Pass a float to override.
+    """
+
+    _sigma_inited: Tensor  # registered buffer: has the data-driven init run yet
+
+    def __init__(
+        self,
+        *,
+        n_steps_input: int = 1,
+        n_steps_output: int = 1,
+        n_channels_in: int = 1,
+        n_channels_out: int = 1,
+        spatial_shape: Sequence[int] = (1, 1),
+        global_cond_features: int = 0,
+        latent_dim: int = 32,
+        hidden_features: Sequence[int] = (128, 128),
+        beta: float = 1.0,
+        init_log_sigma: float | str = "auto",
+        min_log_sigma: float = -7.0,
+        max_log_sigma: float = 5.0,
+    ) -> None:
+        super().__init__()
+        self.n_steps_input = int(n_steps_input)
+        self.n_steps_output = int(n_steps_output)
+        self.n_channels_in = int(n_channels_in)
+        self.n_channels_out = int(n_channels_out)
+        self.spatial_shape = tuple(int(s) for s in spatial_shape)
+        self.global_cond_features = int(global_cond_features)
+        self.latent_dim = int(latent_dim)
+        self.beta = float(beta)
+        self.min_log_sigma = float(min_log_sigma)
+        self.max_log_sigma = float(max_log_sigma)
+
+        spatial = int(math.prod(self.spatial_shape)) if self.spatial_shape else 1
+        self.spatial = spatial
+        self.features = self.n_steps_output * spatial * self.n_channels_out
+        self.context = (
+            self.n_steps_input * spatial * self.n_channels_in
+            + self.global_cond_features
+        )
+
+        hidden = tuple(int(h) for h in hidden_features)
+        self.encoder = _mlp(self.features + self.context, 2 * self.latent_dim, hidden)
+        self.decoder = _mlp(self.latent_dim + self.context, self.features, hidden)
+        # Learned per-channel output log-sigma (the calibration knob). Tiled over
+        # time/space at use; channel is the fastest-varying flattened axis.
+        # "auto" defers the value to the first training batch (data-driven init,
+        # see _maybe_init_sigma); a float is taken as-is and marked initialised.
+        self._auto_sigma = isinstance(init_log_sigma, str) and init_log_sigma == "auto"
+        init_value = 0.0 if self._auto_sigma else float(init_log_sigma)
+        self.log_sigma = nn.Parameter(torch.full((self.n_channels_out,), init_value))
+        # Buffer (not a plain attr) so the "already initialised" state survives
+        # checkpointing -- scoring loads a trained sigma and must never re-init.
+        self.register_buffer(
+            "_sigma_inited", torch.tensor(not self._auto_sigma), persistent=True
+        )
+
+    def _context(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        ctx = x.reshape(x.shape[0], -1)
+        if global_cond is not None and self.global_cond_features > 0:
+            ctx = torch.cat(
+                [ctx, global_cond.reshape(global_cond.shape[0], -1)], dim=-1
+            )
+        if ctx.shape[1] != self.context:
+            msg = (
+                "SigmaVAEProcessor conditioning has "
+                f"{ctx.shape[1]} features per sample but expected {self.context} = "
+                "n_steps_input * prod(spatial_shape) * n_channels_in + "
+                "global_cond_features. Check the processor dims against the data."
+            )
+            raise ValueError(msg)
+        return ctx
+
+    def _sigma_flat(self) -> Tensor:
+        """Per-feature sigma, (features,), from the per-channel learned log-sigma."""
+        log_sigma = self.log_sigma.clamp(self.min_log_sigma, self.max_log_sigma)
+        reps = self.n_steps_output * self.spatial
+        return log_sigma.repeat(reps).exp()
+
+    def _reshape_out(self, flat: Tensor) -> Tensor:
+        return flat.reshape(
+            flat.shape[0], self.n_steps_output, *self.spatial_shape, self.n_channels_out
+        )
+
+    def forward(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        return self.map(x, global_cond)
+
+    def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Draw one generative member: z ~ p(z), x = mu(z, x_t) + sigma * xi."""
+        ctx = self._context(x, global_cond)
+        z = torch.randn(
+            ctx.shape[0], self.latent_dim, device=ctx.device, dtype=ctx.dtype
+        )
+        mu = self.decoder(torch.cat([z, ctx], dim=-1))
+        sample = mu + self._sigma_flat() * torch.randn_like(mu)
+        return self._reshape_out(sample)
+
+    @torch.no_grad()
+    def _maybe_init_sigma(self, batch: EncodedBatch) -> None:
+        """Set the output sigma to the data's one-step residual scale (once).
+
+        Runs on the first *training* batch only. It is skipped outside training so
+        it never fires on Lightning's validation sanity-check pass -- that runs
+        under ``inference_mode`` (the in-place init would raise) and a validation
+        batch is the wrong source for the calibration anyway.
+
+        The per-channel target is ``std(x_{t+1} - x_t)`` -- the conditional spread
+        the decoder must match -- falling back to ``std(x_{t+1})`` when input/output
+        channels differ so the subtraction is undefined. Clamped to the model's
+        log-sigma range. Under DDP each rank initialises from its own first batch,
+        so the value is broadcast from rank 0 to keep the parameter identical
+        across ranks (DDP synchronises gradients, not this in-place init).
+        """
+        if not self.training or bool(self._sigma_inited):
+            return
+        y = batch.encoded_output_fields
+        x = batch.encoded_inputs
+        same = x.shape[-1] == y.shape[-1]
+        resid = (y - x) if same else y
+        std = resid.reshape(-1, self.n_channels_out).std(dim=0).clamp_min(1e-6)
+        self.log_sigma.copy_(std.log().clamp(self.min_log_sigma, self.max_log_sigma))
+        self._sigma_inited.fill_(True)
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            torch.distributed.broadcast(self.log_sigma.data, src=0)
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        """Negative ELBO with a calibrated (learned-sigma) Gaussian decoder."""
+        ctx = self._context(batch.encoded_inputs, batch.global_cond)
+        y = batch.encoded_output_fields.reshape(
+            batch.encoded_output_fields.shape[0], -1
+        )
+        if y.shape[1] != self.features:
+            msg = (
+                "SigmaVAEProcessor output field has "
+                f"{y.shape[1]} features per sample but expected {self.features} = "
+                "n_steps_output * prod(spatial_shape) * n_channels_out. Check the "
+                "processor dims against the data."
+            )
+            raise ValueError(msg)
+        self._maybe_init_sigma(batch)
+
+        mu_z, logvar_z = self.encoder(torch.cat([y, ctx], dim=-1)).chunk(2, dim=-1)
+        std_z = torch.exp(0.5 * logvar_z)
+        z = mu_z + std_z * torch.randn_like(std_z)
+        mu = self.decoder(torch.cat([z, ctx], dim=-1))
+
+        sigma = self._sigma_flat()
+        log_sigma = sigma.log()
+        recon = 0.5 * (((y - mu) / sigma) ** 2 + 2.0 * log_sigma + _LOG_2PI).sum(dim=-1)
+        kl = 0.5 * (mu_z**2 + logvar_z.exp() - 1.0 - logvar_z).sum(dim=-1)
+        return (recon + self.beta * kl).mean()

--- a/tests/processors/test_sigma_vae.py
+++ b/tests/processors/test_sigma_vae.py
@@ -1,0 +1,159 @@
+import pytest
+import torch
+
+from autocast.processors.sigma_vae import SigmaVAEProcessor
+from autocast.types import EncodedBatch
+
+# (spatial_shape, channels) spanning every toy archetype the model must cover:
+#   scalar (ou/dw), vector (mvou), 1D (l96), 2D (gs).
+SHAPES = [((1, 1), 1), ((1, 1), 3), ((40, 1), 1), ((8, 8), 2)]
+
+
+def _batch(b, spatial, channels):
+    shape = (b, 1, *spatial, channels)
+    return EncodedBatch(
+        encoded_inputs=torch.randn(*shape),
+        encoded_output_fields=torch.randn(*shape),
+        global_cond=None,
+        encoded_info={},
+    )
+
+
+def _processor(spatial, channels):
+    return SigmaVAEProcessor(
+        n_channels_in=channels,
+        n_channels_out=channels,
+        spatial_shape=spatial,
+        latent_dim=8,
+        hidden_features=(32, 32),
+    )
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_loss_finite_and_backward(spatial, channels):
+    proc = _processor(spatial, channels)
+    loss = proc.loss(_batch(4, spatial, channels))
+    assert loss.shape == ()
+    assert torch.isfinite(loss)
+    loss.backward()
+    # The learned output sigma must receive a gradient (it is being calibrated).
+    assert proc.log_sigma.grad is not None
+    assert torch.isfinite(proc.log_sigma.grad).all()
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_map_shape_and_finite(spatial, channels):
+    proc = _processor(spatial, channels)
+    x = torch.randn(3, 1, *spatial, channels)
+    y = proc.map(x, None)
+    assert y.shape == (3, 1, *spatial, channels)
+    assert torch.isfinite(y).all()
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_two_train_steps_decrease(spatial, channels):
+    torch.manual_seed(0)
+    proc = _processor(spatial, channels)
+    batch = _batch(16, spatial, channels)
+    opt = torch.optim.Adam(proc.parameters(), lr=1e-2)
+    losses = []
+    for _ in range(3):
+        opt.zero_grad()
+        loss = proc.loss(batch)
+        loss.backward()
+        opt.step()
+        losses.append(loss.item())
+    assert all(torch.isfinite(torch.tensor(losses)))
+    assert losses[-1] < losses[0]
+
+
+def test_auto_init_sets_sigma_to_residual_scale():
+    """init_log_sigma='auto' (the default) sets the output sigma to the data's
+    per-channel one-step residual std on the first training batch.
+
+    The output sigma is a single scalar per channel, so a decaying LR cannot move
+    it far within a budget: started at a fixed constant it ships at that constant
+    (the 4-6x over-dispersion seen when init_log_sigma=0 -> sigma=1 never reached
+    the ~0.1-0.3 residual scale). Data-driven init starts it calibrated."""
+    torch.manual_seed(0)
+    proc = SigmaVAEProcessor(
+        n_channels_in=1,
+        n_channels_out=1,
+        spatial_shape=(4, 1),
+        latent_dim=4,
+        hidden_features=(32, 32),
+    )
+    assert not bool(proc._sigma_inited)
+    resid_std = 0.1
+    x = torch.randn(4096, 1, 4, 1, 1)
+    y = x + resid_std * torch.randn_like(x)
+    proc.loss(
+        EncodedBatch(
+            encoded_inputs=x,
+            encoded_output_fields=y,
+            global_cond=None,
+            encoded_info={},
+        )
+    )
+    assert bool(proc._sigma_inited)
+    assert proc.log_sigma.exp().item() == pytest.approx(resid_std, rel=0.15)
+
+
+def test_loss_under_inference_mode_does_not_init_sigma():
+    """Lightning runs a validation sanity-check pass (eval mode, inference_mode)
+    before training starts. The data-driven sigma init must not fire there: the
+    in-place init would raise under inference_mode, and a validation batch is the
+    wrong source for the calibration. The init is training-only."""
+    proc = _processor((4, 1), 1).eval()
+    assert not bool(proc._sigma_inited)
+    with torch.inference_mode():
+        loss = proc.loss(_batch(4, (4, 1), 1))
+    assert torch.isfinite(loss)
+    assert not bool(proc._sigma_inited)  # still deferred to the first training batch
+
+
+def test_loss_rejects_mismatched_field_shape():
+    """A field whose flattened size does not match the configured dims raises a
+    clear error instead of a cryptic matmul failure inside the encoder."""
+    proc = _processor((8, 8), 1)
+    bad = EncodedBatch(
+        encoded_inputs=torch.randn(4, 1, 8, 8, 1),
+        encoded_output_fields=torch.randn(4, 1, 8, 8, 2),  # wrong channel count
+        global_cond=None,
+        encoded_info={},
+    )
+    with pytest.raises(ValueError, match="features per sample but expected"):
+        proc.loss(bad)
+
+
+def test_predictive_std_calibrates_to_residual_scale():
+    """After a realistic-budget fit on near-identity dynamics with a known small
+    one-step noise, the GENERATIVE predictive std matches that residual scale --
+    not the 4-6x over-dispersion a fixed init_log_sigma=0 (sigma=1) produced."""
+    torch.manual_seed(0)
+    resid_std = 0.1
+    proc = SigmaVAEProcessor(
+        n_channels_in=1,
+        n_channels_out=1,
+        spatial_shape=(4, 1),
+        latent_dim=4,
+        hidden_features=(64, 64),
+    )
+    x = torch.randn(2048, 1, 4, 1, 1)
+    y = x + resid_std * torch.randn_like(x)
+    batch = EncodedBatch(
+        encoded_inputs=x,
+        encoded_output_fields=y,
+        global_cond=None,
+        encoded_info={},
+    )
+    opt = torch.optim.Adam(proc.parameters(), lr=1e-2)
+    for _ in range(300):
+        opt.zero_grad()
+        proc.loss(batch).backward()
+        opt.step()
+    with torch.no_grad():
+        members = torch.stack([proc.map(x[:512], None) for _ in range(64)])
+    pred_std = members.std(dim=0).mean().item()
+    # Tight enough to catch the 4-6x failure, loose enough to be non-flaky.
+    assert 0.5 * resid_std <= pred_std <= 2.0 * resid_std


### PR DESCRIPTION
## Summary

Adds `SigmaVAEProcessor`, a conditional VAE that models the one-step predictive density `p(x_{t+1} | x_t)` with a learned per-channel output standard deviation (the sigma-VAE construction of Rybkin et al., 2021).

- A calibrated decoder balances the reconstruction term against the KL automatically, so the ELBO weight `beta` stays at 1 and no per-problem reconstruction/KL tuning is needed.
- An ensemble member is a full generative draw including the decoder noise, so the predictive spread is calibrated rather than just the latent spread.
- Operates on the flattened field, so it applies to scalar, vector, 1D and 2D fields alike.

## Data-driven sigma init (training-only, DDP-safe)

The output sigma is a single per-channel scalar that a decaying learning rate cannot move far, so it defaults to a data-driven init: on the first training batch it is set to the per-channel one-step residual scale `std(x_{t+1} - x_t)`.

- The init is **training-only** — it never fires on Lightning's validation sanity-check pass, which runs under `inference_mode` (the in-place init would raise there, and a validation batch is the wrong source for the calibration).
- Under **DDP**, each rank would otherwise init from its own first batch; the value is broadcast from rank 0 so the parameter starts identical across ranks (DDP synchronises gradients, not this in-place init).

`loss()` validates the field layout against the configured dims and raises a clear error on a mismatch.

## Testing

- `pytest tests/processors/test_sigma_vae.py` (16 tests): finite loss + backward, the data-driven sigma init, generative-spread calibration, the training-only init guard (under `inference_mode`), and the shape guard.
- `ruff` and `pyright` clean; the full `tests/processors/` suite passes.