### PR TITLE
Add residual flow matching

### DIFF
--- a/docs/walkthrough/processor.md
+++ b/docs/walkthrough/processor.md
@@ -83,6 +83,21 @@ We can check this again by running Python from the AutoCast directory:
 
 If you instead want to load the best checkpoint according to validation metrics, you can do so by loading the `best-val-*.ckpt` file in the `checkpoints` subfolder.
 
+## Processor coordinate systems
+
+A processor operates entirely in the coordinate system of the tensors it
+receives. For a cached-latent workflow these are latent coordinates; with
+identity encoder and decoder modules they are ambient coordinates. A processor
+does not implicitly decode its output or reverse dataset normalization.
+
+Residual processors likewise form their target and reference in processor
+coordinates. Residual standardization is an additional affine transform inside
+that coordinate system and is distinct from dataset normalization. A reference
+provided by another processor must therefore accept the same inputs and return
+the same ambient or latent coordinates, output horizon, and channels. An
+external ambient model must be encoded before it can provide a reference to a
+latent processor.
+
 ## Processors in ambient space
 
 The processor models in AutoCast are designed to operate in the latent space, i.e., with encoded data.

--- a/src/autocast/callbacks/__init__.py
+++ b/src/autocast/callbacks/__init__.py
@@ -7,10 +7,12 @@ from .checkpoint import ProgressModelCheckpoint
 from .ema import EMACallback
 from .grad_norm import GradNormCallback
 from .metrics import ValidationMetricPlotCallback
+from .residual_statistics import ResidualStatisticsCallback
 
 __all__ = [
     "EMACallback",
     "GradNormCallback",
     "ProgressModelCheckpoint",
+    "ResidualStatisticsCallback",
     "ValidationMetricPlotCallback",
 ]

--- a/src/autocast/callbacks/residual_statistics.py
+++ b/src/autocast/callbacks/residual_statistics.py
@@ -1,0 +1,194 @@
+"""Fit residual standardization statistics before training."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Protocol, cast
+
+import lightning as L
+import torch
+from lightning.pytorch.callbacks import Callback
+from lightning.pytorch.utilities.seed import isolate_rng
+from torch import nn
+
+from autocast.processors.residual_normalization import ResidualStandardizer
+from autocast.types import Batch, EncodedBatch, Tensor
+
+log = logging.getLogger(__name__)
+
+
+class _ResidualProcessor(Protocol):
+    standardizer: ResidualStandardizer | None
+    reference: nn.Module
+
+    def target_residual(self, batch: EncodedBatch) -> Tensor: ...
+
+
+class _RunningMoments:
+    """Streaming population moments over batches and spatial dimensions."""
+
+    def __init__(self, standardizer: ResidualStandardizer) -> None:
+        self.granularity = standardizer.granularity
+        self.count = 0
+        self.mean = torch.zeros(standardizer.statistic_shape, dtype=torch.float64)
+        self.m2 = torch.zeros_like(self.mean)
+
+    def update(self, residual: Tensor) -> None:
+        if self.granularity == "channel":
+            values = residual.reshape(-1, residual.shape[-1])
+        else:
+            values = residual.movedim(1, 0).reshape(
+                residual.shape[1], -1, residual.shape[-1]
+            )
+
+        batch_count = values.shape[-2]
+        if batch_count == 0:
+            return
+        batch_variance, batch_mean = torch.var_mean(
+            values.detach().float(), dim=-2, correction=0
+        )
+        batch_mean = batch_mean.to(device="cpu", dtype=torch.float64)
+        batch_m2 = batch_variance.to(device="cpu", dtype=torch.float64) * batch_count
+
+        total_count = self.count + batch_count
+        delta = batch_mean - self.mean
+        self.mean.add_(delta * (batch_count / total_count))
+        self.m2.add_(
+            batch_m2 + delta.square() * (self.count * batch_count / total_count)
+        )
+        self.count = total_count
+
+    def compute(self) -> tuple[Tensor, Tensor]:
+        if self.count == 0:
+            msg = "Cannot fit residual statistics from an empty training loader."
+            raise ValueError(msg)
+        return self.mean.float(), torch.sqrt(self.m2 / self.count).float()
+
+
+class ResidualStatisticsCallback(Callback):
+    """Fit residual statistics once from the full training split.
+
+    The callback uses a processor's public ``target_residual`` method, so it is
+    not tied to flow matching. It accepts ``EncodedBatch`` directly or ``Batch``
+    through a frozen latent encoder. Rank zero fits streaming moments, broadcasts
+    them to other ranks, and stores them in the standardizer checkpoint buffers.
+    """
+
+    def on_fit_start(
+        self,
+        trainer: L.Trainer,
+        pl_module: L.LightningModule,
+    ) -> None:
+        """Fit statistics unless they were restored from a checkpoint."""
+        processor, standardizer = self._configuration(pl_module)
+        needs_fit = not standardizer.fitted if trainer.is_global_zero else False
+        if not trainer.strategy.broadcast(needs_fit, src=0):
+            return
+
+        if trainer.is_global_zero:
+            mean, scale, count = self._fit_statistics(
+                trainer, pl_module, processor, standardizer
+            )
+            standardizer.set_statistics(mean=mean, scale=scale)
+            log.info("Fitted residual statistics from %d values per statistic.", count)
+
+        mean = trainer.strategy.broadcast(standardizer.mean.detach().clone(), src=0)
+        scale = trainer.strategy.broadcast(standardizer.scale.detach().clone(), src=0)
+        standardizer.set_statistics(mean=mean, scale=scale)
+
+    @staticmethod
+    def _configuration(
+        pl_module: L.LightningModule,
+    ) -> tuple[_ResidualProcessor, ResidualStandardizer]:
+        processor = getattr(pl_module, "processor", None)
+        if not callable(getattr(processor, "target_residual", None)):
+            msg = "model.processor must expose target_residual(batch)."
+            raise TypeError(msg)
+        standardizer = getattr(processor, "standardizer", None)
+        if not isinstance(standardizer, ResidualStandardizer):
+            msg = "model.processor.standardizer must be a ResidualStandardizer."
+            raise TypeError(msg)
+        reference = getattr(processor, "reference", None)
+        if not isinstance(reference, nn.Module):
+            msg = "model.processor.reference must be an nn.Module."
+            raise TypeError(msg)
+        if any(parameter.requires_grad for parameter in reference.parameters()):
+            msg = "Residual statistics require a fixed, non-trainable reference."
+            raise ValueError(msg)
+        return cast(_ResidualProcessor, processor), standardizer
+
+    def _fit_statistics(
+        self,
+        trainer: L.Trainer,
+        pl_module: L.LightningModule,
+        processor: _ResidualProcessor,
+        standardizer: ResidualStandardizer,
+    ) -> tuple[Tensor, Tensor, int]:
+        for attribute in ("noise_injector", "input_noise_injector"):
+            if getattr(pl_module, attribute, None) is not None:
+                msg = (
+                    "Residual statistics do not yet support model input noise; "
+                    f"{attribute} must be None."
+                )
+                raise ValueError(msg)
+
+        datamodule = getattr(trainer, "datamodule", None)
+        if datamodule is None:
+            msg = "ResidualStatisticsCallback requires a trainer datamodule."
+            raise ValueError(msg)
+        encoder = self._frozen_encoder(pl_module)
+        modules = [processor.reference, *([encoder] if encoder is not None else [])]
+        training_modes = [module.training for module in modules]
+        moments = _RunningMoments(standardizer)
+
+        try:
+            for module in modules:
+                module.eval()
+            with isolate_rng(), torch.inference_mode():
+                for batch in datamodule.train_dataloader():
+                    encoded_batch = self._encode_batch(
+                        batch, encoder, standardizer.mean.device
+                    )
+                    moments.update(processor.target_residual(encoded_batch))
+        finally:
+            for module, mode in zip(modules, training_modes, strict=True):
+                module.train(mode)
+
+        mean, scale = moments.compute()
+        return mean, scale, moments.count
+
+    @staticmethod
+    def _frozen_encoder(pl_module: L.LightningModule) -> nn.Module | None:
+        encoder = getattr(getattr(pl_module, "encoder_decoder", None), "encoder", None)
+        if encoder is None:
+            return None
+        if not getattr(pl_module, "train_in_latent_space", False):
+            msg = "Raw Batch statistics require train_in_latent_space=True."
+            raise ValueError(msg)
+        if any(parameter.requires_grad for parameter in encoder.parameters()):
+            msg = "Latent residual statistics require a frozen encoder."
+            raise ValueError(msg)
+        if not callable(getattr(encoder, "encode_batch", None)):
+            msg = "The latent encoder must expose encode_batch(batch)."
+            raise TypeError(msg)
+        return cast(nn.Module, encoder)
+
+    @staticmethod
+    def _encode_batch(
+        batch: object,
+        encoder: nn.Module | None,
+        device: torch.device,
+    ) -> EncodedBatch:
+        if isinstance(batch, EncodedBatch):
+            return batch.to(device)
+        if not isinstance(batch, Batch):
+            msg = f"Training loader yielded unsupported {type(batch).__name__}."
+            raise TypeError(msg)
+        if encoder is None:
+            msg = "Training loader yielded Batch without a frozen latent encoder."
+            raise TypeError(msg)
+        encode_batch = cast(
+            Callable[[Batch], EncodedBatch], encoder.encode_batch  # type: ignore[attr-defined]
+        )
+        return encode_batch(batch.to(device))

--- a/src/autocast/configs/flow_source/iid_gaussian.yaml
+++ b/src/autocast/configs/flow_source/iid_gaussian.yaml
@@ -1,0 +1,1 @@
+_target_: autocast.nn.noise.source.IIDGaussianSource

--- a/src/autocast/configs/flow_source/separable_gaussian.yaml
+++ b/src/autocast/configs/flow_source/separable_gaussian.yaml
@@ -1,0 +1,5 @@
+_target_: autocast.nn.noise.source.SeparableGaussianSource
+temporal_correlation_time: 4.0
+spatial_length_scale: 2.0
+channel_correlation: null
+dt: 1.0

--- a/src/autocast/configs/flow_source/separable_gaussian.yaml
+++ b/src/autocast/configs/flow_source/separable_gaussian.yaml
@@ -2,4 +2,5 @@ _target_: autocast.nn.noise.source.SeparableGaussianSource
 temporal_correlation_time: 4.0
 spatial_length_scale: 2.0
 channel_correlation: null
+spatial_boundaries: periodic
 dt: 1.0

--- a/src/autocast/configs/flow_source/temporal_ou.yaml
+++ b/src/autocast/configs/flow_source/temporal_ou.yaml
@@ -1,0 +1,3 @@
+_target_: autocast.nn.noise.source.TemporalOUSource
+correlation_time: 4.0
+dt: 1.0

--- a/src/autocast/configs/processor/residual_flow_matching_vit.yaml
+++ b/src/autocast/configs/processor/residual_flow_matching_vit.yaml
@@ -1,0 +1,24 @@
+defaults:
+  - /backbone@backbone: vit_small
+  - /flow_source@source: iid_gaussian
+  - _self_
+
+_target_: autocast.processors.residual_flow_matching.ResidualFlowMatchingProcessor
+flow_ode_steps: 20
+n_steps_output: auto
+n_channels_out: auto
+integrator: euler
+
+# IID residual noise plus this reference corresponds to a noisy persistence
+# source in full-state coordinates. Replace with ProcessorReference for a
+# pretrained surrogate or, later, a physics model.
+reference:
+  _target_: autocast.processors.residual_reference.LastFrameReference
+  n_steps_output: auto
+  channel_indices: null
+
+standardizer:
+  _target_: autocast.processors.residual_normalization.ResidualStandardizer
+  n_steps_output: auto
+  n_channels: auto
+  granularity: lead_channel

--- a/src/autocast/nn/noise/__init__.py
+++ b/src/autocast/nn/noise/__init__.py
@@ -1,0 +1,15 @@
+from autocast.nn.noise.source import (
+    FlowSource,
+    IIDGaussianSource,
+    SeparableGaussianSource,
+    TemporalOUSource,
+    ZeroSource,
+)
+
+__all__ = [
+    "FlowSource",
+    "IIDGaussianSource",
+    "SeparableGaussianSource",
+    "TemporalOUSource",
+    "ZeroSource",
+]

--- a/src/autocast/nn/noise/source.py
+++ b/src/autocast/nn/noise/source.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from typing import cast
 
 import torch
 from torch import nn
 
+from autocast.nn.noise.spatial import (
+    SpatialBoundary,
+    gaussian_spatial_filter,
+    validate_spatial_boundary,
+)
 from autocast.types import Tensor
 
 
@@ -75,7 +81,7 @@ class TemporalOUSource(FlowSource):
 
 
 class SeparableGaussianSource(TemporalOUSource):
-    """OU-time x periodic squared-exponential spatial Gaussian process."""
+    """OU-time x boundary-aware squared-exponential spatial Gaussian process."""
 
     channel_factor: Tensor | None
 
@@ -85,6 +91,7 @@ class SeparableGaussianSource(TemporalOUSource):
         temporal_correlation_time: float,
         spatial_length_scale: float,
         channel_correlation: Tensor | Sequence[Sequence[float]] | None = None,
+        spatial_boundaries: SpatialBoundary | Sequence[SpatialBoundary] = "periodic",
         dt: float = 1.0,
     ) -> None:
         super().__init__(correlation_time=temporal_correlation_time, dt=dt)
@@ -92,14 +99,30 @@ class SeparableGaussianSource(TemporalOUSource):
             msg = "spatial_length_scale must be positive."
             raise ValueError(msg)
         self.spatial_length_scale = spatial_length_scale
+        self.spatial_boundaries = self._validate_spatial_boundaries(spatial_boundaries)
         self.register_buffer(
             "channel_factor",
-            self._channel_factor(channel_correlation),
+            self._channel_factor(channel_correlation, self.spatial_boundaries),
         )
+
+    @staticmethod
+    def _validate_spatial_boundaries(
+        boundaries: SpatialBoundary | Sequence[SpatialBoundary],
+    ) -> SpatialBoundary | tuple[SpatialBoundary, ...]:
+        if isinstance(boundaries, str):
+            return validate_spatial_boundary(boundaries)
+        validated: tuple[SpatialBoundary, ...] = tuple(
+            validate_spatial_boundary(value) for value in boundaries
+        )
+        if not validated:
+            msg = "spatial_boundaries must not be empty."
+            raise ValueError(msg)
+        return validated
 
     @staticmethod
     def _channel_factor(
         correlation: Tensor | Sequence[Sequence[float]] | None,
+        boundaries: SpatialBoundary | tuple[SpatialBoundary, ...],
     ) -> Tensor | None:
         if correlation is None:
             return None
@@ -117,58 +140,88 @@ class SeparableGaussianSource(TemporalOUSource):
         if not torch.allclose(matrix, matrix.mT):
             msg = "channel_correlation must be symmetric."
             raise ValueError(msg)
-        if not torch.allclose(matrix.diagonal(), torch.ones(matrix.shape[0])):
+        diagonal = matrix.diagonal()
+        if not torch.allclose(diagonal, torch.ones_like(diagonal)):
             msg = "channel_correlation must have a unit diagonal."
             raise ValueError(msg)
+        if isinstance(boundaries, tuple):
+            if len(boundaries) != matrix.shape[0]:
+                msg = (
+                    "spatial_boundaries size must match channel_correlation: "
+                    f"expected {matrix.shape[0]}, got {len(boundaries)}."
+                )
+                raise ValueError(msg)
+            compatible = torch.tensor(
+                [[left == right for right in boundaries] for left in boundaries],
+                dtype=torch.bool,
+                device=matrix.device,
+            )
+            if torch.any(matrix.masked_select(~compatible).abs() > 1e-6):
+                msg = (
+                    "channel_correlation cannot couple channels with different "
+                    "spatial boundaries."
+                )
+                raise ValueError(msg)
         factor, info = torch.linalg.cholesky_ex(matrix)
         if torch.any(info):
             msg = "channel_correlation must be positive definite."
             raise ValueError(msg)
         return factor
 
-    def _spatial_amplitude(self, reference: Tensor) -> Tensor:
-        height, width = reference.shape[2:4]
-        angular_y = (
-            2.0
-            * math.pi
-            * torch.fft.fftfreq(
-                height,
-                dtype=reference.dtype,
-                device=reference.device,
+    def _resolved_spatial_boundaries(
+        self,
+        n_channels: int,
+    ) -> tuple[SpatialBoundary, ...]:
+        if isinstance(self.spatial_boundaries, str):
+            boundary = cast("SpatialBoundary", self.spatial_boundaries)
+            return (boundary,) * n_channels
+        if len(self.spatial_boundaries) != n_channels:
+            msg = (
+                "spatial_boundaries size must match the reference channels: "
+                f"expected {len(self.spatial_boundaries)}, got {n_channels}."
             )
-        )
-        angular_x = (
-            2.0
-            * math.pi
-            * torch.fft.fftfreq(
-                width,
-                dtype=reference.dtype,
-                device=reference.device,
+            raise ValueError(msg)
+        return self.spatial_boundaries
+
+    def _filter_spatially(
+        self,
+        samples: Tensor,
+        boundaries: tuple[SpatialBoundary, ...],
+    ) -> Tensor:
+        if all(boundary == boundaries[0] for boundary in boundaries):
+            return gaussian_spatial_filter(
+                samples,
+                length_scale=self.spatial_length_scale,
+                boundary=boundaries[0],
             )
-        )
-        squared_frequency = angular_y[:, None].square() + angular_x[None, :].square()
-        power = torch.exp(-0.5 * self.spatial_length_scale**2 * squared_frequency)
-        return (power / power.mean()).sqrt().to(dtype=reference.dtype)
+
+        filtered = torch.empty_like(samples)
+        for boundary in dict.fromkeys(boundaries):
+            channels = [
+                index
+                for index, channel_boundary in enumerate(boundaries)
+                if channel_boundary == boundary
+            ]
+            filtered[..., channels] = gaussian_spatial_filter(
+                samples[..., channels],
+                length_scale=self.spatial_length_scale,
+                boundary=boundary,
+            )
+        return filtered
 
     def sample_like(self, reference: Tensor) -> Tensor:
-        """Draw a zero-mean, unit-marginal separable GP sample."""
+        """Draw a zero-mean, unit-pooled-variance separable GP sample."""
         temporally_correlated = super().sample_like(reference)
         working = (
             temporally_correlated.float()
             if temporally_correlated.dtype in (torch.float16, torch.bfloat16)
             else temporally_correlated
         )
-        spectrum = torch.fft.fft2(
+        boundaries = self._resolved_spatial_boundaries(working.shape[-1])
+        samples = self._filter_spatially(
             working,
-            dim=(2, 3),
-            norm="ortho",
+            boundaries,
         )
-        amplitude = self._spatial_amplitude(working)[None, None, :, :, None]
-        samples = torch.fft.ifft2(
-            spectrum * amplitude,
-            dim=(2, 3),
-            norm="ortho",
-        ).real
         if self.channel_factor is not None:
             if samples.shape[-1] != self.channel_factor.shape[0]:
                 msg = (

--- a/src/autocast/nn/noise/source.py
+++ b/src/autocast/nn/noise/source.py
@@ -1,0 +1,181 @@
+"""Source distributions for flow matching."""
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+import torch
+from torch import nn
+
+from autocast.types import Tensor
+
+
+class FlowSource(nn.Module, ABC):
+    """Sample initial flow states matching a reference tensor."""
+
+    @abstractmethod
+    def sample_like(self, reference: Tensor) -> Tensor:
+        """Draw source states with the reference shape, device, and dtype."""
+
+
+class ZeroSource(FlowSource):
+    """Deterministic point source at zero."""
+
+    def sample_like(self, reference: Tensor) -> Tensor:
+        return torch.zeros_like(reference)
+
+
+class IIDGaussianSource(FlowSource):
+    """Independent standard Gaussian source."""
+
+    def sample_like(self, reference: Tensor) -> Tensor:
+        return torch.randn_like(reference)
+
+
+def _validate_spatiotemporal(reference: Tensor) -> None:
+    if reference.ndim != 5 or reference.shape[1] < 1:
+        msg = "reference must have shape (B, T, Y, X, C) with T >= 1."
+        raise ValueError(msg)
+    if not torch.is_floating_point(reference):
+        msg = "reference must be floating point."
+        raise TypeError(msg)
+
+
+class TemporalOUSource(FlowSource):
+    """Stationary Gaussian source with an OU kernel over output time."""
+
+    def __init__(self, *, correlation_time: float, dt: float = 1.0) -> None:
+        super().__init__()
+        if correlation_time <= 0.0:
+            msg = "correlation_time must be positive."
+            raise ValueError(msg)
+        if dt <= 0.0:
+            msg = "dt must be positive."
+            raise ValueError(msg)
+        self.correlation_time = correlation_time
+        self.dt = dt
+
+    @property
+    def correlation(self) -> float:
+        """Return the correlation between adjacent output frames."""
+        return math.exp(-self.dt / self.correlation_time)
+
+    def sample_like(self, reference: Tensor) -> Tensor:
+        """Draw unit-variance OU samples independently over space and channel."""
+        _validate_spatiotemporal(reference)
+        innovations = torch.randn_like(reference)
+        correlation = self.correlation
+        innovation_scale = math.sqrt(max(0.0, 1.0 - correlation**2))
+        samples = [innovations[:, 0]]
+        for innovation in innovations[:, 1:].unbind(dim=1):
+            samples.append(correlation * samples[-1] + innovation_scale * innovation)
+        return torch.stack(samples, dim=1)
+
+
+class SeparableGaussianSource(TemporalOUSource):
+    """OU-time x periodic squared-exponential spatial Gaussian process."""
+
+    channel_factor: Tensor | None
+
+    def __init__(
+        self,
+        *,
+        temporal_correlation_time: float,
+        spatial_length_scale: float,
+        channel_correlation: Tensor | Sequence[Sequence[float]] | None = None,
+        dt: float = 1.0,
+    ) -> None:
+        super().__init__(correlation_time=temporal_correlation_time, dt=dt)
+        if spatial_length_scale <= 0.0:
+            msg = "spatial_length_scale must be positive."
+            raise ValueError(msg)
+        self.spatial_length_scale = spatial_length_scale
+        self.register_buffer(
+            "channel_factor",
+            self._channel_factor(channel_correlation),
+        )
+
+    @staticmethod
+    def _channel_factor(
+        correlation: Tensor | Sequence[Sequence[float]] | None,
+    ) -> Tensor | None:
+        if correlation is None:
+            return None
+        matrix = torch.as_tensor(correlation, dtype=torch.float32)
+        if (
+            matrix.ndim != 2
+            or matrix.shape[0] == 0
+            or matrix.shape[0] != matrix.shape[1]
+        ):
+            msg = "channel_correlation must be a non-empty square matrix."
+            raise ValueError(msg)
+        if not torch.isfinite(matrix).all():
+            msg = "channel_correlation must contain only finite values."
+            raise ValueError(msg)
+        if not torch.allclose(matrix, matrix.mT):
+            msg = "channel_correlation must be symmetric."
+            raise ValueError(msg)
+        if not torch.allclose(matrix.diagonal(), torch.ones(matrix.shape[0])):
+            msg = "channel_correlation must have a unit diagonal."
+            raise ValueError(msg)
+        factor, info = torch.linalg.cholesky_ex(matrix)
+        if torch.any(info):
+            msg = "channel_correlation must be positive definite."
+            raise ValueError(msg)
+        return factor
+
+    def _spatial_amplitude(self, reference: Tensor) -> Tensor:
+        height, width = reference.shape[2:4]
+        angular_y = (
+            2.0
+            * math.pi
+            * torch.fft.fftfreq(
+                height,
+                dtype=reference.dtype,
+                device=reference.device,
+            )
+        )
+        angular_x = (
+            2.0
+            * math.pi
+            * torch.fft.fftfreq(
+                width,
+                dtype=reference.dtype,
+                device=reference.device,
+            )
+        )
+        squared_frequency = angular_y[:, None].square() + angular_x[None, :].square()
+        power = torch.exp(-0.5 * self.spatial_length_scale**2 * squared_frequency)
+        return (power / power.mean()).sqrt().to(dtype=reference.dtype)
+
+    def sample_like(self, reference: Tensor) -> Tensor:
+        """Draw a zero-mean, unit-marginal separable GP sample."""
+        temporally_correlated = super().sample_like(reference)
+        working = (
+            temporally_correlated.float()
+            if temporally_correlated.dtype in (torch.float16, torch.bfloat16)
+            else temporally_correlated
+        )
+        spectrum = torch.fft.fft2(
+            working,
+            dim=(2, 3),
+            norm="ortho",
+        )
+        amplitude = self._spatial_amplitude(working)[None, None, :, :, None]
+        samples = torch.fft.ifft2(
+            spectrum * amplitude,
+            dim=(2, 3),
+            norm="ortho",
+        ).real
+        if self.channel_factor is not None:
+            if samples.shape[-1] != self.channel_factor.shape[0]:
+                msg = (
+                    "channel_correlation size must match the reference channels: "
+                    f"expected {self.channel_factor.shape[0]}, got {samples.shape[-1]}."
+                )
+                raise ValueError(msg)
+            factor = self.channel_factor.to(device=samples.device, dtype=samples.dtype)
+            samples = torch.einsum("btyxc,dc->btyxd", samples, factor)
+        return samples.to(dtype=reference.dtype)

--- a/src/autocast/nn/noise/spatial.py
+++ b/src/autocast/nn/noise/spatial.py
@@ -1,0 +1,182 @@
+"""Boundary-aware spatial filtering for Gaussian flow sources."""
+
+from __future__ import annotations
+
+import math
+from typing import Literal, cast
+
+import torch
+
+from autocast.types import Tensor
+
+SpatialBoundary = Literal["periodic", "neumann", "dirichlet"]
+
+_BOUNDARIES = ("periodic", "neumann", "dirichlet")
+
+
+def validate_spatial_boundary(boundary: str) -> SpatialBoundary:
+    """Return a supported spatial boundary or raise a configuration error."""
+    if boundary not in _BOUNDARIES:
+        msg = f"spatial boundaries must be one of {_BOUNDARIES}; got {boundary!r}."
+        raise ValueError(msg)
+    return cast("SpatialBoundary", boundary)
+
+
+def _squared_frequency(reference: Tensor) -> Tensor:
+    height, width = reference.shape[2:4]
+    angular_y = (
+        2.0
+        * math.pi
+        * torch.fft.fftfreq(
+            height,
+            dtype=reference.dtype,
+            device=reference.device,
+        )
+    )
+    angular_x = (
+        2.0
+        * math.pi
+        * torch.fft.fftfreq(
+            width,
+            dtype=reference.dtype,
+            device=reference.device,
+        )
+    )
+    return angular_y[:, None].square() + angular_x[None, :].square()
+
+
+def _periodic_amplitude(reference: Tensor, length_scale: float) -> Tensor:
+    power = torch.exp(-0.5 * length_scale**2 * _squared_frequency(reference))
+    return (power / power.mean()).sqrt().to(dtype=reference.dtype)
+
+
+def _extend_even(field: Tensor, dim: int) -> Tensor:
+    return torch.cat((field, field.flip(dims=(dim,))), dim=dim)
+
+
+def _extend_odd(field: Tensor, dim: int) -> Tensor:
+    if field.shape[dim] < 3:
+        msg = "Dirichlet filtering requires at least three points per spatial axis."
+        raise ValueError(msg)
+    interior = field.narrow(dim, 1, field.shape[dim] - 2)
+    zero_shape = list(field.shape)
+    zero_shape[dim] = 1
+    zero = field.new_zeros(zero_shape)
+    return torch.cat((zero, interior, zero, -interior.flip(dims=(dim,))), dim=dim)
+
+
+def _extended_field(field: Tensor, boundary: SpatialBoundary) -> Tensor:
+    if boundary == "neumann":
+        return _extend_even(_extend_even(field, 2), 3)
+    return _extend_odd(_extend_odd(field, 2), 3)
+
+
+def _active_modes(size: int, boundary: SpatialBoundary) -> slice:
+    if boundary == "neumann":
+        return slice(0, size)
+    return slice(1, size - 1)
+
+
+def _basis_mode_mask(
+    reference: Tensor,
+    *,
+    original_shape: tuple[int, int],
+    boundary: SpatialBoundary,
+) -> Tensor:
+    frequency_y = torch.arange(reference.shape[2], device=reference.device)
+    frequency_x = torch.arange(reference.shape[3], device=reference.device)
+    if boundary == "neumann":
+        active_y = frequency_y != original_shape[0]
+        active_x = frequency_x != original_shape[1]
+    else:
+        active_y = (frequency_y != 0) & (frequency_y != original_shape[0] - 1)
+        active_x = (frequency_x != 0) & (frequency_x != original_shape[1] - 1)
+    return active_y[:, None] & active_x[None, :]
+
+
+def _extended_amplitude(
+    reference: Tensor,
+    *,
+    original_shape: tuple[int, int],
+    length_scale: float,
+    boundary: SpatialBoundary,
+) -> Tensor:
+    log_power = -0.5 * length_scale**2 * _squared_frequency(reference)
+    active_y = _active_modes(original_shape[0], boundary)
+    active_x = _active_modes(original_shape[1], boundary)
+    active_log_power = log_power[active_y, active_x]
+    log_mean_power = torch.logsumexp(active_log_power.flatten(), dim=0) - math.log(
+        active_log_power.numel()
+    )
+    log_amplitude = 0.5 * (log_power - log_mean_power)
+    if boundary == "dirichlet":
+        full_points = original_shape[0] * original_shape[1]
+        interior_points = (original_shape[0] - 2) * (original_shape[1] - 2)
+        log_amplitude = log_amplitude + 0.5 * math.log(full_points / interior_points)
+    active = _basis_mode_mask(
+        reference,
+        original_shape=original_shape,
+        boundary=boundary,
+    )
+    masked_log_amplitude = torch.where(
+        active,
+        log_amplitude,
+        torch.full_like(log_amplitude, -math.inf),
+    )
+    return torch.exp(masked_log_amplitude).to(dtype=reference.dtype)
+
+
+def _filter_periodic(field: Tensor, length_scale: float) -> Tensor:
+    spectrum = torch.fft.fft2(field, dim=(2, 3), norm="ortho")
+    amplitude = _periodic_amplitude(field, length_scale)[None, None, :, :, None]
+    return torch.fft.ifft2(
+        spectrum * amplitude,
+        dim=(2, 3),
+        norm="ortho",
+    ).real
+
+
+def _filter_bounded(
+    field: Tensor,
+    *,
+    length_scale: float,
+    boundary: SpatialBoundary,
+) -> Tensor:
+    height, width = field.shape[2:4]
+    extended = _extended_field(field, boundary)
+    spectrum = torch.fft.fft2(extended, dim=(2, 3), norm="ortho")
+    amplitude = _extended_amplitude(
+        extended,
+        original_shape=(height, width),
+        length_scale=length_scale,
+        boundary=boundary,
+    )[None, None, :, :, None]
+    filtered = torch.fft.ifft2(
+        spectrum * amplitude,
+        dim=(2, 3),
+        norm="ortho",
+    ).real
+    return filtered[:, :, :height, :width]
+
+
+def gaussian_spatial_filter(
+    field: Tensor,
+    *,
+    length_scale: float,
+    boundary: SpatialBoundary,
+) -> Tensor:
+    """Apply a squared-exponential filter with the selected boundary basis.
+
+    Periodic fields use their native Fourier grid. Neumann fields use an even
+    extension at the outer cell faces, equivalent to a cell-centred cosine
+    basis. Dirichlet fields use an odd extension of their interior, equivalent
+    to a sine basis with exact zero boundary values. Power is normalized to
+    unit pooled variance on the original full grid.
+    """
+    if boundary == "periodic":
+        return _filter_periodic(field, length_scale)
+    return _filter_bounded(
+        field,
+        length_scale=length_scale,
+        boundary=boundary,
+    )

--- a/src/autocast/processors/__init__.py
+++ b/src/autocast/processors/__init__.py
@@ -5,6 +5,11 @@ from autocast.processors.flow_matching import FlowMatchingProcessor
 from autocast.processors.flow_matching_masked_window import (
     FlowMatchingMaskedWindowProcessor,
 )
+from autocast.processors.residual_reference import (
+    LastFrameReference,
+    ProcessorReference,
+    ReferenceTrajectory,
+)
 from autocast.processors.sigma_vae import SigmaVAEProcessor
 from autocast.processors.swin_vit import SwinViTProcessor
 from autocast.processors.tarflow import TarFlowProcessor
@@ -15,7 +20,10 @@ __all__ = [
     "ConvCouplingFlowProcessor",
     "FlowMatchingMaskedWindowProcessor",
     "FlowMatchingProcessor",
+    "LastFrameReference",
     "Processor",
+    "ProcessorReference",
+    "ReferenceTrajectory",
     "SigmaVAEProcessor",
     "SwinViTProcessor",
     "TarFlowProcessor",

--- a/src/autocast/processors/__init__.py
+++ b/src/autocast/processors/__init__.py
@@ -5,6 +5,7 @@ from autocast.processors.flow_matching import FlowMatchingProcessor
 from autocast.processors.flow_matching_masked_window import (
     FlowMatchingMaskedWindowProcessor,
 )
+from autocast.processors.residual_flow_matching import ResidualFlowMatchingProcessor
 from autocast.processors.residual_reference import (
     LastFrameReference,
     ProcessorReference,
@@ -24,6 +25,7 @@ __all__ = [
     "Processor",
     "ProcessorReference",
     "ReferenceTrajectory",
+    "ResidualFlowMatchingProcessor",
     "SigmaVAEProcessor",
     "SwinViTProcessor",
     "TarFlowProcessor",

--- a/src/autocast/processors/__init__.py
+++ b/src/autocast/processors/__init__.py
@@ -6,6 +6,7 @@ from autocast.processors.flow_matching_masked_window import (
     FlowMatchingMaskedWindowProcessor,
 )
 from autocast.processors.residual_flow_matching import ResidualFlowMatchingProcessor
+from autocast.processors.residual_normalization import ResidualStandardizer
 from autocast.processors.residual_reference import (
     LastFrameReference,
     ProcessorReference,
@@ -26,6 +27,7 @@ __all__ = [
     "ProcessorReference",
     "ReferenceTrajectory",
     "ResidualFlowMatchingProcessor",
+    "ResidualStandardizer",
     "SigmaVAEProcessor",
     "SwinViTProcessor",
     "TarFlowProcessor",

--- a/src/autocast/processors/flow_matching.py
+++ b/src/autocast/processors/flow_matching.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
+from autocast.nn.noise.source import FlowSource, IIDGaussianSource
 from autocast.processors.base import Processor
 from autocast.types import EncodedBatch, Tensor
 
@@ -20,6 +21,7 @@ class FlowMatchingProcessor(Processor):
         n_steps_output: int = 4,
         n_channels_out: int = 1,
         integrator: str = "euler",
+        source: FlowSource | None = None,
     ) -> None:
         # Store core hyperparameters and optional prebuilt backbone.
         super().__init__()
@@ -34,6 +36,15 @@ class FlowMatchingProcessor(Processor):
         self.n_steps_output = n_steps_output
         self.n_channels_out = n_channels_out
         self.integrator = integrator
+        self.source = source if source is not None else IIDGaussianSource()
+
+    def _output_shape(self, x: Tensor) -> tuple[int, ...]:
+        return (
+            x.shape[0],
+            self.n_steps_output,
+            *x.shape[2:-1],
+            self.n_channels_out,
+        )
 
     def flow_field(
         self, z: Tensor, t: Tensor, x: Tensor, global_cond: Tensor | None = None
@@ -74,13 +85,23 @@ class FlowMatchingProcessor(Processor):
         Returns:
             Generated outputs of shape (B, T_out, *spatial, C_out).
         """
+        template = x.new_empty(self._output_shape(x))
+        source_states = self.source.sample_like(template)
+        return self.map_from_source(x, global_cond, source_states=source_states)
+
+    def map_from_source(
+        self,
+        x: Tensor,
+        global_cond: Tensor | None,
+        *,
+        source_states: Tensor,
+    ) -> Tensor:
+        """Integrate the flow ODE from caller-supplied source states."""
+        template = x.new_empty(self._output_shape(x))
+        self._validate_source_states(source_states, template)
+        z = source_states
         batch_size = x.shape[0]
         device, dtype = x.device, x.dtype
-
-        # Initialize noisy sample and scalar time for each batch element.
-        spatial_shape = tuple(x.shape[2:-1])
-        z_shape = (batch_size, self.n_steps_output, *spatial_shape, self.n_channels_out)
-        z = torch.randn(z_shape, device=device, dtype=dtype)
         t = torch.zeros(batch_size, device=device, dtype=dtype)
 
         # Fixed-step integration over the flow field.
@@ -97,14 +118,24 @@ class FlowMatchingProcessor(Processor):
 
     def loss(self, batch: EncodedBatch) -> Tensor:
         """Compute flow-matching loss for a batch."""
-        input_states = batch.encoded_inputs
-        target_states = batch.encoded_output_fields
+        return self._flow_matching_loss(
+            target_states=batch.encoded_output_fields,
+            conditioning=batch.encoded_inputs,
+            global_cond=batch.global_cond,
+        )
 
+    def _flow_matching_loss(
+        self,
+        *,
+        target_states: Tensor,
+        conditioning: Tensor,
+        global_cond: Tensor | None,
+    ) -> Tensor:
+        """Match the configured source distribution to target states."""
         self._validate_output_shape(target_states)
-
         batch_size = target_states.shape[0]
-
-        z0 = torch.randn_like(target_states, requires_grad=True)
+        z0 = self.source.sample_like(target_states)
+        self._validate_source_states(z0, target_states)
         t = torch.rand(
             batch_size, device=target_states.device, dtype=target_states.dtype
         )
@@ -112,8 +143,23 @@ class FlowMatchingProcessor(Processor):
         zt = (1 - t_broadcast) * z0 + t_broadcast * target_states
 
         target_velocity = target_states - z0
-        v_pred = self.flow_field(zt, t, input_states, global_cond=batch.global_cond)
+        v_pred = self.flow_field(zt, t, conditioning, global_cond=global_cond)
         return torch.mean((v_pred - target_velocity) ** 2)
+
+    @staticmethod
+    def _validate_source_states(source_states: Tensor, reference: Tensor) -> None:
+        if source_states.shape != reference.shape:
+            msg = (
+                f"Source states must have shape {tuple(reference.shape)}; "
+                f"received {tuple(source_states.shape)}."
+            )
+            raise ValueError(msg)
+        if (
+            source_states.device != reference.device
+            or source_states.dtype != reference.dtype
+        ):
+            msg = "Source states must use the reference device and dtype."
+            raise ValueError(msg)
 
     def _validate_output_shape(self, target_states: Tensor) -> None:
         """Validate output-window shape against processor configuration."""

--- a/src/autocast/processors/residual_flow_matching.py
+++ b/src/autocast/processors/residual_flow_matching.py
@@ -1,0 +1,76 @@
+"""Flow matching for residual forecast trajectories."""
+
+from __future__ import annotations
+
+from torch import nn
+
+from autocast.nn.noise.source import FlowSource
+from autocast.processors.flow_matching import FlowMatchingProcessor
+from autocast.processors.residual_reference import ReferenceTrajectory
+from autocast.types import EncodedBatch, Tensor
+
+
+class ResidualFlowMatchingProcessor(FlowMatchingProcessor):
+    """Transport source noise to a residual and add it to a reference forecast."""
+
+    def __init__(
+        self,
+        *,
+        backbone: nn.Module,
+        reference: ReferenceTrajectory,
+        flow_ode_steps: int = 1,
+        n_steps_output: int = 4,
+        n_channels_out: int = 1,
+        integrator: str = "euler",
+        source: FlowSource | None = None,
+    ) -> None:
+        super().__init__(
+            backbone=backbone,
+            flow_ode_steps=flow_ode_steps,
+            n_steps_output=n_steps_output,
+            n_channels_out=n_channels_out,
+            integrator=integrator,
+            source=source,
+        )
+        self.reference = reference
+
+    def reference_trajectory(
+        self,
+        x: Tensor,
+        global_cond: Tensor | None,
+    ) -> Tensor:
+        """Generate and validate the configured reference trajectory."""
+        reference = self.reference(x, global_cond)
+        expected_shape = self._output_shape(x)
+        if reference.shape != expected_shape:
+            msg = (
+                f"Reference trajectory must have shape {expected_shape}; "
+                f"received {tuple(reference.shape)}."
+            )
+            raise ValueError(msg)
+        return reference
+
+    def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Generate a residual trajectory and add it to the reference."""
+        reference = self.reference_trajectory(x, global_cond)
+        return reference + super().map(x, global_cond)
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        """Match the source distribution to target-minus-reference residuals."""
+        target = batch.encoded_output_fields
+        self._validate_output_shape(target)
+        reference = self.reference_trajectory(
+            batch.encoded_inputs,
+            batch.global_cond,
+        )
+        if reference.shape != target.shape:
+            msg = (
+                "Reference and target trajectories must have identical shapes; "
+                f"received {tuple(reference.shape)} and {tuple(target.shape)}."
+            )
+            raise ValueError(msg)
+        return self._flow_matching_loss(
+            target_states=target - reference,
+            conditioning=batch.encoded_inputs,
+            global_cond=batch.global_cond,
+        )

--- a/src/autocast/processors/residual_flow_matching.py
+++ b/src/autocast/processors/residual_flow_matching.py
@@ -6,12 +6,13 @@ from torch import nn
 
 from autocast.nn.noise.source import FlowSource
 from autocast.processors.flow_matching import FlowMatchingProcessor
+from autocast.processors.residual_normalization import ResidualStandardizer
 from autocast.processors.residual_reference import ReferenceTrajectory
 from autocast.types import EncodedBatch, Tensor
 
 
 class ResidualFlowMatchingProcessor(FlowMatchingProcessor):
-    """Transport source noise to a residual and add it to a reference forecast."""
+    """Transport noise to a standardized processor-coordinate residual."""
 
     def __init__(
         self,
@@ -23,6 +24,7 @@ class ResidualFlowMatchingProcessor(FlowMatchingProcessor):
         n_channels_out: int = 1,
         integrator: str = "euler",
         source: FlowSource | None = None,
+        standardizer: ResidualStandardizer | None = None,
     ) -> None:
         super().__init__(
             backbone=backbone,
@@ -33,6 +35,17 @@ class ResidualFlowMatchingProcessor(FlowMatchingProcessor):
             source=source,
         )
         self.reference = reference
+        if standardizer is not None and (
+            standardizer.n_steps_output != n_steps_output
+            or standardizer.n_channels != n_channels_out
+        ):
+            msg = (
+                "Residual standardizer dimensions must match the processor "
+                f"(expected T={n_steps_output}, C={n_channels_out}; received "
+                f"T={standardizer.n_steps_output}, C={standardizer.n_channels})."
+            )
+            raise ValueError(msg)
+        self.standardizer = standardizer
 
     def reference_trajectory(
         self,
@@ -53,10 +66,13 @@ class ResidualFlowMatchingProcessor(FlowMatchingProcessor):
     def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
         """Generate a residual trajectory and add it to the reference."""
         reference = self.reference_trajectory(x, global_cond)
-        return reference + super().map(x, global_cond)
+        generated_residual = super().map(x, global_cond)
+        if self.standardizer is not None:
+            generated_residual = self.standardizer.unstandardize(generated_residual)
+        return reference + generated_residual
 
-    def loss(self, batch: EncodedBatch) -> Tensor:
-        """Match the source distribution to target-minus-reference residuals."""
+    def target_residual(self, batch: EncodedBatch) -> Tensor:
+        """Return and validate target-minus-reference residuals for a batch."""
         target = batch.encoded_output_fields
         self._validate_output_shape(target)
         reference = self.reference_trajectory(
@@ -69,8 +85,15 @@ class ResidualFlowMatchingProcessor(FlowMatchingProcessor):
                 f"received {tuple(reference.shape)} and {tuple(target.shape)}."
             )
             raise ValueError(msg)
+        return target - reference
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        """Match the source distribution to target-minus-reference residuals."""
+        target_residual = self.target_residual(batch)
+        if self.standardizer is not None:
+            target_residual = self.standardizer.standardize(target_residual)
         return self._flow_matching_loss(
-            target_states=target - reference,
+            target_states=target_residual,
             conditioning=batch.encoded_inputs,
             global_cond=batch.global_cond,
         )

--- a/src/autocast/processors/residual_normalization.py
+++ b/src/autocast/processors/residual_normalization.py
@@ -1,0 +1,172 @@
+"""Affine normalization for residual forecast trajectories."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+
+import torch
+from torch import nn
+
+from autocast.types import Tensor
+
+ResidualGranularity = Literal["channel", "lead_channel"]
+Statistic = float | Sequence[float] | Sequence[Sequence[float]] | Tensor
+
+
+class ResidualStandardizer(nn.Module):
+    """Standardize processor-coordinate residuals using fitted statistics.
+
+    Statistics can be shared over output time (``channel``) or vary by lead
+    (``lead_channel``). Spatial dimensions are always pooled. Constructing the
+    module without statistics leaves it unfitted for a training callback to
+    initialize later; omitting the module from a residual processor preserves
+    identity behavior. These operations are distinct from dataset normalization:
+    they map between a residual and its standardized representation within the
+    processor's ambient or latent coordinate system.
+    """
+
+    mean: Tensor
+    scale: Tensor
+    _fitted: Tensor
+
+    _GRANULARITIES = ("channel", "lead_channel")
+
+    def __init__(
+        self,
+        *,
+        n_steps_output: int,
+        n_channels: int,
+        granularity: ResidualGranularity = "lead_channel",
+        mean: Statistic | None = None,
+        scale: Statistic | None = None,
+        epsilon: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        if n_steps_output < 1:
+            msg = "n_steps_output must be positive."
+            raise ValueError(msg)
+        if n_channels < 1:
+            msg = "n_channels must be positive."
+            raise ValueError(msg)
+        if granularity not in self._GRANULARITIES:
+            msg = (
+                f"granularity must be one of {self._GRANULARITIES}; "
+                f"got {granularity!r}."
+            )
+            raise ValueError(msg)
+        if epsilon <= 0.0:
+            msg = "epsilon must be positive."
+            raise ValueError(msg)
+        if (mean is None) != (scale is None):
+            msg = "mean and scale must either both be provided or both be omitted."
+            raise ValueError(msg)
+
+        self.n_steps_output = n_steps_output
+        self.n_channels = n_channels
+        self.granularity = granularity
+        self.epsilon = epsilon
+        statistic_shape = self.statistic_shape
+        self.register_buffer("mean", torch.zeros(statistic_shape), persistent=True)
+        self.register_buffer("scale", torch.ones(statistic_shape), persistent=True)
+        self.register_buffer("_fitted", torch.tensor(False), persistent=True)
+
+        if mean is not None and scale is not None:
+            self.set_statistics(mean=mean, scale=scale)
+
+    @property
+    def statistic_shape(self) -> tuple[int, ...]:
+        """Shape of the stored residual statistics."""
+        if self.granularity == "channel":
+            return (self.n_channels,)
+        return (self.n_steps_output, self.n_channels)
+
+    @property
+    def fitted(self) -> bool:
+        """Whether usable residual statistics have been assigned."""
+        return bool(self._fitted.item())
+
+    def _coerce_statistic(self, value: Statistic, *, name: str) -> Tensor:
+        statistic = torch.as_tensor(value, dtype=torch.float32)
+        if statistic.numel() == 1:
+            return statistic.reshape(1).expand(self.statistic_shape).clone()
+        if tuple(statistic.shape) != self.statistic_shape:
+            msg = (
+                f"{name} must be scalar or have shape {self.statistic_shape}; "
+                f"received {tuple(statistic.shape)}."
+            )
+            raise ValueError(msg)
+        return statistic
+
+    @torch.no_grad()
+    def set_statistics(self, *, mean: Statistic, scale: Statistic) -> None:
+        """Assign statistics, flooring zero scales for stable normalization."""
+        mean_tensor = self._coerce_statistic(mean, name="mean")
+        scale_tensor = self._coerce_statistic(scale, name="scale")
+        if not torch.isfinite(mean_tensor).all() or not torch.isfinite(
+            scale_tensor
+        ).all():
+            msg = "Residual statistics must contain only finite values."
+            raise ValueError(msg)
+        if torch.any(scale_tensor < 0.0):
+            msg = "Residual scales must be non-negative."
+            raise ValueError(msg)
+
+        self.mean.copy_(mean_tensor.to(device=self.mean.device, dtype=self.mean.dtype))
+        self.scale.copy_(
+            scale_tensor.clamp_min(self.epsilon).to(
+                device=self.scale.device,
+                dtype=self.scale.dtype,
+            )
+        )
+        self._fitted.fill_(True)
+
+    def _validate_residual(self, residual: Tensor) -> None:
+        if residual.ndim < 3:
+            msg = "residual must have shape (B, T, ..., C)."
+            raise ValueError(msg)
+        if (
+            residual.shape[1] != self.n_steps_output
+            or residual.shape[-1] != self.n_channels
+        ):
+            msg = (
+                "Residual shape does not match standardizer dimensions "
+                f"(expected T={self.n_steps_output}, C={self.n_channels}; "
+                f"received T={residual.shape[1]}, C={residual.shape[-1]})."
+            )
+            raise ValueError(msg)
+        if not torch.is_floating_point(residual):
+            msg = "residual must be floating point."
+            raise TypeError(msg)
+
+    def _statistics_like(self, residual: Tensor) -> tuple[Tensor, Tensor]:
+        if not self.fitted:
+            msg = "ResidualStandardizer must be fitted before use."
+            raise RuntimeError(msg)
+        self._validate_residual(residual)
+        if self.granularity == "channel":
+            broadcast_shape = (*([1] * (residual.ndim - 1)), self.n_channels)
+        else:
+            broadcast_shape = (
+                1,
+                self.n_steps_output,
+                *([1] * (residual.ndim - 3)),
+                self.n_channels,
+            )
+        mean = self.mean.to(device=residual.device, dtype=residual.dtype).view(
+            broadcast_shape
+        )
+        scale = self.scale.to(device=residual.device, dtype=residual.dtype).view(
+            broadcast_shape
+        )
+        return mean, scale
+
+    def standardize(self, residual: Tensor) -> Tensor:
+        """Map a processor-coordinate residual into standardized coordinates."""
+        mean, scale = self._statistics_like(residual)
+        return (residual - mean) / scale
+
+    def unstandardize(self, standardized_residual: Tensor) -> Tensor:
+        """Map a standardized residual back into processor coordinates."""
+        mean, scale = self._statistics_like(standardized_residual)
+        return mean + scale * standardized_residual

--- a/src/autocast/processors/residual_reference.py
+++ b/src/autocast/processors/residual_reference.py
@@ -15,11 +15,16 @@ from autocast.types import Tensor
 
 
 class ReferenceTrajectory(nn.Module, ABC):
-    """Build the trajectory about which a residual is modelled."""
+    """Build a processor-coordinate trajectory about which a residual is modelled.
+
+    A reference must use the same ambient or latent coordinates as the processor
+    target. References computed by an external ambient model must therefore be
+    encoded before use with a latent processor.
+    """
 
     @abstractmethod
     def forward(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:
-        """Return a reference trajectory conditioned on ``x``."""
+        """Return a processor-coordinate reference conditioned on ``x``."""
 
 
 class LastFrameReference(ReferenceTrajectory):
@@ -55,7 +60,13 @@ class LastFrameReference(ReferenceTrajectory):
 
 
 class ProcessorReference(ReferenceTrajectory):
-    """Use another processor as a reference trajectory generator."""
+    """Use another processor as a processor-coordinate reference generator.
+
+    The wrapped processor receives ``x`` and ``global_cond`` unchanged. Its
+    ``map`` output must already use the same ambient or latent coordinates,
+    horizon, and channels as the outer residual processor target. In particular,
+    it must not return dataset-denormalized states or standardized residuals.
+    """
 
     def __init__(self, processor: Processor, *, frozen: bool = True) -> None:
         super().__init__()
@@ -73,7 +84,7 @@ class ProcessorReference(ReferenceTrajectory):
         return self
 
     def forward(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:
-        """Delegate trajectory generation to the wrapped processor."""
+        """Return the wrapped processor's output without coordinate transforms."""
         context = torch.no_grad() if self.frozen else nullcontext()
         with context:
             return self.processor.map(x, global_cond)

--- a/src/autocast/processors/residual_reference.py
+++ b/src/autocast/processors/residual_reference.py
@@ -1,0 +1,79 @@
+"""Reference trajectories for residual forecasting."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from contextlib import nullcontext
+
+import torch
+from einops import repeat
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.types import Tensor
+
+
+class ReferenceTrajectory(nn.Module, ABC):
+    """Build the trajectory about which a residual is modelled."""
+
+    @abstractmethod
+    def forward(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:
+        """Return a reference trajectory conditioned on ``x``."""
+
+
+class LastFrameReference(ReferenceTrajectory):
+    """Repeat selected channels of the latest input frame over the horizon."""
+
+    def __init__(
+        self,
+        *,
+        n_steps_output: int,
+        channel_indices: Sequence[int] | None = None,
+    ) -> None:
+        super().__init__()
+        if n_steps_output < 1:
+            msg = "n_steps_output must be positive."
+            raise ValueError(msg)
+        if channel_indices is not None and not channel_indices:
+            msg = "channel_indices cannot be empty."
+            raise ValueError(msg)
+        self.n_steps_output = n_steps_output
+        self.channel_indices = (
+            tuple(channel_indices) if channel_indices is not None else None
+        )
+
+    def forward(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:  # noqa: ARG002
+        """Repeat the last frame of a channels-last spatiotemporal input."""
+        if x.ndim < 3 or x.shape[1] == 0:
+            msg = "x must have shape (B, T, ..., C) with at least one timestep."
+            raise ValueError(msg)
+        frame = x[:, -1:]
+        if self.channel_indices is not None:
+            frame = frame[..., list(self.channel_indices)]
+        return repeat(frame, "b 1 ... c -> b t ... c", t=self.n_steps_output)
+
+
+class ProcessorReference(ReferenceTrajectory):
+    """Use another processor as a reference trajectory generator."""
+
+    def __init__(self, processor: Processor, *, frozen: bool = True) -> None:
+        super().__init__()
+        self.processor = processor
+        self.frozen = frozen
+        if frozen:
+            self.processor.requires_grad_(False)
+            self.processor.eval()
+
+    def train(self, mode: bool = True) -> ProcessorReference:
+        """Keep a frozen reference in evaluation mode."""
+        super().train(mode)
+        if self.frozen:
+            self.processor.eval()
+        return self
+
+    def forward(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:
+        """Delegate trajectory generation to the wrapped processor."""
+        context = torch.no_grad() if self.frozen else nullcontext()
+        with context:
+            return self.processor.map(x, global_cond)

--- a/src/autocast/scripts/setup.py
+++ b/src/autocast/scripts/setup.py
@@ -197,6 +197,15 @@ def _apply_processor_channel_defaults(
         list(spatial_resolution) if spatial_resolution is not None else None,
     )
 
+    reference_config = processor_config.get("reference")
+    if isinstance(reference_config, DictConfig):
+        _set_if_auto(reference_config, "n_steps_output", n_steps_output)
+
+    standardizer_config = processor_config.get("standardizer")
+    if isinstance(standardizer_config, DictConfig):
+        _set_if_auto(standardizer_config, "n_steps_output", n_steps_output)
+        _set_if_auto(standardizer_config, "n_channels", n_channels_out)
+
     backbone_config = processor_config.get("backbone")
     if backbone_config is None:
         return

--- a/src/autocast/scripts/training.py
+++ b/src/autocast/scripts/training.py
@@ -15,10 +15,12 @@ from matplotlib import pyplot as plt
 from omegaconf import DictConfig, OmegaConf
 
 from autocast.callbacks.gpu_util import GpuUtilizationLogCallback
+from autocast.callbacks.residual_statistics import ResidualStatisticsCallback
 from autocast.data.datamodule import SpatioTemporalDataModule, TheWellDataModule
 from autocast.logging import create_wandb_logger
 from autocast.logging.wandb import maybe_watch_model
 from autocast.models.autoencoder import AE
+from autocast.processors.residual_normalization import ResidualStandardizer
 from autocast.scripts.config import save_resolved_config
 from autocast.scripts.data import batch_to_device
 from autocast.scripts.setup import setup_autoencoder_model, setup_datamodule
@@ -388,6 +390,30 @@ def _gpu_util_callbacks(config: DictConfig) -> list[Callback]:
     return []
 
 
+def _ensure_residual_statistics_callback(
+    callbacks: object,
+    model: L.LightningModule,
+) -> list:
+    """Prepend the statistics pass required by an unfitted standardizer."""
+    callback_list = callbacks if isinstance(callbacks, list) else []
+    processor = getattr(model, "processor", None)
+    standardizer = getattr(processor, "standardizer", None)
+    if not isinstance(standardizer, ResidualStandardizer) or standardizer.fitted:
+        return callback_list
+    for index, callback in enumerate(callback_list):
+        configured = isinstance(callback, ResidualStatisticsCallback) or (
+            isinstance(callback, dict)
+            and str(callback.get("_target_", "")).endswith(
+                "ResidualStatisticsCallback"
+            )
+        )
+        if configured:
+            callback_list.insert(0, callback_list.pop(index))
+            return callback_list
+    callback_list.insert(0, ResidualStatisticsCallback())
+    return callback_list
+
+
 def run_training(
     config: DictConfig,
     model: L.LightningModule,
@@ -436,9 +462,9 @@ def run_training(
         msg = "trainer config must resolve to a mapping"
         raise TypeError(msg)
 
-    callbacks = trainer_cfg.get("callbacks", [])
-    if not isinstance(callbacks, list):
-        callbacks = []
+    callbacks = _ensure_residual_statistics_callback(
+        trainer_cfg.get("callbacks", []), model
+    )
 
     for callback in callbacks:
         if isinstance(callback, dict) and callback.get("_target_", "").endswith(

--- a/tests/callbacks/test_residual_statistics.py
+++ b/tests/callbacks/test_residual_statistics.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from autocast.callbacks.residual_statistics import ResidualStatisticsCallback
+from autocast.decoders.identity import IdentityDecoder
+from autocast.encoders.identity import IdentityEncoder
+from autocast.models.encoder_decoder import EncoderDecoder
+from autocast.models.encoder_processor_decoder import EncoderProcessorDecoder
+from autocast.models.processor import ProcessorModel
+from autocast.nn.noise.noise_injector import AdditiveNoiseInjector
+from autocast.nn.noise.source import ZeroSource
+from autocast.processors.residual_flow_matching import ResidualFlowMatchingProcessor
+from autocast.processors.residual_normalization import (
+    ResidualGranularity,
+    ResidualStandardizer,
+)
+from autocast.processors.residual_reference import (
+    LastFrameReference,
+    ReferenceTrajectory,
+)
+from autocast.types import Batch, EncodedBatch
+
+
+class _ZeroField(nn.Module):
+    def forward(self, z, t, cond, global_cond=None):  # noqa: ARG002
+        return torch.zeros_like(z)
+
+
+class _SingleProcessStrategy:
+    def __init__(self) -> None:
+        self.broadcasts: list[object] = []
+
+    def broadcast(self, value, src=0):  # noqa: ARG002
+        self.broadcasts.append(value)
+        return value
+
+
+class _DataModule:
+    def __init__(self, train_batches: list[Batch] | list[EncodedBatch]) -> None:
+        self.train_batches = train_batches
+        self.train_calls = 0
+        self.val_calls = 0
+
+    def train_dataloader(self):
+        self.train_calls += 1
+        return self.train_batches
+
+    def val_dataloader(self):
+        self.val_calls += 1
+        return []
+
+
+class _Trainer:
+    def __init__(self, datamodule: _DataModule) -> None:
+        self.datamodule = datamodule
+        self.strategy = _SingleProcessStrategy()
+        self.is_global_zero = True
+
+
+class _TrainableReference(ReferenceTrajectory):
+    def __init__(self, n_steps_output: int) -> None:
+        super().__init__()
+        self.n_steps_output = n_steps_output
+        self.offset = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, global_cond=None):  # noqa: ARG002
+        return x[:, -1:].expand(-1, self.n_steps_output, *([-1] * (x.ndim - 2)))
+
+
+def _processor(
+    *,
+    granularity: ResidualGranularity = "lead_channel",
+    reference: ReferenceTrajectory | None = None,
+    with_standardizer: bool = True,
+) -> ResidualFlowMatchingProcessor:
+    n_steps_output = 3
+    standardizer = (
+        ResidualStandardizer(
+            n_steps_output=n_steps_output,
+            n_channels=2,
+            granularity=granularity,
+        )
+        if with_standardizer
+        else None
+    )
+    return ResidualFlowMatchingProcessor(
+        backbone=_ZeroField(),
+        reference=reference
+        if reference is not None
+        else LastFrameReference(n_steps_output=n_steps_output),
+        source=ZeroSource(),
+        standardizer=standardizer,
+        n_steps_output=n_steps_output,
+        n_channels_out=2,
+    )
+
+
+def _encoded_batches() -> list[EncodedBatch]:
+    residuals = torch.tensor(
+        [
+            [
+                [[[1.0, 2.0], [3.0, 4.0]]],
+                [[[2.0, 5.0], [4.0, 7.0]]],
+                [[[6.0, 9.0], [8.0, 11.0]]],
+            ],
+            [
+                [[[5.0, 6.0], [7.0, 8.0]]],
+                [[[6.0, 9.0], [8.0, 11.0]]],
+                [[[10.0, 13.0], [12.0, 15.0]]],
+            ],
+        ]
+    )
+    inputs = torch.zeros(2, 1, 1, 2, 2)
+    batches = []
+    for index in range(2):
+        batches.append(
+            EncodedBatch(
+                encoded_inputs=inputs[index : index + 1],
+                encoded_output_fields=residuals[index : index + 1],
+                global_cond=None,
+                encoded_info={},
+            )
+        )
+    return batches
+
+
+def _fit(
+    callback: ResidualStatisticsCallback,
+    trainer: _Trainer,
+    model: nn.Module,
+) -> None:
+    callback.on_fit_start(trainer, model)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("granularity", ["channel", "lead_channel"])
+def test_fits_streaming_training_statistics(granularity: ResidualGranularity):
+    batches = _encoded_batches()
+    datamodule = _DataModule(batches)
+    trainer = _Trainer(datamodule)
+    processor = _processor(granularity=granularity)
+    model = ProcessorModel(processor=processor)
+    callback = ResidualStatisticsCallback()
+    rng_state = torch.random.get_rng_state()
+
+    _fit(callback, trainer, model)
+
+    residual = torch.cat(
+        [batch.encoded_output_fields for batch in batches],
+        dim=0,
+    )
+    if granularity == "channel":
+        values = residual.reshape(-1, residual.shape[-1])
+    else:
+        values = residual.movedim(1, 0).reshape(
+            residual.shape[1],
+            -1,
+            residual.shape[-1],
+        )
+    expected_scale, expected_mean = torch.std_mean(values, dim=-2, correction=0)
+
+    assert processor.standardizer is not None
+    assert processor.standardizer.fitted
+    assert torch.allclose(processor.standardizer.mean, expected_mean)
+    assert torch.allclose(processor.standardizer.scale, expected_scale)
+    assert datamodule.train_calls == 1
+    assert datamodule.val_calls == 0
+    assert len(trainer.strategy.broadcasts) == 3
+    assert torch.equal(torch.random.get_rng_state(), rng_state)
+
+
+def test_skips_training_loader_when_statistics_are_restored():
+    datamodule = _DataModule(_encoded_batches())
+    trainer = _Trainer(datamodule)
+    processor = _processor()
+    assert processor.standardizer is not None
+    processor.standardizer.set_statistics(mean=2.0, scale=3.0)
+
+    _fit(ResidualStatisticsCallback(), trainer, ProcessorModel(processor=processor))
+
+    assert datamodule.train_calls == 0
+    assert torch.equal(processor.standardizer.mean, torch.full((3, 2), 2.0))
+    assert torch.equal(processor.standardizer.scale, torch.full((3, 2), 3.0))
+    assert len(trainer.strategy.broadcasts) == 1
+
+
+def test_fits_after_frozen_encoder_for_raw_batches():
+    encoded_batches = _encoded_batches()
+    raw_batches = [
+        Batch(
+            input_fields=batch.encoded_inputs,
+            output_fields=batch.encoded_output_fields,
+            constant_scalars=None,
+            constant_fields=None,
+        )
+        for batch in encoded_batches
+    ]
+    datamodule = _DataModule(raw_batches)
+    trainer = _Trainer(datamodule)
+    processor = _processor()
+    encoder_decoder = EncoderDecoder(
+        encoder=IdentityEncoder(in_channels=2),
+        decoder=IdentityDecoder(in_channels=2),
+    )
+    model = EncoderProcessorDecoder(
+        encoder_decoder=encoder_decoder,
+        processor=processor,
+        train_in_latent_space=True,
+    )
+
+    _fit(ResidualStatisticsCallback(), trainer, model)
+
+    residual = torch.cat([batch.output_fields for batch in raw_batches], dim=0)
+    values = residual.movedim(1, 0).reshape(3, -1, 2)
+    expected_scale, expected_mean = torch.std_mean(values, dim=1, correction=0)
+    assert processor.standardizer is not None
+    assert torch.allclose(processor.standardizer.mean, expected_mean)
+    assert torch.allclose(processor.standardizer.scale, expected_scale)
+
+
+def test_rejects_trainable_reference():
+    processor = _processor(reference=_TrainableReference(n_steps_output=3))
+    trainer = _Trainer(_DataModule(_encoded_batches()))
+
+    with pytest.raises(ValueError, match="fixed, non-trainable reference"):
+        _fit(ResidualStatisticsCallback(), trainer, ProcessorModel(processor=processor))
+
+
+def test_rejects_input_noise_until_its_statistics_are_defined():
+    processor = _processor()
+    model = ProcessorModel(
+        processor=processor,
+        noise_injector=AdditiveNoiseInjector(std=0.1),
+    )
+    trainer = _Trainer(_DataModule(_encoded_batches()))
+
+    with pytest.raises(ValueError, match="do not yet support model input noise"):
+        _fit(ResidualStatisticsCallback(), trainer, model)
+
+
+def test_requires_configured_standardizer():
+    processor = _processor(with_standardizer=False)
+    trainer = _Trainer(_DataModule(_encoded_batches()))
+
+    with pytest.raises(TypeError, match="processor.standardizer"):
+        _fit(ResidualStatisticsCallback(), trainer, ProcessorModel(processor=processor))

--- a/tests/nn/test_source.py
+++ b/tests/nn/test_source.py
@@ -61,6 +61,128 @@ def test_separable_gp_has_temporal_and_spatial_correlation():
     assert spatial > 0.5
 
 
+def test_separable_gp_preserves_periodic_formulation():
+    reference = torch.empty(2, 4, 8, 8, 2)
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+    )
+
+    torch.manual_seed(7)
+    actual = source.sample_like(reference)
+
+    torch.manual_seed(7)
+    temporal = TemporalOUSource(correlation_time=2.0).sample_like(reference)
+    angular_y = 2.0 * math.pi * torch.fft.fftfreq(8)
+    angular_x = 2.0 * math.pi * torch.fft.fftfreq(8)
+    squared_frequency = angular_y[:, None].square() + angular_x[None, :].square()
+    power = torch.exp(-0.5 * 2.0**2 * squared_frequency)
+    amplitude = (power / power.mean()).sqrt()[None, None, :, :, None]
+    expected = torch.fft.ifft2(
+        torch.fft.fft2(temporal, dim=(2, 3), norm="ortho") * amplitude,
+        dim=(2, 3),
+        norm="ortho",
+    ).real
+
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize("boundary", ["neumann", "dirichlet"])
+def test_bounded_separable_gp_has_unit_pooled_variance(boundary):
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+        spatial_boundaries=boundary,
+    )
+
+    samples = source.sample_like(torch.empty(512, 2, 16, 16, 1))
+
+    assert samples.std(correction=0) == pytest.approx(1.0, abs=0.08)
+
+
+def test_dirichlet_separable_gp_has_zero_boundary():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+        spatial_boundaries="dirichlet",
+    )
+
+    samples = source.sample_like(torch.empty(8, 2, 12, 16, 1))
+    boundary = torch.cat(
+        (
+            samples[:, :, 0].flatten(),
+            samples[:, :, -1].flatten(),
+            samples[:, :, :, 0].flatten(),
+            samples[:, :, :, -1].flatten(),
+        )
+    )
+
+    assert torch.allclose(boundary, torch.zeros_like(boundary), atol=1e-6)
+    assert torch.count_nonzero(samples[:, :, 1:-1, 1:-1]) > 0
+
+
+def test_dirichlet_separable_gp_is_finite_at_large_length_scale():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=100.0,
+        spatial_boundaries="dirichlet",
+    )
+
+    samples = source.sample_like(torch.empty(8, 2, 16, 16, 1))
+
+    assert torch.isfinite(samples).all()
+
+
+def test_neumann_separable_gp_does_not_wrap_boundaries():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+        spatial_boundaries="neumann",
+    )
+
+    samples = source.sample_like(torch.empty(2048, 1, 16, 16, 1))[:, 0, :, :, 0]
+    variance = samples.square().mean()
+    adjacent = (samples[:, :, 0] * samples[:, :, 1]).mean() / variance
+    opposite = (samples[:, :, 0] * samples[:, :, -1]).mean() / variance
+
+    assert adjacent > 0.5
+    assert opposite.abs() < 0.1
+
+
+def test_separable_gp_supports_mixed_channel_boundaries():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+        spatial_boundaries=("neumann", "dirichlet", "dirichlet"),
+        channel_correlation=(
+            (1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.75),
+            (0.0, 0.75, 1.0),
+        ),
+    )
+
+    samples = source.sample_like(torch.empty(512, 2, 16, 16, 3))
+    velocity = samples[..., 1:]
+    observed = (velocity[..., 0] * velocity[..., 1]).mean() / (
+        velocity[..., 0].std(correction=0) * velocity[..., 1].std(correction=0)
+    )
+
+    assert torch.count_nonzero(samples[..., 0]) > 0
+    assert torch.allclose(
+        velocity[:, :, 0], torch.zeros_like(velocity[:, :, 0]), atol=1e-6
+    )
+    assert torch.allclose(
+        velocity[:, :, -1], torch.zeros_like(velocity[:, :, -1]), atol=1e-6
+    )
+    assert torch.allclose(
+        velocity[:, :, :, 0], torch.zeros_like(velocity[:, :, :, 0]), atol=1e-6
+    )
+    assert torch.allclose(
+        velocity[:, :, :, -1], torch.zeros_like(velocity[:, :, :, -1]), atol=1e-6
+    )
+    assert observed == pytest.approx(0.75, abs=0.05)
+
+
 def test_separable_gp_preserves_low_precision_dtype():
     source = SeparableGaussianSource(
         temporal_correlation_time=2.0,
@@ -113,6 +235,56 @@ def test_separable_gp_validates_reference_channel_count():
 
     with pytest.raises(ValueError, match="expected 2, got 1"):
         source.sample_like(torch.empty(2, 4, 8, 8, 1))
+
+
+def test_separable_gp_validates_spatial_boundary_channel_count():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+        spatial_boundaries=("neumann", "dirichlet"),
+    )
+
+    with pytest.raises(ValueError, match="expected 2, got 1"):
+        source.sample_like(torch.empty(2, 4, 8, 8, 1))
+
+
+def test_separable_gp_rejects_cross_boundary_channel_correlation():
+    with pytest.raises(ValueError, match="different spatial boundaries"):
+        SeparableGaussianSource(
+            temporal_correlation_time=2.0,
+            spatial_length_scale=2.0,
+            spatial_boundaries=("neumann", "dirichlet"),
+            channel_correlation=((1.0, 0.5), (0.5, 1.0)),
+        )
+
+
+def test_separable_gp_accepts_accelerator_channel_correlation():
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        pytest.skip("No accelerator is available.")
+    correlation = torch.eye(2, device=device)
+
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+        spatial_boundaries=("neumann", "dirichlet"),
+        channel_correlation=correlation,
+    )
+
+    assert source.channel_factor is not None
+    assert source.channel_factor.device.type == device.type
+
+
+def test_separable_gp_validates_spatial_boundaries():
+    with pytest.raises(ValueError, match="must be one of"):
+        SeparableGaussianSource(
+            temporal_correlation_time=2.0,
+            spatial_length_scale=2.0,
+            spatial_boundaries="open",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/nn/test_source.py
+++ b/tests/nn/test_source.py
@@ -1,0 +1,138 @@
+import math
+
+import pytest
+import torch
+
+from autocast.nn.noise.source import (
+    IIDGaussianSource,
+    SeparableGaussianSource,
+    TemporalOUSource,
+    ZeroSource,
+)
+
+
+@pytest.mark.parametrize("source", [ZeroSource(), IIDGaussianSource()])
+def test_simple_sources_preserve_shape_device_and_dtype(source):
+    reference = torch.empty(2, 4, 8, 8, 3, dtype=torch.float64)
+
+    samples = source.sample_like(reference)
+
+    assert samples.shape == reference.shape
+    assert samples.device == reference.device
+    assert samples.dtype == reference.dtype
+
+
+def test_zero_source_is_deterministic():
+    reference = torch.empty(2, 4, 3)
+
+    assert torch.count_nonzero(ZeroSource().sample_like(reference)) == 0
+
+
+def test_temporal_ou_source_has_stationary_target_correlation():
+    source = TemporalOUSource(correlation_time=4.0)
+    samples = source.sample_like(torch.empty(4096, 6, 1, 1, 1))
+    variance = samples.square().mean()
+    lag_one = (samples[:, 1:] * samples[:, :-1]).mean() / variance
+
+    assert samples.std(correction=0) == pytest.approx(1.0, abs=0.03)
+    assert lag_one == pytest.approx(math.exp(-0.25), abs=0.03)
+
+
+def test_infinite_ou_correlation_time_shares_noise_across_frames():
+    samples = TemporalOUSource(correlation_time=math.inf).sample_like(
+        torch.empty(2, 4, 3, 3, 1)
+    )
+
+    assert torch.equal(samples, samples[:, :1].expand_as(samples))
+
+
+def test_separable_gp_has_temporal_and_spatial_correlation():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+    )
+    samples = source.sample_like(torch.empty(512, 4, 16, 16, 1))
+    variance = samples.square().mean()
+    temporal = (samples[:, 1:] * samples[:, :-1]).mean() / variance
+    spatial = (samples[:, :, :, 1:] * samples[:, :, :, :-1]).mean() / variance
+
+    assert samples.std(correction=0) == pytest.approx(1.0, abs=0.1)
+    assert temporal > 0.5
+    assert spatial > 0.5
+
+
+def test_separable_gp_preserves_low_precision_dtype():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+    )
+
+    samples = source.sample_like(torch.empty(2, 4, 8, 8, 1, dtype=torch.bfloat16))
+
+    assert samples.dtype == torch.bfloat16
+
+
+def test_separable_gp_applies_channel_correlation():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+        channel_correlation=((1.0, 0.75), (0.75, 1.0)),
+    )
+    samples = source.sample_like(torch.empty(512, 4, 8, 8, 2))
+    observed = (samples[..., 0] * samples[..., 1]).mean() / (
+        samples[..., 0].std(correction=0) * samples[..., 1].std(correction=0)
+    )
+
+    assert observed == pytest.approx(0.75, abs=0.05)
+
+
+@pytest.mark.parametrize(
+    ("correlation", "message"),
+    [
+        (((1.0, 0.0),), "square"),
+        (((1.0, 0.5), (0.0, 1.0)), "symmetric"),
+        (((2.0, 0.0), (0.0, 1.0)), "unit diagonal"),
+        (((1.0, 2.0), (2.0, 1.0)), "positive definite"),
+    ],
+)
+def test_separable_gp_validates_channel_correlation(correlation, message):
+    with pytest.raises(ValueError, match=message):
+        SeparableGaussianSource(
+            temporal_correlation_time=2.0,
+            spatial_length_scale=2.0,
+            channel_correlation=correlation,
+        )
+
+
+def test_separable_gp_validates_reference_channel_count():
+    source = SeparableGaussianSource(
+        temporal_correlation_time=2.0,
+        spatial_length_scale=2.0,
+        channel_correlation=((1.0, 0.5), (0.5, 1.0)),
+    )
+
+    with pytest.raises(ValueError, match="expected 2, got 1"):
+        source.sample_like(torch.empty(2, 4, 8, 8, 1))
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: TemporalOUSource(correlation_time=0.0), "correlation_time"),
+        (
+            lambda: SeparableGaussianSource(
+                temporal_correlation_time=1.0,
+                spatial_length_scale=0.0,
+            ),
+            "spatial_length_scale",
+        ),
+    ],
+)
+def test_correlated_sources_validate_length_scales(factory, message):
+    with pytest.raises(ValueError, match=message):
+        factory()
+
+
+def test_correlated_sources_require_spatiotemporal_fields():
+    with pytest.raises(ValueError, match=r"\(B, T, Y, X, C\)"):
+        TemporalOUSource(correlation_time=1.0).sample_like(torch.empty(2, 4, 3))

--- a/tests/processors/test_flow_matching.py
+++ b/tests/processors/test_flow_matching.py
@@ -317,6 +317,37 @@ def test_flow_matching_euler_default_unchanged():
     assert torch.equal(actual, expected)
 
 
+def test_flow_matching_default_loss_matches_original_formulation():
+    """The default source preserves the original loss and RNG sequence."""
+    inputs = torch.randn(3, 1, 2, 2, 1)
+    targets = torch.randn(3, 2, 2, 2, 1)
+    batch = EncodedBatch(
+        encoded_inputs=inputs,
+        encoded_output_fields=targets,
+        global_cond=None,
+        encoded_info={},
+    )
+    processor = FlowMatchingProcessor(
+        backbone=_DecayField(),
+        n_steps_output=2,
+        n_channels_out=1,
+    )
+
+    torch.manual_seed(123)
+    actual = processor.loss(batch)
+
+    # Reconstruct the implementation before sources became configurable.
+    torch.manual_seed(123)
+    z0 = torch.randn_like(targets)
+    t = torch.rand(targets.shape[0], device=targets.device, dtype=targets.dtype)
+    t_broadcast = t.view(targets.shape[0], *([1] * (targets.ndim - 1)))
+    zt = (1 - t_broadcast) * z0 + t_broadcast * targets
+    target_velocity = targets - z0
+    expected = torch.mean((-zt - target_velocity) ** 2)
+
+    assert torch.equal(actual, expected)
+
+
 @pytest.mark.parametrize("integrator", ["euler", "heun"])
 def test_flow_matching_integrator_shapes(integrator):
     x = torch.randn(2, 1, 4, 4, 2)

--- a/tests/processors/test_flow_matching.py
+++ b/tests/processors/test_flow_matching.py
@@ -297,13 +297,24 @@ def test_flow_matching_euler_default_unchanged():
     """integrator='euler' (the default) reproduces the original sampling path
     bit-for-bit: same RNG consumption, same update rule."""
     x = torch.randn(3, 1, 2, 2, 1)
+    steps = 4
     torch.manual_seed(123)
-    out_default = FlowMatchingProcessor(
-        backbone=_DecayField(), n_steps_output=1, n_channels_out=1, flow_ode_steps=4
+    actual = FlowMatchingProcessor(
+        backbone=_DecayField(),
+        n_steps_output=1,
+        n_channels_out=1,
+        flow_ode_steps=steps,
     ).map(x, None)
+
+    # Reconstruct the pre-source-API implementation directly: draw with
+    # torch.randn, then apply the original Euler update z <- z - dt * z.
     torch.manual_seed(123)
-    out_euler = _decay_processor("euler", 4).map(x, None)
-    assert torch.equal(out_default, out_euler)
+    expected = torch.randn(3, 1, 2, 2, 1)
+    dt = 1.0 / steps
+    for _ in range(steps):
+        expected = expected - dt * expected
+
+    assert torch.equal(actual, expected)
 
 
 @pytest.mark.parametrize("integrator", ["euler", "heun"])

--- a/tests/processors/test_residual_flow_matching.py
+++ b/tests/processors/test_residual_flow_matching.py
@@ -1,0 +1,169 @@
+import pytest
+import torch
+from einops import repeat
+from torch import nn
+
+from autocast.nn.noise.source import FlowSource, IIDGaussianSource, ZeroSource
+from autocast.nn.vit import TemporalViTBackbone
+from autocast.processors.residual_flow_matching import ResidualFlowMatchingProcessor
+from autocast.processors.residual_reference import LastFrameReference
+from autocast.types import EncodedBatch
+
+
+class _ZeroField(nn.Module):
+    def forward(self, z, t, cond, global_cond=None):  # noqa: ARG002
+        return torch.zeros_like(z)
+
+
+class _ScaledField(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.scale = nn.Parameter(torch.tensor(0.1))
+
+    def forward(self, z, t, cond, global_cond=None):  # noqa: ARG002
+        return self.scale * z
+
+
+def _batch(
+    *,
+    batch_size: int = 2,
+    n_steps_input: int = 1,
+    n_steps_output: int = 4,
+    spatial_size: int = 8,
+    n_channels: int = 1,
+    residual_scale: float = 0.1,
+) -> EncodedBatch:
+    inputs = torch.randn(
+        batch_size,
+        n_steps_input,
+        spatial_size,
+        spatial_size,
+        n_channels,
+    )
+    reference = repeat(
+        inputs[:, -1:],
+        "b 1 y x c -> b t y x c",
+        t=n_steps_output,
+    )
+    targets = reference + residual_scale * torch.randn_like(reference)
+    return EncodedBatch(
+        encoded_inputs=inputs,
+        encoded_output_fields=targets,
+        global_cond=torch.randn(batch_size, 2),
+        encoded_info={},
+    )
+
+
+def _processor(
+    *,
+    backbone: nn.Module | None = None,
+    source: FlowSource | None = None,
+    n_steps_output: int = 4,
+) -> ResidualFlowMatchingProcessor:
+    return ResidualFlowMatchingProcessor(
+        backbone=backbone if backbone is not None else _ZeroField(),
+        reference=LastFrameReference(n_steps_output=n_steps_output),
+        source=source,
+        n_steps_output=n_steps_output,
+        n_channels_out=1,
+    )
+
+
+def test_map_returns_reference_for_zero_source_and_field():
+    batch = _batch()
+    processor = _processor(source=ZeroSource())
+
+    prediction = processor.map(batch.encoded_inputs, batch.global_cond)
+
+    expected = repeat(
+        batch.encoded_inputs[:, -1:],
+        "b 1 y x c -> b t y x c",
+        t=4,
+    )
+    assert torch.equal(prediction, expected)
+
+
+def test_map_adds_configured_source_to_reference():
+    batch = _batch()
+    processor = _processor(source=IIDGaussianSource())
+    torch.manual_seed(7)
+
+    prediction = processor.map(batch.encoded_inputs, batch.global_cond)
+
+    torch.manual_seed(7)
+    source = torch.randn_like(batch.encoded_output_fields)
+    expected_reference = repeat(
+        batch.encoded_inputs[:, -1:],
+        "b 1 y x c -> b t y x c",
+        t=4,
+    )
+    assert torch.equal(prediction, expected_reference + source)
+
+
+def test_loss_targets_residual_instead_of_full_state():
+    batch = _batch(residual_scale=0.0)
+    processor = _processor(source=ZeroSource())
+
+    loss = processor.loss(batch)
+
+    assert loss.item() == 0.0
+
+
+def test_residual_flow_loss_has_finite_backbone_gradients():
+    batch = _batch()
+    backbone = _ScaledField()
+    processor = _processor(backbone=backbone, source=IIDGaussianSource())
+
+    loss = processor.loss(batch)
+    loss.backward()
+
+    assert torch.isfinite(loss)
+    assert backbone.scale.grad is not None
+    assert torch.isfinite(backbone.scale.grad)
+
+
+def test_reference_shape_is_validated():
+    batch = _batch()
+    processor = ResidualFlowMatchingProcessor(
+        backbone=_ZeroField(),
+        reference=LastFrameReference(n_steps_output=3),
+        source=ZeroSource(),
+        n_steps_output=4,
+        n_channels_out=1,
+    )
+
+    with pytest.raises(ValueError, match="Reference trajectory must have shape"):
+        processor.map(batch.encoded_inputs, batch.global_cond)
+
+
+def test_temporal_vit_residual_flow_shapes_and_gradients():
+    batch = _batch()
+    backbone = TemporalViTBackbone(
+        in_channels=1,
+        out_channels=1,
+        cond_channels=1,
+        n_steps_output=4,
+        n_steps_input=1,
+        global_cond_channels=2,
+        include_global_cond=True,
+        mod_features=16,
+        hid_channels=32,
+        hid_blocks=1,
+        attention_heads=4,
+        patch_size=4,
+        spatial=2,
+        dropout=0.0,
+    )
+    processor = _processor(backbone=backbone, source=IIDGaussianSource())
+
+    loss = processor.loss(batch)
+    loss.backward()
+    prediction = processor.map(batch.encoded_inputs, batch.global_cond)
+
+    assert torch.isfinite(loss)
+    assert prediction.shape == batch.encoded_output_fields.shape
+    assert all(
+        parameter.grad is not None
+        for parameter in backbone.parameters()
+        if parameter.requires_grad
+    )

--- a/tests/processors/test_residual_flow_matching.py
+++ b/tests/processors/test_residual_flow_matching.py
@@ -5,8 +5,13 @@ from torch import nn
 
 from autocast.nn.noise.source import FlowSource, IIDGaussianSource, ZeroSource
 from autocast.nn.vit import TemporalViTBackbone
+from autocast.processors.base import Processor
 from autocast.processors.residual_flow_matching import ResidualFlowMatchingProcessor
-from autocast.processors.residual_reference import LastFrameReference
+from autocast.processors.residual_normalization import ResidualStandardizer
+from autocast.processors.residual_reference import (
+    LastFrameReference,
+    ProcessorReference,
+)
 from autocast.types import EncodedBatch
 
 
@@ -22,6 +27,19 @@ class _ScaledField(nn.Module):
 
     def forward(self, z, t, cond, global_cond=None):  # noqa: ARG002
         return self.scale * z
+
+
+class _OneField(nn.Module):
+    def forward(self, z, t, cond, global_cond=None):  # noqa: ARG002
+        return torch.ones_like(z)
+
+
+class _OffsetReferenceProcessor(Processor[EncodedBatch]):
+    def map(self, x, global_cond):  # noqa: ARG002
+        return repeat(x[:, -1:] + 3.0, "b 1 y x c -> b t y x c", t=4)
+
+    def loss(self, batch):
+        raise NotImplementedError
 
 
 def _batch(
@@ -59,6 +77,7 @@ def _processor(
     backbone: nn.Module | None = None,
     source: FlowSource | None = None,
     n_steps_output: int = 4,
+    standardizer: ResidualStandardizer | None = None,
 ) -> ResidualFlowMatchingProcessor:
     return ResidualFlowMatchingProcessor(
         backbone=backbone if backbone is not None else _ZeroField(),
@@ -66,6 +85,7 @@ def _processor(
         source=source,
         n_steps_output=n_steps_output,
         n_channels_out=1,
+        standardizer=standardizer,
     )
 
 
@@ -100,6 +120,57 @@ def test_map_adds_configured_source_to_reference():
     assert torch.equal(prediction, expected_reference + source)
 
 
+def test_map_denormalizes_generated_residual_before_adding_reference():
+    batch = _batch()
+    standardizer = ResidualStandardizer(
+        n_steps_output=4,
+        n_channels=1,
+        mean=0.25,
+        scale=2.0,
+    )
+    processor = _processor(
+        backbone=_OneField(),
+        source=ZeroSource(),
+        standardizer=standardizer,
+    )
+
+    prediction = processor.map(batch.encoded_inputs, batch.global_cond)
+
+    expected_reference = repeat(
+        batch.encoded_inputs[:, -1:],
+        "b 1 y x c -> b t y x c",
+        t=4,
+    )
+    assert torch.equal(prediction, expected_reference + 2.25)
+
+
+def test_processor_reference_is_not_residual_standardized():
+    batch = _batch()
+    standardizer = ResidualStandardizer(
+        n_steps_output=4,
+        n_channels=1,
+        mean=0.25,
+        scale=2.0,
+    )
+    processor = ResidualFlowMatchingProcessor(
+        backbone=_ZeroField(),
+        reference=ProcessorReference(_OffsetReferenceProcessor()),
+        source=ZeroSource(),
+        n_steps_output=4,
+        n_channels_out=1,
+        standardizer=standardizer,
+    )
+
+    prediction = processor.map(batch.encoded_inputs, batch.global_cond)
+
+    expected_reference = repeat(
+        batch.encoded_inputs[:, -1:] + 3.0,
+        "b 1 y x c -> b t y x c",
+        t=4,
+    )
+    assert torch.equal(prediction, expected_reference + 0.25)
+
+
 def test_loss_targets_residual_instead_of_full_state():
     batch = _batch(residual_scale=0.0)
     processor = _processor(source=ZeroSource())
@@ -107,6 +178,26 @@ def test_loss_targets_residual_instead_of_full_state():
     loss = processor.loss(batch)
 
     assert loss.item() == 0.0
+
+
+def test_loss_targets_standardized_residual():
+    batch = _batch(residual_scale=0.0)
+    batch.encoded_output_fields = repeat(
+        batch.encoded_inputs[:, -1:],
+        "b 1 y x c -> b t y x c",
+        t=4,
+    ) + 5.0
+    standardizer = ResidualStandardizer(
+        n_steps_output=4,
+        n_channels=1,
+        mean=1.0,
+        scale=2.0,
+    )
+    processor = _processor(source=ZeroSource(), standardizer=standardizer)
+
+    loss = processor.loss(batch)
+
+    assert loss.item() == pytest.approx(4.0)
 
 
 def test_residual_flow_loss_has_finite_backbone_gradients():
@@ -134,6 +225,18 @@ def test_reference_shape_is_validated():
 
     with pytest.raises(ValueError, match="Reference trajectory must have shape"):
         processor.map(batch.encoded_inputs, batch.global_cond)
+
+
+def test_standardizer_dimensions_are_validated():
+    standardizer = ResidualStandardizer(
+        n_steps_output=3,
+        n_channels=1,
+        mean=0.0,
+        scale=1.0,
+    )
+
+    with pytest.raises(ValueError, match="must match the processor"):
+        _processor(standardizer=standardizer)
 
 
 def test_temporal_vit_residual_flow_shapes_and_gradients():

--- a/tests/processors/test_residual_flow_matching.py
+++ b/tests/processors/test_residual_flow_matching.py
@@ -171,6 +171,21 @@ def test_processor_reference_is_not_residual_standardized():
     assert torch.equal(prediction, expected_reference + 0.25)
 
 
+def test_processor_reference_defines_training_residual():
+    batch = _batch(residual_scale=0.0)
+    processor = ResidualFlowMatchingProcessor(
+        backbone=_ZeroField(),
+        reference=ProcessorReference(_OffsetReferenceProcessor()),
+        source=ZeroSource(),
+        n_steps_output=4,
+        n_channels_out=1,
+    )
+
+    loss = processor.loss(batch)
+
+    assert loss.item() == pytest.approx(9.0)
+
+
 def test_loss_targets_residual_instead_of_full_state():
     batch = _batch(residual_scale=0.0)
     processor = _processor(source=ZeroSource())

--- a/tests/processors/test_residual_normalization.py
+++ b/tests/processors/test_residual_normalization.py
@@ -1,0 +1,104 @@
+import pytest
+import torch
+
+from autocast.processors.residual_normalization import ResidualStandardizer
+
+
+def test_channel_statistics_broadcast_and_round_trip():
+    standardizer = ResidualStandardizer(
+        n_steps_output=3,
+        n_channels=2,
+        granularity="channel",
+        mean=(1.0, -2.0),
+        scale=(2.0, 4.0),
+    )
+    standardized = torch.full((2, 3, 4, 5, 2), 3.0)
+    residual = standardizer.unstandardize(standardized)
+
+    assert torch.equal(residual[..., 0], torch.full((2, 3, 4, 5), 7.0))
+    assert torch.equal(residual[..., 1], torch.full((2, 3, 4, 5), 10.0))
+    assert torch.equal(standardizer.standardize(residual), standardized)
+
+
+def test_lead_channel_statistics_broadcast_and_round_trip():
+    standardizer = ResidualStandardizer(
+        n_steps_output=3,
+        n_channels=1,
+        granularity="lead_channel",
+        mean=((1.0,), (2.0,), (3.0,)),
+        scale=((0.5,), (1.0,), (2.0,)),
+    )
+    standardized = torch.ones(2, 3, 4, 5, 1)
+    residual = standardizer.unstandardize(standardized)
+
+    expected = torch.tensor((1.5, 3.0, 5.0)).view(1, 3, 1, 1, 1)
+    assert torch.equal(residual, expected.expand_as(residual))
+    assert torch.equal(standardizer.standardize(residual), standardized)
+
+
+def test_unfitted_standardizer_fails_before_use():
+    standardizer = ResidualStandardizer(n_steps_output=4, n_channels=1)
+
+    with pytest.raises(RuntimeError, match="must be fitted"):
+        standardizer.standardize(torch.empty(2, 4, 1, 1, 1))
+
+
+def test_set_statistics_floors_zero_scale_and_persists_state():
+    standardizer = ResidualStandardizer(
+        n_steps_output=2,
+        n_channels=1,
+        epsilon=1e-4,
+    )
+    standardizer.set_statistics(mean=((1.0,), (2.0,)), scale=((0.0,), (3.0,)))
+    restored = ResidualStandardizer(n_steps_output=2, n_channels=1)
+    restored.load_state_dict(standardizer.state_dict())
+
+    assert restored.fitted
+    assert restored.scale[0, 0] == pytest.approx(1e-4)
+    assert torch.equal(restored.mean, standardizer.mean)
+    assert torch.equal(restored.scale, standardizer.scale)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"granularity": "space"}, "granularity"),
+        ({"mean": 0.0}, "both be provided"),
+        ({"scale": 1.0}, "both be provided"),
+        ({"epsilon": 0.0}, "epsilon"),
+    ],
+)
+def test_standardizer_configuration_is_validated(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        ResidualStandardizer(n_steps_output=4, n_channels=1, **kwargs)
+
+
+def test_statistic_shape_is_validated():
+    with pytest.raises(ValueError, match=r"shape \(4, 2\)"):
+        ResidualStandardizer(
+            n_steps_output=4,
+            n_channels=2,
+            mean=(0.0, 0.0),
+            scale=(1.0, 1.0),
+        )
+
+
+def test_residual_shape_is_validated():
+    standardizer = ResidualStandardizer(
+        n_steps_output=4,
+        n_channels=1,
+        mean=0.0,
+        scale=1.0,
+    )
+
+    with pytest.raises(ValueError, match="expected T=4, C=1"):
+        standardizer.standardize(torch.empty(2, 3, 1, 1, 1))
+
+
+def test_negative_or_nonfinite_statistics_are_rejected():
+    standardizer = ResidualStandardizer(n_steps_output=2, n_channels=1)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        standardizer.set_statistics(mean=0.0, scale=-1.0)
+    with pytest.raises(ValueError, match="finite"):
+        standardizer.set_statistics(mean=float("nan"), scale=1.0)

--- a/tests/processors/test_residual_reference.py
+++ b/tests/processors/test_residual_reference.py
@@ -1,0 +1,78 @@
+import pytest
+import torch
+from einops import repeat
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.processors.residual_reference import (
+    LastFrameReference,
+    ProcessorReference,
+)
+from autocast.types import EncodedBatch, Tensor
+
+
+class _RecordingProcessor(Processor[EncodedBatch]):
+    def __init__(self, n_steps_output: int = 3) -> None:
+        super().__init__()
+        self.n_steps_output = n_steps_output
+        self.scale = nn.Parameter(torch.tensor(2.0))
+        self.received_global_cond: Tensor | None = None
+
+    def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        self.received_global_cond = global_cond
+        return repeat(
+            self.scale * x[:, -1:],
+            "b 1 ... c -> b t ... c",
+            t=self.n_steps_output,
+        )
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        raise NotImplementedError
+
+
+def test_last_frame_reference_repeats_selected_channels():
+    x = torch.arange(2 * 3 * 4 * 5 * 2).reshape(2, 3, 4, 5, 2)
+    reference = LastFrameReference(n_steps_output=4, channel_indices=(1,))
+
+    actual = reference(x)
+
+    expected = repeat(x[:, -1:, ..., 1:2], "b 1 ... c -> b t ... c", t=4)
+    assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"n_steps_output": 0}, "must be positive"),
+        ({"n_steps_output": 1, "channel_indices": ()}, "cannot be empty"),
+    ],
+)
+def test_last_frame_reference_validates_configuration(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        LastFrameReference(**kwargs)
+
+
+def test_frozen_processor_reference_passes_conditioning_without_gradients():
+    processor = _RecordingProcessor()
+    reference = ProcessorReference(processor)
+    reference.train()
+    x = torch.randn(2, 1, 4, 4, 1, requires_grad=True)
+    global_cond = torch.randn(2, 2)
+
+    output = reference(x, global_cond)
+
+    assert processor.received_global_cond is global_cond
+    assert not processor.training
+    assert not processor.scale.requires_grad
+    assert not output.requires_grad
+
+
+def test_trainable_processor_reference_preserves_gradients():
+    processor = _RecordingProcessor()
+    reference = ProcessorReference(processor, frozen=False)
+    x = torch.randn(2, 1, 4, 4, 1, requires_grad=True)
+
+    reference(x).sum().backward()
+
+    assert processor.scale.grad is not None
+    assert x.grad is not None

--- a/tests/scripts/test_config_integration.py
+++ b/tests/scripts/test_config_integration.py
@@ -107,6 +107,32 @@ def test_processor_configs_exist(processor_configs: list[str]):
     assert "flow_matching" in processor_configs or "fno" in processor_configs
 
 
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [
+        ("iid_gaussian", "IIDGaussianSource"),
+        ("temporal_ou", "TemporalOUSource"),
+        ("separable_gaussian", "SeparableGaussianSource"),
+    ],
+)
+def test_residual_flow_source_configs_compose(
+    config_dir: str,
+    source: str,
+    target: str,
+):
+    cfg = _load_config(
+        config_dir,
+        "model/processor",
+        overrides=[
+            "processor@model.processor=residual_flow_matching_vit",
+            f"flow_source@model.processor.source={source}",
+        ],
+    )
+
+    assert cfg.model.processor._target_.endswith("ResidualFlowMatchingProcessor")
+    assert cfg.model.processor.source._target_.endswith(target)
+
+
 # --- Tests using real configs ---
 
 

--- a/tests/scripts/test_config_integration.py
+++ b/tests/scripts/test_config_integration.py
@@ -131,6 +131,8 @@ def test_residual_flow_source_configs_compose(
 
     assert cfg.model.processor._target_.endswith("ResidualFlowMatchingProcessor")
     assert cfg.model.processor.source._target_.endswith(target)
+    if source == "separable_gaussian":
+        assert cfg.model.processor.source.spatial_boundaries == "periodic"
 
 
 # --- Tests using real configs ---

--- a/tests/scripts/test_setup.py
+++ b/tests/scripts/test_setup.py
@@ -131,6 +131,33 @@ def test_apply_processor_defaults_to_backbone():
     assert cfg["backbone"]["cond_channels"] == 8  # in_channels for backbone
 
 
+def test_apply_processor_defaults_to_residual_components():
+    cfg = OmegaConf.create(
+        {
+            "n_steps_output": "auto",
+            "n_channels_out": "auto",
+            "reference": {"n_steps_output": "auto"},
+            "standardizer": {
+                "n_steps_output": "auto",
+                "n_channels": "auto",
+            },
+        }
+    )
+
+    _apply_processor_channel_defaults(
+        cfg,
+        in_channels=2,
+        out_channels=3,
+        n_steps_input=1,
+        n_steps_output=8,
+        n_channels_out=3,
+    )
+
+    assert cfg.reference.n_steps_output == 8
+    assert cfg.standardizer.n_steps_output == 8
+    assert cfg.standardizer.n_channels == 3
+
+
 def test_apply_processor_handles_none_config():
     # Should not raise
     _apply_processor_channel_defaults(

--- a/tests/scripts/test_training.py
+++ b/tests/scripts/test_training.py
@@ -12,14 +12,19 @@ import torch
 from conftest import get_optimizer_config
 from hydra import compose, initialize_config_dir
 from hydra.utils import instantiate
-from lightning.pytorch.callbacks import ModelCheckpoint, Timer
+from lightning.pytorch.callbacks import Callback, ModelCheckpoint, Timer
 from matplotlib import pyplot as plt
 from omegaconf import DictConfig, OmegaConf, open_dict
+from torch.utils.data import DataLoader, Dataset
 from torchmetrics import Metric, MetricCollection
 
 from autocast.callbacks.checkpoint import ProgressModelCheckpoint
 from autocast.callbacks.metrics import ValidationMetricPlotCallback
+from autocast.callbacks.residual_statistics import ResidualStatisticsCallback
+from autocast.data.datamodule import SpatioTemporalDataModule
 from autocast.encoders.base import EncoderWithCond
+from autocast.nn.noise.source import TemporalOUSource
+from autocast.processors.residual_flow_matching import ResidualFlowMatchingProcessor
 from autocast.scripts.setup import (
     _infer_latent_spatial_resolution,
     setup_autoencoder_model,
@@ -30,6 +35,7 @@ from autocast.scripts.training import (
     ResetResumeTimerCallback,
     TrainingTimerCallback,
     _attach_reset_timer_callback,
+    _ensure_residual_statistics_callback,
     _validate_resume_settings,
 )
 from autocast.types import Batch, EncodedBatch
@@ -73,6 +79,38 @@ def _stats_from_encoded_batch(batch: EncodedBatch) -> dict:
         "output_shape": batch.encoded_output_fields.shape,
         "example_batch": batch,
     }
+
+
+def _first_encoded_batch(batches: list[EncodedBatch]) -> EncodedBatch:
+    return batches[0]
+
+
+class _EncodedDataset(Dataset[EncodedBatch]):
+    def __init__(self, batch: EncodedBatch) -> None:
+        self.batch = batch
+
+    def __len__(self) -> int:
+        return 1
+
+    def __getitem__(self, index: int) -> EncodedBatch:
+        return self.batch
+
+
+class _EncodedDataModule(L.LightningDataModule):
+    def __init__(self, batch: EncodedBatch) -> None:
+        super().__init__()
+        self.train_dataset = _EncodedDataset(batch)
+
+    def train_dataloader(self):
+        return DataLoader(
+            self.train_dataset,
+            batch_size=1,
+            collate_fn=_first_encoded_batch,
+            num_workers=0,
+        )
+
+    def val_dataloader(self):
+        return self.train_dataloader()
 
 
 def test_autoencoder_config_trainer_fit_smoke(
@@ -255,6 +293,100 @@ def test_processor_config_training_step_smoke(config_dir: str, dummy_datamodule)
     loss = model.training_step(batch, batch_idx=0)
     assert torch.is_tensor(loss)
     assert loss.ndim == 0
+
+
+def test_residual_flow_config_fits_and_restores_statistics(
+    config_dir: str,
+    tmp_path: Path,
+):
+    model_cfg = _load_config(
+        config_dir,
+        "model/processor",
+        overrides=[
+            "processor@model.processor=residual_flow_matching_vit",
+            "flow_source@model.processor.source=temporal_ou",
+        ],
+    )
+    with open_dict(model_cfg):
+        processor_cfg = model_cfg.model.processor
+        processor_cfg.flow_ode_steps = 1
+        processor_cfg.backbone.include_global_cond = False
+        processor_cfg.backbone.global_cond_channels = 0
+        processor_cfg.backbone.mod_features = 8
+        processor_cfg.backbone.hid_channels = 16
+        processor_cfg.backbone.hid_blocks = 1
+        processor_cfg.backbone.attention_heads = 2
+        model_cfg.optimizer = get_optimizer_config(learning_rate=1e-3)
+        model_cfg.datamodule = {
+            "stride": 1,
+            "n_steps_input": 1,
+            "n_steps_output": 3,
+        }
+
+    inputs = torch.randn(2, 1, 4, 4, 1)
+    residual = torch.randn(2, 3, 4, 4, 1)
+    targets = inputs[:, -1:].expand(-1, 3, -1, -1, -1) + residual
+    batch = EncodedBatch(
+        encoded_inputs=inputs,
+        encoded_output_fields=targets,
+        global_cond=None,
+        encoded_info={},
+    )
+    datamodule = _EncodedDataModule(batch)
+    setup_datamodule = cast(SpatioTemporalDataModule, datamodule)
+    model = setup_processor_model(
+        model_cfg,
+        _stats_from_encoded_batch(batch),
+        setup_datamodule,
+    )
+    callbacks: list = [Callback()]
+    callbacks = _ensure_residual_statistics_callback(callbacks, model)
+
+    assert isinstance(model.processor, ResidualFlowMatchingProcessor)
+    assert isinstance(model.processor.source, TemporalOUSource)
+    assert isinstance(callbacks[0], ResidualStatisticsCallback)
+    assert len(callbacks) == 2
+
+    trainer = L.Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_steps=1,
+        limit_val_batches=0,
+        num_sanity_val_steps=0,
+        callbacks=callbacks,
+        logger=False,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+    )
+    trainer.fit(model, datamodule=datamodule)
+
+    standardizer = model.processor.standardizer
+    assert standardizer is not None
+    expected_scale, expected_mean = torch.std_mean(
+        residual.movedim(1, 0).reshape(3, -1, 1),
+        dim=1,
+        correction=0,
+    )
+    assert standardizer.fitted
+    assert torch.allclose(standardizer.mean, expected_mean)
+    assert torch.allclose(standardizer.scale, expected_scale)
+
+    checkpoint = tmp_path / "residual.ckpt"
+    trainer.save_checkpoint(checkpoint)
+    restored = setup_processor_model(
+        model_cfg,
+        _stats_from_encoded_batch(batch),
+        setup_datamodule,
+    )
+    payload = torch.load(checkpoint, map_location="cpu", weights_only=False)
+    restored.load_state_dict(payload["state_dict"])
+    assert isinstance(restored.processor, ResidualFlowMatchingProcessor)
+    restored_standardizer = restored.processor.standardizer
+    assert restored_standardizer is not None
+    assert restored_standardizer.fitted
+    assert torch.equal(restored_standardizer.mean, standardizer.mean)
+    assert torch.equal(restored_standardizer.scale, standardizer.scale)
 
 
 def test_masked_window_flow_matching_config_smoke(config_dir: str, dummy_datamodule):


### PR DESCRIPTION
## Summary

This PR adds support for residual flow matching from alternative source distributions:
- Adds configurable reference trajectories and flow source distributions.
- Learns standardized residuals around a reference forecast.
- Supports IID, temporal OU, and separable spatial-temporal Gaussian sources.
- Fits residual statistics from the training split.
- Preserves the existing flow matching behaviour by default.
- Adds Hydra configuration and focused tests.