### PR TITLE
Add normalizing-flow, distilled and consistency processors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,11 @@ docs = [
     "sphinx-copybutton>=0.5.2",
     "sphinx-autodoc-typehints>=1.24.0",
 ]
+# Optional zuko-backed normalizing-flow processor; the package imports without
+# zuko and only errors if such a processor is instantiated.
+flows = [
+    "zuko>=1.6.0",
+]
 
 [project.scripts]
 autocast = "autocast.scripts.workflow:main"

--- a/src/autocast/configs/processor/consistency.yaml
+++ b/src/autocast/configs/processor/consistency.yaml
@@ -1,0 +1,22 @@
+_target_: autocast.processors.consistency.ConsistencyDistilledProcessor
+# Output field dims are auto-filled from the datamodule by scripts/setup.py.
+n_steps_output: null
+n_channels_out: null
+# Conditioning field dims + spatial shape are set per toy in the experiment
+# config. The teacher is injected at train time (cal_study/distill_student.py),
+# not configured here, so the saved student checkpoint stands alone.
+n_steps_input: 1
+n_channels_in: 1
+spatial_shape: [1, 1]
+global_cond_features: 0
+# Student capacity (set per toy by field size). The predictive spread is not a
+# hyperparameter here: it emerges from imposing self-consistency over the
+# teacher's probability-flow ODE.
+hidden_features: [256, 256]
+# Number of equal time sub-intervals on [0, 1]; the consistency small step is 1/N.
+n_consistency_steps: 18
+# Fourier time-embedding frequencies (sin/cos pairs) added to the network input.
+n_time_frequencies: 6
+# Tilt the step sampling toward the noise boundary (the deployed t=0 slice) so the
+# one-pass draw is well-supervised; 1.0 = uniform, larger concentrates near t=0.
+boundary_bias: 2.0

--- a/src/autocast/configs/processor/distilled.yaml
+++ b/src/autocast/configs/processor/distilled.yaml
@@ -1,0 +1,14 @@
+_target_: autocast.processors.distilled.DistilledProcessor
+# Output field dims are auto-filled from the datamodule by scripts/setup.py.
+n_steps_output: null
+n_channels_out: null
+# Conditioning field dims + spatial shape are set per toy in the experiment
+# config. The teacher is injected at train time (cal_study/distill_student.py),
+# not configured here, so the saved student checkpoint stands alone.
+n_steps_input: 1
+n_channels_in: 1
+spatial_shape: [1, 1]
+global_cond_features: 0
+# Student capacity (set per toy by field size). The predictive spread is not a
+# hyperparameter here: it is learned from the teacher's noise->sample map.
+hidden_features: [256, 256]

--- a/src/autocast/configs/processor/normalizing_flow.yaml
+++ b/src/autocast/configs/processor/normalizing_flow.yaml
@@ -1,0 +1,14 @@
+_target_: autocast.processors.normalizing_flow.NormalizingFlowProcessor
+# Output field dims are auto-filled from the datamodule by scripts/setup.py.
+n_steps_output: null
+n_channels_out: null
+# Conditioning field dims + spatial shape are set per toy in the experiment
+# config (no backbone is mounted; the flow builds its own conditioner networks).
+n_steps_input: 1
+n_channels_in: 1
+spatial_shape: [1, 1]
+global_cond_features: 0
+# Flow family: coupling (one-forward) = realnvp/nice/ncsf; autoregressive = maf/nsf.
+flow_type: nsf
+transforms: 4
+hidden_features: [128, 128]

--- a/src/autocast/processors/__init__.py
+++ b/src/autocast/processors/__init__.py
@@ -1,6 +1,10 @@
+from typing import TYPE_CHECKING
+
 from autocast.processors.azula_vit import AzulaViTProcessor
 from autocast.processors.base import Processor
+from autocast.processors.consistency import ConsistencyDistilledProcessor
 from autocast.processors.conv_coupling import ConvCouplingFlowProcessor
+from autocast.processors.distilled import DistilledProcessor
 from autocast.processors.flow_matching import FlowMatchingProcessor
 from autocast.processors.flow_matching_masked_window import (
     FlowMatchingMaskedWindowProcessor,
@@ -10,11 +14,38 @@ from autocast.processors.swin_vit import SwinViTProcessor
 from autocast.processors.tarflow import TarFlowProcessor
 from autocast.processors.unet import UNetProcessor
 
+# NormalizingFlowProcessor depends on the optional ``zuko`` package. Import it
+# lazily so the processors package stays importable when zuko is not installed;
+# instantiating the processor without zuko then raises a clear ImportError.
+if TYPE_CHECKING:
+    from autocast.processors.normalizing_flow import NormalizingFlowProcessor
+else:
+    try:
+        from autocast.processors.normalizing_flow import NormalizingFlowProcessor
+    except ImportError as exc:
+        # The ``as`` target is cleared at the end of the except block, so bind
+        # the error to a name that survives for the placeholder to chain from.
+        _zuko_import_error = exc
+
+        class NormalizingFlowProcessor:
+            """Placeholder when the optional ``zuko`` dependency is unavailable."""
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                msg = (
+                    "NormalizingFlowProcessor requires the optional 'zuko' "
+                    "package; install zuko to use normalizing-flow processors."
+                )
+                raise ImportError(msg) from _zuko_import_error
+
+
 __all__ = [
     "AzulaViTProcessor",
+    "ConsistencyDistilledProcessor",
     "ConvCouplingFlowProcessor",
+    "DistilledProcessor",
     "FlowMatchingMaskedWindowProcessor",
     "FlowMatchingProcessor",
+    "NormalizingFlowProcessor",
     "Processor",
     "SigmaVAEProcessor",
     "SwinViTProcessor",

--- a/src/autocast/processors/consistency.py
+++ b/src/autocast/processors/consistency.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Protocol, cast
+
+import torch
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.types import EncodedBatch, Tensor
+
+
+class _FlowTeacher(Protocol):
+    """The flow-matching teacher interface the consistency student consumes."""
+
+    def flow_field(
+        self, z: Tensor, t: Tensor, x: Tensor, global_cond: Tensor | None
+    ) -> Tensor: ...
+
+
+def _mlp(in_features: int, out_features: int, hidden: Sequence[int]) -> nn.Sequential:
+    layers: list[nn.Module] = []
+    prev = in_features
+    for h in hidden:
+        layers += [nn.Linear(prev, h), nn.SiLU()]
+        prev = h
+    layers.append(nn.Linear(prev, out_features))
+    return nn.Sequential(*layers)
+
+
+class ConsistencyDistilledProcessor(Processor):
+    r"""Small-step consistency-distilled student of a flow-matching teacher.
+
+    The sibling of :class:`DistilledProcessor`. Where the one-pass distilled
+    student regresses directly onto the teacher's *full* noise-to-data endpoint
+    (``g(z, x) -> ODE_teacher(z | x)``), this student imposes the **self-consistency**
+    property of consistency models [Song et al. 2023] over the teacher's
+    probability-flow ODE: a single time-conditioned map ``f(z, t | x)`` is trained
+    so that any two points on the *same* teacher trajectory map to the same
+    data endpoint, learned one *small step* at a time rather than from the whole
+    integrated trajectory.
+
+    Concretely, with the conditional flow-matching path running from ``t = 0``
+    (Gaussian noise) to ``t = 1`` (data) and the teacher velocity ``v(z, t | x)``:
+
+      * a forward-marginal point ``z_t = (1 - t) z_0 + t y`` is sampled at a random
+        grid time ``t_n`` (``y`` the true next state, ``z_0`` fresh noise);
+      * the teacher takes ONE Euler step toward the data,
+        ``ẑ_{t_{n+1}} = z_t + (t_{n+1} - t_n)\, v(z_t, t_n | x)``;
+      * the student is trained to be consistent across that small step,
+        ``f(z_t, t_n | x) \approx \mathrm{stopgrad}\, f(ẑ_{t_{n+1}}, t_{n+1} | x)``.
+
+    The target is the SAME network evaluated at the adjacent, closer-to-data time
+    with the gradient blocked (the modern no-EMA-target variant; the teacher, not an
+    EMA copy, supplies the one solver step that makes the closer-to-data point more
+    accurate). The map is parameterised as ``f(z, t | x) = z + (1 - t) F(z, t | x)``
+    so the boundary condition ``f(z, 1 | x) = z`` (identity at the data end) holds by
+    construction; ``F`` is a time-conditioned network.
+
+    Inference (:meth:`map`) is a single network pass per member — draw ``z_0`` and
+    return ``f(z_0, 0 | x)`` — so, like the one-pass distilled student, this is a
+    cheap one-forward-pass generator, but trained by self-consistency over small
+    steps rather than by whole-trajectory endpoint matching. The teacher is
+    *injected* (:meth:`set_teacher`) for training only and is not a submodule, so
+    it never enters the student checkpoint. Operates on the flattened field.
+    """
+
+    def __init__(
+        self,
+        *,
+        n_steps_input: int = 1,
+        n_steps_output: int = 1,
+        n_channels_in: int = 1,
+        n_channels_out: int = 1,
+        spatial_shape: Sequence[int] = (1, 1),
+        global_cond_features: int = 0,
+        hidden_features: Sequence[int] = (256, 256),
+        n_consistency_steps: int = 18,
+        n_time_frequencies: int = 6,
+        boundary_bias: float = 2.0,
+    ) -> None:
+        super().__init__()
+        self.n_steps_input = int(n_steps_input)
+        self.n_steps_output = int(n_steps_output)
+        self.n_channels_in = int(n_channels_in)
+        self.n_channels_out = int(n_channels_out)
+        self.spatial_shape = tuple(int(s) for s in spatial_shape)
+        self.global_cond_features = int(global_cond_features)
+        # Number of equal time sub-intervals on [0, 1]; the small step is 1/N. A
+        # finer grid lowers the per-step discretisation error of the consistency
+        # target at the cost of a smaller learning signal per step.
+        self.n_consistency_steps = int(n_consistency_steps)
+        self.n_time_frequencies = int(n_time_frequencies)
+        # Sampling tilt toward the noise boundary (the deployed t=0 slice); 1.0 =
+        # uniform over steps, larger concentrates supervision near t=0.
+        self.boundary_bias = float(boundary_bias)
+
+        spatial = int(math.prod(self.spatial_shape)) if self.spatial_shape else 1
+        self.spatial = spatial
+        self.features = self.n_steps_output * spatial * self.n_channels_out
+        self.context = (
+            self.n_steps_input * spatial * self.n_channels_in
+            + self.global_cond_features
+        )
+        # Time conditioning: t itself plus sin/cos Fourier features at geometric
+        # frequencies, concatenated to the flattened state + context.
+        self.n_time_features = 1 + 2 * self.n_time_frequencies
+        self.net = _mlp(
+            self.features + self.context + self.n_time_features,
+            self.features,
+            tuple(int(h) for h in hidden_features),
+        )
+        # Teacher injected for training only (not a submodule -> excluded from the
+        # checkpoint, so scoring loads the student alone).
+        self._teacher: list[_FlowTeacher] = []
+
+    def set_teacher(self, teacher: Processor) -> None:
+        """Attach a frozen flow-matching teacher for consistency distillation."""
+        if not callable(getattr(teacher, "flow_field", None)):
+            msg = (
+                "ConsistencyDistilledProcessor requires a flow-matching-capable "
+                "teacher exposing a flow_field(z, t, x, global_cond) method; got "
+                f"{type(teacher).__name__}."
+            )
+            raise TypeError(msg)
+        teacher.eval()
+        for p in teacher.parameters():
+            p.requires_grad_(False)
+        self._teacher = [cast(_FlowTeacher, teacher)]
+
+    # -- layout helpers -------------------------------------------------------
+    def _context(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        ctx = x.reshape(x.shape[0], -1)
+        if global_cond is not None and self.global_cond_features > 0:
+            ctx = torch.cat(
+                [ctx, global_cond.reshape(global_cond.shape[0], -1)], dim=-1
+            )
+        return ctx
+
+    def _z_shape(self, b: int) -> tuple[int, ...]:
+        return (b, self.n_steps_output, *self.spatial_shape, self.n_channels_out)
+
+    def _time_features(self, t: Tensor) -> Tensor:
+        """Sin/cos Fourier features of t (shape (B,)) -> (B, n_time_features)."""
+        feats = [t.unsqueeze(-1)]
+        for k in range(self.n_time_frequencies):
+            w = math.pi * (2.0**k)
+            feats += [torch.sin(w * t).unsqueeze(-1), torch.cos(w * t).unsqueeze(-1)]
+        return torch.cat(feats, dim=-1)
+
+    @staticmethod
+    def _bcast(t: Tensor, ref: Tensor) -> Tensor:
+        """Reshape a per-sample time (B,) to broadcast against a field tensor ref."""
+        return t.reshape(t.shape[0], *([1] * (ref.ndim - 1)))
+
+    def _consistency_map(self, z: Tensor, t: Tensor, ctx: Tensor) -> Tensor:
+        """Boundary-correct consistency map f(z, t | x) = z + (1 - t) F(z, t | x).
+
+        z is a field (B, T_out, *spatial, C_out); t is (B,); ctx is the flattened
+        conditioning. At t = 1 this returns z exactly (the data-end identity).
+        """
+        z_flat = z.reshape(z.shape[0], -1)
+        inp = torch.cat([z_flat, ctx, self._time_features(t)], dim=-1)
+        f = self.net(inp).reshape(self._z_shape(z.shape[0]))
+        return z + (1.0 - self._bcast(t, z)) * f
+
+    # -- Processor API --------------------------------------------------------
+    def forward(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        return self.map(x, global_cond)
+
+    def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Draw one member in a single pass: f(z, 0 | x), z ~ N(0, I)."""
+        ctx = self._context(x, global_cond)
+        z = torch.randn(self._z_shape(x.shape[0]), device=x.device, dtype=x.dtype)
+        t0 = torch.zeros(x.shape[0], device=x.device, dtype=x.dtype)
+        return self._consistency_map(z, t0, ctx)
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        """Consistency-distillation loss over one small teacher ODE step."""
+        if not self._teacher:
+            msg = (
+                "ConsistencyDistilledProcessor.loss requires a teacher; call "
+                "set_teacher(...) before training."
+            )
+            raise RuntimeError(msg)
+        teacher = self._teacher[0]
+        x = batch.encoded_inputs
+        y = batch.encoded_output_fields
+        gc = batch.global_cond
+        ctx = self._context(x, gc)
+        b = x.shape[0]
+        device, dtype = x.device, x.dtype
+
+        # Grid step n in {0, ..., N-1}: t_n -> t_{n+1} = t_n + 1/N, one small step
+        # toward the data end (t = 1). The noise-boundary slice (small n, t ~ 0) is
+        # the one the one-pass inference draw f(z0, 0 | x) actually reads, yet under
+        # uniform sampling it is the rarest and hardest to learn — which leaves the
+        # deployed spread under-supervised and over-dispersed. `boundary_bias` >= 1
+        # tilts the sampling toward small n (u**bias concentrates a uniform draw
+        # near 0; bias = 1 recovers uniform), supervising the deployed slice more.
+        n_steps = self.n_consistency_steps
+        u = torch.rand(b, device=device)
+        n = (u.pow(self.boundary_bias) * n_steps).long().clamp_(max=n_steps - 1)
+        tn = (n.to(dtype)) / n_steps
+        tnp1 = (n.to(dtype) + 1.0) / n_steps
+
+        # Forward-marginal point at t_n on the conditional straight-line path.
+        z0 = torch.randn_like(y)
+        zt = (1.0 - self._bcast(tn, y)) * z0 + self._bcast(tn, y) * y
+
+        # One teacher Euler step toward the data (t_n -> t_{n+1}).
+        with torch.no_grad():
+            v = teacher.flow_field(zt, tn, x, gc)
+            zt_next = zt + self._bcast(tnp1 - tn, zt) * v
+
+        # Self-consistency: the noisier point (with grad) matches the closer-to-data
+        # point (stop-grad), which the teacher step made more accurate.
+        pred = self._consistency_map(zt, tn, ctx)
+        with torch.no_grad():
+            target = self._consistency_map(zt_next, tnp1, ctx)
+        return torch.mean((pred - target) ** 2)

--- a/src/autocast/processors/distilled.py
+++ b/src/autocast/processors/distilled.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Protocol, cast
+
+import torch
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.types import EncodedBatch, Tensor
+
+
+class _FlowTeacher(Protocol):
+    """The flow-matching teacher interface the distilled student consumes."""
+
+    flow_ode_steps: int
+
+    def flow_field(
+        self, z: Tensor, t: Tensor, x: Tensor, global_cond: Tensor | None
+    ) -> Tensor: ...
+
+
+def _mlp(in_features: int, out_features: int, hidden: Sequence[int]) -> nn.Sequential:
+    layers: list[nn.Module] = []
+    prev = in_features
+    for h in hidden:
+        layers += [nn.Linear(prev, h), nn.SiLU()]
+        prev = h
+    layers.append(nn.Linear(prev, out_features))
+    return nn.Sequential(*layers)
+
+
+class DistilledProcessor(Processor):
+    """One-pass student that *sample-matches* a flow-matching teacher.
+
+    The student is a deterministic map ``g(z, x_t)`` from an input noise draw
+    ``z`` (the same shape as the teacher's latent noise) and the current state
+    ``x_t`` to a next-state sample. It is trained by **noise-paired**
+    distillation: for each ``z`` the teacher's ODE is integrated from that exact
+    ``z`` to its endpoint, and the student regresses to it. Because the teacher's
+    flow is a deterministic, invertible transport, matching the noise->sample map
+    pointwise reproduces the teacher's *whole* predictive distribution — the
+    spread is inherited per toy, not set by a fixed noise hyperparameter. This is
+    sample-matching, never endpoint/mean-matching (which would collapse to a
+    deterministic forecaster with zero spread).
+
+    Inference (:meth:`map`) is a single network pass per ensemble member, so the
+    student is the cheap "can we keep the teacher's UQ at one-pass cost?" arm.
+    The teacher is *injected* (:meth:`set_teacher`) only for training and is not
+    a submodule, so it never enters the student checkpoint and inference needs no
+    teacher. Operates on the flattened field, so it applies to every toy.
+    """
+
+    def __init__(
+        self,
+        *,
+        n_steps_input: int = 1,
+        n_steps_output: int = 1,
+        n_channels_in: int = 1,
+        n_channels_out: int = 1,
+        spatial_shape: Sequence[int] = (1, 1),
+        global_cond_features: int = 0,
+        hidden_features: Sequence[int] = (256, 256),
+    ) -> None:
+        super().__init__()
+        self.n_steps_input = int(n_steps_input)
+        self.n_steps_output = int(n_steps_output)
+        self.n_channels_in = int(n_channels_in)
+        self.n_channels_out = int(n_channels_out)
+        self.spatial_shape = tuple(int(s) for s in spatial_shape)
+        self.global_cond_features = int(global_cond_features)
+
+        spatial = int(math.prod(self.spatial_shape)) if self.spatial_shape else 1
+        self.spatial = spatial
+        self.features = self.n_steps_output * spatial * self.n_channels_out
+        self.context = (
+            self.n_steps_input * spatial * self.n_channels_in
+            + self.global_cond_features
+        )
+        self.student = _mlp(
+            self.features + self.context,
+            self.features,
+            tuple(int(h) for h in hidden_features),
+        )
+        # Teacher is injected for training only (not a submodule -> excluded from
+        # the checkpoint, so scoring loads the student alone).
+        self._teacher: list[_FlowTeacher] = []
+
+    def set_teacher(self, teacher: Processor) -> None:
+        """Attach a frozen flow-matching teacher for distillation training."""
+        if not callable(getattr(teacher, "flow_field", None)):
+            msg = (
+                "DistilledProcessor requires a flow-matching-capable teacher "
+                "exposing a flow_field(z, t, x, global_cond) method; got "
+                f"{type(teacher).__name__}."
+            )
+            raise TypeError(msg)
+        teacher.eval()
+        for p in teacher.parameters():
+            p.requires_grad_(False)
+        self._teacher = [cast(_FlowTeacher, teacher)]
+
+    # -- layout helpers -------------------------------------------------------
+    def _context(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        ctx = x.reshape(x.shape[0], -1)
+        if global_cond is not None and self.global_cond_features > 0:
+            ctx = torch.cat(
+                [ctx, global_cond.reshape(global_cond.shape[0], -1)], dim=-1
+            )
+        return ctx
+
+    def _z_shape(self, b: int) -> tuple[int, ...]:
+        return (b, self.n_steps_output, *self.spatial_shape, self.n_channels_out)
+
+    def _generate(self, z_flat: Tensor, ctx: Tensor) -> Tensor:
+        """Student forward: (z_flat, ctx) -> next-state field (B, T, *spatial, C)."""
+        out = self.student(torch.cat([z_flat, ctx], dim=-1))
+        return out.reshape(self._z_shape(out.shape[0]))
+
+    # -- teacher integration (noise-paired endpoint) --------------------------
+    @torch.no_grad()
+    def _teacher_endpoint(
+        self, z: Tensor, x: Tensor, global_cond: Tensor | None
+    ) -> Tensor:
+        """Integrate the teacher's flow ODE from a *given* noise z to its sample."""
+        teacher = self._teacher[0]
+        steps = max(int(teacher.flow_ode_steps), 1)
+        integrator = getattr(teacher, "integrator", "euler")
+        dt = torch.tensor(1.0 / steps, device=z.device, dtype=z.dtype)
+        t = torch.zeros(z.shape[0], device=z.device, dtype=z.dtype)
+        for _ in range(steps):
+            if integrator == "heun":
+                k1 = teacher.flow_field(z, t, x, global_cond)
+                k2 = teacher.flow_field(z + dt * k1, t + dt, x, global_cond)
+                z = z + dt * 0.5 * (k1 + k2)
+            else:
+                z = z + dt * teacher.flow_field(z, t, x, global_cond)
+            t = t + dt
+        return z
+
+    # -- Processor API --------------------------------------------------------
+    def forward(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        return self.map(x, global_cond)
+
+    def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Draw one member in a single pass: g(z, x_t), z ~ N(0, I)."""
+        ctx = self._context(x, global_cond)
+        z = torch.randn(self._z_shape(x.shape[0]), device=x.device, dtype=x.dtype)
+        return self._generate(z.reshape(z.shape[0], -1), ctx)
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        """Noise-paired sample-matching distillation loss against the teacher."""
+        if not self._teacher:
+            msg = (
+                "DistilledProcessor.loss requires a teacher; call set_teacher(...) "
+                "before training."
+            )
+            raise RuntimeError(msg)
+        x = batch.encoded_inputs
+        ctx = self._context(x, batch.global_cond)
+        z = torch.randn(self._z_shape(x.shape[0]), device=x.device, dtype=x.dtype)
+        target = self._teacher_endpoint(z, x, batch.global_cond)
+        pred = self._generate(z.reshape(z.shape[0], -1), ctx)
+        return torch.mean((pred - target) ** 2)

--- a/src/autocast/processors/normalizing_flow.py
+++ b/src/autocast/processors/normalizing_flow.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import torch
+import zuko
+
+from autocast.processors.base import Processor
+from autocast.types import EncodedBatch, Tensor
+
+# flow_type -> zuko flow family. Coupling flows sample in a single network pass
+# (one-forward); autoregressive flows sample in D sequential passes. All are
+# trained on the EXACT log-likelihood (the logarithmic score).
+_FLOW_CLASSES = {
+    # coupling (one-forward sampling)
+    "realnvp": zuko.flows.RealNVP,  # affine coupling
+    "nice": zuko.flows.NICE,  # additive coupling
+    "ncsf": zuko.flows.NCSF,  # neural coupling spline
+    # autoregressive (expressive; D sequential sampling passes)
+    "maf": zuko.flows.MAF,  # masked autoregressive (affine)
+    "nsf": zuko.flows.NSF,  # masked autoregressive neural spline
+}
+
+
+class NormalizingFlowProcessor(Processor):
+    """Conditional normalizing-flow processor trained on the exact log score.
+
+    Models the one-step predictive density ``p(x_{t+1} | x_t)`` exactly with a
+    zuko flow conditioned on the flattened current state. Training minimises the
+    negative log-likelihood (the strictly proper logarithmic score, computed
+    exactly via the change-of-variables rule). Each :meth:`map` call draws one
+    ensemble member with a single ``distribution.sample()`` — one network pass
+    for a coupling flow, ``features`` sequential passes for an autoregressive
+    flow. Ensembles are produced by calling :meth:`map` repeatedly.
+
+    The two plan arms are this one class under different ``flow_type``:
+    coupling (``realnvp`` / ``nice`` / ``ncsf``) is the cheap one-forward pilot;
+    autoregressive (``maf`` / ``nsf``) is the expressive exact-likelihood arm.
+    """
+
+    def __init__(
+        self,
+        *,
+        n_steps_input: int = 1,
+        n_steps_output: int = 1,
+        n_channels_in: int = 1,
+        n_channels_out: int = 1,
+        spatial_shape: Sequence[int] = (1, 1),
+        global_cond_features: int = 0,
+        flow_type: str = "nsf",
+        transforms: int = 4,
+        hidden_features: Sequence[int] = (128, 128),
+    ) -> None:
+        super().__init__()
+        if flow_type not in _FLOW_CLASSES:
+            msg = (
+                f"flow_type must be one of {sorted(_FLOW_CLASSES)}; got {flow_type!r}."
+            )
+            raise ValueError(msg)
+        self.n_steps_input = int(n_steps_input)
+        self.n_steps_output = int(n_steps_output)
+        self.n_channels_in = int(n_channels_in)
+        self.n_channels_out = int(n_channels_out)
+        self.spatial_shape = tuple(int(s) for s in spatial_shape)
+        self.global_cond_features = int(global_cond_features)
+        self.flow_type = flow_type
+
+        spatial = int(math.prod(self.spatial_shape)) if self.spatial_shape else 1
+        # target dimension D = T_out * spatial * C_out (the field, flattened)
+        self.features = self.n_steps_output * spatial * self.n_channels_out
+        # conditioning dimension = flattened current state (+ optional global cond)
+        self.context = (
+            self.n_steps_input * spatial * self.n_channels_in
+            + self.global_cond_features
+        )
+
+        self.flow = _FLOW_CLASSES[flow_type](
+            features=self.features,
+            context=self.context,
+            transforms=int(transforms),
+            hidden_features=tuple(int(h) for h in hidden_features),
+        )
+
+    def _context(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Flatten the current state (and optional global cond) to (B, context)."""
+        ctx = x.reshape(x.shape[0], -1)
+        if global_cond is not None and self.global_cond_features > 0:
+            ctx = torch.cat(
+                [ctx, global_cond.reshape(global_cond.shape[0], -1)], dim=-1
+            )
+        return ctx
+
+    def forward(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Alias to map for Lightning/PyTorch compatibility."""
+        return self.map(x, global_cond)
+
+    def map(self, x: Tensor, global_cond: Tensor | None) -> Tensor:
+        """Draw one stochastic next-state member, shape (B, T_out, *spatial, C_out)."""
+        b = x.shape[0]
+        ctx = self._context(x, global_cond)
+        sample = self.flow(ctx).sample()  # (B, features)
+        return sample.reshape(
+            b, self.n_steps_output, *self.spatial_shape, self.n_channels_out
+        )
+
+    def loss(self, batch: EncodedBatch) -> Tensor:
+        """Exact negative log-likelihood of the next state given the current."""
+        target = batch.encoded_output_fields
+        if (
+            target.shape[1] != self.n_steps_output
+            or target.shape[-1] != self.n_channels_out
+        ):
+            msg = (
+                f"Target shape {tuple(target.shape)} does not match configured "
+                f"n_steps_output={self.n_steps_output}, "
+                f"n_channels_out={self.n_channels_out}."
+            )
+            raise ValueError(msg)
+        ctx = self._context(batch.encoded_inputs, batch.global_cond)
+        y = target.reshape(target.shape[0], -1)  # (B, features)
+        log_prob = self.flow(ctx).log_prob(y)  # (B,)
+        loss = -log_prob.mean()
+        self._latest_diagnostics = {
+            "nll": loss.detach(),
+            "log_prob": log_prob.mean().detach(),
+        }
+        return loss

--- a/src/autocast/processors/normalizing_flow.py
+++ b/src/autocast/processors/normalizing_flow.py
@@ -4,7 +4,12 @@ import math
 from collections.abc import Sequence
 
 import torch
-import zuko
+
+# zuko ships in the optional "flows" extra, so it is absent from the default dev
+# environment CI installs. The processors package imports this module lazily and
+# falls back to a placeholder that raises a clear ImportError, so a missing zuko
+# is a supported state rather than a defect.
+import zuko  # pyright: ignore[reportMissingImports]
 
 from autocast.processors.base import Processor
 from autocast.types import EncodedBatch, Tensor

--- a/tests/processors/test_consistency.py
+++ b/tests/processors/test_consistency.py
@@ -1,0 +1,162 @@
+from typing import cast
+
+import pytest
+import torch
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.processors.consistency import ConsistencyDistilledProcessor
+from autocast.processors.flow_matching import FlowMatchingProcessor
+from autocast.types import EncodedBatch
+
+# Archetypes: scalar (ou/dw), vector (mvou), 1D (l96), 2D (gs).
+SHAPES = [((1, 1), 1), ((1, 1), 3), ((40, 1), 1), ((8, 8), 2)]
+
+
+class _CondField(nn.Module):
+    """Stub flow field f(z,t) = cond, so a 1-step Euler step adds the conditioning.
+
+    The step depends on the conditioning x_t, so the teacher carries real
+    structure for the student to be consistent with.
+    """
+
+    include_time_embedding = False
+
+    def forward(self, z, t=None, cond=None, global_cond=None):  # noqa: ARG002
+        return cond
+
+
+def _teacher(channels):
+    return FlowMatchingProcessor(
+        backbone=_CondField(),
+        n_steps_output=1,
+        n_channels_out=channels,
+        flow_ode_steps=1,
+    )
+
+
+def _student(spatial, channels, hidden=(64, 64)):
+    return ConsistencyDistilledProcessor(
+        n_channels_in=channels,
+        n_channels_out=channels,
+        spatial_shape=spatial,
+        hidden_features=hidden,
+        n_consistency_steps=8,
+    )
+
+
+def _batch(b, spatial, channels):
+    shape = (b, 1, *spatial, channels)
+    return EncodedBatch(
+        encoded_inputs=torch.randn(*shape),
+        encoded_output_fields=torch.randn(*shape),
+        global_cond=None,
+        encoded_info={},
+    )
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_map_shape_and_finite_without_teacher(spatial, channels):
+    proc = _student(spatial, channels)
+    x = torch.randn(3, 1, *spatial, channels)
+    y = proc.map(x, None)
+    assert y.shape == (3, 1, *spatial, channels)
+    assert torch.isfinite(y).all()
+
+
+def test_map_is_stochastic():
+    """Two draws from the same input differ (the student is a generative sampler)."""
+    torch.manual_seed(0)
+    proc = _student((40, 1), 1)
+    x = torch.randn(5, 1, 40, 1)
+    a = proc.map(x, None)
+    b = proc.map(x, None)
+    assert not torch.allclose(a, b)
+
+
+def test_boundary_condition_identity_at_data_end():
+    """f(z, t=1 | x) = z exactly (the data-end identity), for any z."""
+    proc = _student((40, 1), 1)
+    z = torch.randn(4, 1, 40, 1)
+    ctx = proc._context(torch.randn(4, 1, 40, 1), None)
+    t1 = torch.ones(4)
+    out = proc._consistency_map(z, t1, ctx)
+    assert torch.allclose(out, z, atol=1e-6)
+
+
+class _RecordingField(nn.Module):
+    """Flow field that records every time t it is queried at (returns cond)."""
+
+    include_time_embedding = False
+
+    def __init__(self):
+        super().__init__()
+        self.seen_t: list[float] = []
+
+    def forward(self, z, t: torch.Tensor, cond=None, global_cond=None):  # noqa: ARG002
+        self.seen_t.extend(t.reshape(-1).tolist())
+        return cond
+
+
+def test_teacher_stepped_from_noisier_time_toward_data():
+    """The teacher must be queried at the noisier grid time t_n = n/N (n in
+    {0..N-1}), stepping toward the data end — never at the data boundary t=1, which
+    would only occur if the step originated from the closer-to-data t_{n+1}. This
+    pins the teacher-step time-direction (a t-independent stub teacher cannot)."""
+    torch.manual_seed(0)
+    n_steps = 5
+    field = _RecordingField()
+    teacher = FlowMatchingProcessor(
+        backbone=field,
+        n_steps_output=1,
+        n_channels_out=1,
+        flow_ode_steps=1,
+    )
+    proc = _student((4, 1), 1)
+    proc.n_consistency_steps = n_steps
+    proc.set_teacher(teacher)
+    proc.loss(_batch(64, (4, 1), 1))
+    assert field.seen_t, "teacher was never queried"
+    # t_n grid is {0, 1/N, ..., (N-1)/N}; max is (N-1)/N < 1. A swap to t_{n+1}
+    # would put 1.0 in the set.
+    assert max(field.seen_t) <= (n_steps - 1) / n_steps + 1e-6, (
+        f"teacher queried at/above the data boundary: max t = {max(field.seen_t)}"
+    )
+    assert min(field.seen_t) == 0.0, "the noisiest slice t=0 was never sampled"
+
+
+def test_loss_requires_teacher():
+    proc = _student((4, 1), 1)
+    with pytest.raises(RuntimeError, match="requires a teacher"):
+        proc.loss(_batch(2, (4, 1), 1))
+
+
+def test_set_teacher_rejects_non_flow_matching():
+    """The teacher must be flow-matching-capable (expose flow_field); anything
+    else is rejected up front rather than failing cryptically during training."""
+    proc = _student((4, 1), 1)
+    with pytest.raises(TypeError, match="flow-matching-capable"):
+        proc.set_teacher(cast(Processor, object()))
+
+
+def test_teacher_excluded_from_checkpoint():
+    """The injected teacher must not leak into the student state_dict (scoring
+    loads the student alone via a strict state_dict load)."""
+    proc = _student((8, 8), 2)
+    keys_before = set(proc.state_dict())
+    proc.set_teacher(_teacher(2))
+    assert set(proc.state_dict()) == keys_before
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_consistency_loss_backward_only_student(spatial, channels):
+    proc = _student(spatial, channels)
+    teacher = _teacher(channels)
+    proc.set_teacher(teacher)
+    loss = proc.loss(_batch(4, spatial, channels))
+    assert loss.shape == ()
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert all(p.grad is not None for p in proc.net.parameters())
+    # Teacher is frozen and not part of the student graph.
+    assert all(not p.requires_grad for p in teacher.parameters())

--- a/tests/processors/test_distilled.py
+++ b/tests/processors/test_distilled.py
@@ -1,0 +1,124 @@
+from typing import cast
+
+import pytest
+import torch
+from torch import nn
+
+from autocast.processors.base import Processor
+from autocast.processors.distilled import DistilledProcessor
+from autocast.processors.flow_matching import FlowMatchingProcessor
+from autocast.types import EncodedBatch
+
+# Archetypes: scalar (ou/dw), vector (mvou), 1D (l96), 2D (gs).
+SHAPES = [((1, 1), 1), ((1, 1), 3), ((40, 1), 1), ((8, 8), 2)]
+
+
+class _CondField(nn.Module):
+    """Stub flow field f(z,t) = cond, so a 1-step Euler endpoint is z + x_t.
+
+    The endpoint depends on the noise z (the teacher has real spread) and on the
+    conditioning x_t, so a successful student must reproduce both.
+    """
+
+    include_time_embedding = False
+
+    def forward(self, z, t=None, cond=None, global_cond=None):  # noqa: ARG002
+        return cond
+
+
+def _teacher(channels):
+    return FlowMatchingProcessor(
+        backbone=_CondField(),
+        n_steps_output=1,
+        n_channels_out=channels,
+        flow_ode_steps=1,
+    )
+
+
+def _student(spatial, channels, hidden=(64, 64)):
+    return DistilledProcessor(
+        n_channels_in=channels,
+        n_channels_out=channels,
+        spatial_shape=spatial,
+        hidden_features=hidden,
+    )
+
+
+def _batch(b, spatial, channels):
+    shape = (b, 1, *spatial, channels)
+    return EncodedBatch(
+        encoded_inputs=torch.randn(*shape),
+        encoded_output_fields=torch.randn(*shape),
+        global_cond=None,
+        encoded_info={},
+    )
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_map_shape_and_finite_without_teacher(spatial, channels):
+    proc = _student(spatial, channels)
+    x = torch.randn(3, 1, *spatial, channels)
+    y = proc.map(x, None)
+    assert y.shape == (3, 1, *spatial, channels)
+    assert torch.isfinite(y).all()
+
+
+def test_loss_requires_teacher():
+    proc = _student((4, 1), 1)
+    with pytest.raises(RuntimeError, match="requires a teacher"):
+        proc.loss(_batch(2, (4, 1), 1))
+
+
+def test_set_teacher_rejects_non_flow_matching():
+    """The teacher must be flow-matching-capable (expose flow_field); anything
+    else is rejected up front rather than failing cryptically during training."""
+    proc = _student((4, 1), 1)
+    with pytest.raises(TypeError, match="flow-matching-capable"):
+        proc.set_teacher(cast(Processor, object()))
+
+
+@pytest.mark.parametrize(("spatial", "channels"), SHAPES)
+def test_distill_loss_backward_only_student(spatial, channels):
+    proc = _student(spatial, channels)
+    teacher = _teacher(channels)
+    proc.set_teacher(teacher)
+    loss = proc.loss(_batch(4, spatial, channels))
+    assert loss.shape == ()
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert all(p.grad is not None for p in proc.student.parameters())
+    # Teacher is frozen and not part of the student graph.
+    assert all(p.grad is None for p in teacher.parameters())
+
+
+def test_teacher_excluded_from_checkpoint():
+    """The injected teacher must not leak into the student state_dict (scoring
+    loads the student alone via a strict state_dict load)."""
+    proc = _student((8, 8), 2)
+    keys_before = set(proc.state_dict())
+    proc.set_teacher(_teacher(2))
+    assert set(proc.state_dict()) == keys_before
+
+
+def test_distillation_matches_teacher_and_keeps_spread():
+    """Training drives the student toward the teacher's noise->sample map: the
+    distillation MSE drops and the student's member spread stays non-trivial
+    (sample-matching, not a collapsed mean)."""
+    torch.manual_seed(0)
+    spatial, channels = (4, 1), 1
+    proc = _student(spatial, channels, hidden=(128, 128))
+    proc.set_teacher(_teacher(channels))
+    batch = _batch(64, spatial, channels)
+    opt = torch.optim.Adam(proc.student.parameters(), lr=3e-3)
+    losses = []
+    for _ in range(400):
+        opt.zero_grad()
+        loss = proc.loss(batch)
+        loss.backward()
+        opt.step()
+        losses.append(loss.item())
+    assert losses[-1] < 0.25 * losses[0]  # student learned the teacher map
+    # Member spread over a fixed input must be > 0 (UQ preserved).
+    x = torch.randn(8, 1, *spatial, channels)
+    members = torch.stack([proc.map(x, None) for _ in range(32)], dim=0)
+    assert members.std(dim=0).mean() > 0.1

--- a/tests/processors/test_normalizing_flow.py
+++ b/tests/processors/test_normalizing_flow.py
@@ -1,0 +1,90 @@
+import pytest
+import torch
+
+from autocast.types import EncodedBatch
+
+pytest.importorskip("zuko")
+
+from autocast.processors.normalizing_flow import NormalizingFlowProcessor
+
+# Cover a coupling flow (one-forward sampling) and an autoregressive flow.
+FLOW_TYPES = ["realnvp", "nsf"]
+
+
+def _batch(b, spatial, channels):
+    shape = (b, 1, *spatial, channels)
+    return EncodedBatch(
+        encoded_inputs=torch.randn(*shape),
+        encoded_output_fields=torch.randn(*shape),
+        global_cond=None,
+        encoded_info={},
+    )
+
+
+def _processor(flow_type, spatial=(4, 1), channels=1):
+    return NormalizingFlowProcessor(
+        n_channels_in=channels,
+        n_channels_out=channels,
+        spatial_shape=spatial,
+        flow_type=flow_type,
+        transforms=2,
+        hidden_features=(32, 32),
+    )
+
+
+@pytest.mark.parametrize("flow_type", FLOW_TYPES)
+def test_loss_finite_and_backward(flow_type):
+    proc = _processor(flow_type)
+    loss = proc.loss(_batch(8, (4, 1), 1))
+    assert loss.shape == ()
+    assert torch.isfinite(loss)
+    loss.backward()
+    grads = [p.grad for p in proc.parameters() if p.grad is not None]
+    assert grads, "no gradients flowed"
+    assert all(torch.isfinite(g).all() for g in grads)
+
+
+@pytest.mark.parametrize("flow_type", FLOW_TYPES)
+def test_map_shape_and_finite(flow_type):
+    proc = _processor(flow_type)
+    x = torch.randn(3, 1, 4, 1, 1)
+    y = proc.map(x, None)
+    assert y.shape == (3, 1, 4, 1, 1)
+    assert torch.isfinite(y).all()
+
+
+@pytest.mark.parametrize("flow_type", FLOW_TYPES)
+def test_two_train_steps_decrease(flow_type):
+    """Overfitting a fixed batch reduces the exact NLL (the log score is real)."""
+    torch.manual_seed(0)
+    proc = _processor(flow_type)
+    batch = _batch(32, (4, 1), 1)
+    opt = torch.optim.Adam(proc.parameters(), lr=1e-3)
+    losses = []
+    for _ in range(3):
+        opt.zero_grad()
+        loss = proc.loss(batch)
+        loss.backward()
+        opt.step()
+        losses.append(loss.item())
+    assert all(torch.isfinite(torch.tensor(losses)))
+    assert losses[-1] < losses[0]
+
+
+def test_invalid_flow_type_raises():
+    with pytest.raises(ValueError, match="flow_type must be one of"):
+        NormalizingFlowProcessor(flow_type="not_a_flow")
+
+
+def test_loss_rejects_mismatched_field_shape():
+    """A target whose dims don't match the configured n_steps_output /
+    n_channels_out raises a clear error instead of a cryptic reshape failure."""
+    proc = _processor("realnvp", spatial=(8, 8), channels=1)
+    bad = EncodedBatch(
+        encoded_inputs=torch.randn(4, 1, 8, 8, 1),
+        encoded_output_fields=torch.randn(4, 2, 8, 8, 1),  # wrong n_steps_output
+        global_cond=None,
+        encoded_info={},
+    )
+    with pytest.raises(ValueError, match="does not match configured"):
+        proc.loss(bad)


### PR DESCRIPTION
## What this adds

Three generative one-step processors that model or approximate the predictive distribution `p(x_{t+1} | x_t)` directly, completing the family alongside the existing TarFlow, sigma-VAE and convolutional-coupling processors.

**`NormalizingFlowProcessor`** models the predictive density *exactly* with a conditional [zuko](https://github.com/probabilists/zuko) flow over the flattened field, conditioned on the flattened current state. Training minimises the exact negative log-likelihood — the strictly proper logarithmic score. `flow_type` selects the family:

- coupling flows (`realnvp`, `nice`, `ncsf`) sample in a single network pass;
- masked-autoregressive flows (`maf`, `nsf`) are more expressive but sample in D sequential passes.

Because it flattens the field it makes no use of spatial structure, so it suits scalar or small fields — in contrast to the spatially structured convolutional-coupling and patch-autoregressive processors, which remain the right choice for larger grids.

**`DistilledProcessor`** and **`ConsistencyDistilledProcessor`** train a one-pass student to match samples from a frozen flow-matching teacher, trading the teacher's iterative ODE solve for a single forward pass at inference. Both validate the teacher interface when it is attached, so a mismatched teacher fails at `set_teacher` with a clear error rather than deep inside the training loop.

## zuko is optional

`zuko` is declared under a new `flows` extra and imported lazily. The processors package stays importable without it, and instantiating `NormalizingFlowProcessor` without it raises a clear `ImportError` naming the missing package rather than an import traceback. The flow tests skip when it is absent.

## Testing

`209 passed` across `tests/processors/`. Each processor ships its own test module. Ruff, ruff-format and pyright are clean on all added files.

## Notes for review

- The three processors were developed on a downstream research fork and are proposed here because they are framework code rather than research-specific. They were rebuilt against current `main` rather than ported wholesale: the fork's copies of `tarflow.py`, `sigma_vae.py` and `conv_coupling.py` predate this repository's versions, so nothing shared is touched by this PR.
- Two older branches on this repository, `add-zuko-flow-processor` and `add-distilled-flow-processors`, are superseded by this one. `zuko_flow.py` is the same file as `normalizing_flow.py` under its earlier name. Both can be deleted once this merges.
