### PR TITLE
Add Rayleigh-Benard workflow guide

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -24,6 +24,8 @@ chapters:
   - file: tutorials/diffusion_and_flow_matching
   - file: tutorials/deterministic_ensembles
 
+- file: walkthrough/rayleigh-benard
+
 - file: tutorials/evaluation_and_results
 
 - file: howto/index

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -58,3 +58,5 @@ reusing old checkpoints. Each cell has a
 downloads are cached, but notebook execution is repeated after library changes.
 
 CLI walkthrough pages are explanatory Markdown and are not executed by this build.
+The research-scale [Rayleigh–Bénard workflow](../walkthrough/rayleigh-benard.md)
+remains a non-executed guide.

--- a/docs/walkthrough/index.md
+++ b/docs/walkthrough/index.md
@@ -10,6 +10,7 @@ For a short Python introduction, start with the
 [focused notebooks](../tutorials/index.md) explore individual model and evaluation
 choices with small datasets and plots.
 
-After evaluating your experiments, use
+The [Rayleigh–Bénard guide](rayleigh-benard.md) extends the workflow to The Well
+and pretrained autoencoders. After evaluating your experiments, use
 [evaluation and results](../tutorials/evaluation_and_results.ipynb) to inspect
 metrics and compare saved runs.

--- a/docs/walkthrough/rayleigh-benard.md
+++ b/docs/walkthrough/rayleigh-benard.md
@@ -1,0 +1,153 @@
+# Rayleigh–Bénard with The Well
+
+Download [Rayleigh–Bénard convection from The Well](https://polymathic-ai.org/the_well/datasets/rayleigh_benard/), reuse a pretrained autoencoder, train a latent processor, and evaluate decoded forecasts.
+Choose either an AutoCast-native cache or an existing LoLA HDF5 cache; you do not need both.
+
+:::{warning}
+The dataset and pretrained autoencoder are large, and processor training is best run on a GPU.
+The commands below are not executed while building these docs.
+Add `--first-only` to the data download for a smaller workflow check.
+:::
+
+Run the commands from the AutoCast repository root unless noted otherwise.
+
+## Download the data
+
+The Well downloader creates `datasets/rayleigh_benard` with train, validation, and test splits.
+Raw data is needed for caching and for evaluation against the original fields, even when reusing a latent cache.
+
+```bash
+uv run the-well-download \
+    --dataset rayleigh_benard \
+    --base-path .
+```
+
+## Download the pretrained autoencoder
+
+[LoLA provides the autoencoder weights](https://github.com/francois-rozet/lola#pre-trained-models) used for its Rayleigh–Bénard latent experiments.
+Download and unpack the 64× compression model:
+
+```bash
+curl --fail --location \
+    --output datasets/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large.zip \
+    https://users.flatironinstitute.org/~polymathic/data/lola/ae/1e3z5x2c_rayleigh_benard_dcae_f32c64_large.zip
+
+unzip \
+    datasets/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large.zip \
+    -d datasets/rayleigh_benard
+```
+
+The archive contains only the model configuration and `state.pth` weights; it does not include cached latents.
+AutoCast's checkpoint preset supplies the matching architecture, field normalization, and Rayleigh/Prandtl conditioning.
+
+## Choose a latent cache
+
+### Generate with AutoCast
+
+Encode each trajectory once with the downloaded checkpoint:
+
+```bash
+uv run autocast cache-latents \
+    --workdir outputs/rayleigh_benard/cache \
+    --output-dir datasets/rayleigh_benard/cached_latents \
+    local_experiment=cache_latents/the_well/rayleigh_benard/lola_f32c64
+```
+
+The preset encodes one frame at a time to limit activation memory and retains the full trajectories.
+AutoCast saves `.pt` trajectories and the configuration needed to reload the autoencoder:
+
+```text
+datasets/rayleigh_benard/cached_latents
+├── autoencoder_config.yaml
+├── metadata.json
+├── train
+├── valid
+└── test
+```
+
+### Reuse a LoLA cache
+
+The maintained RB experiment presets use HDF5 caches produced by [LoLA's `cache_latents.py`](https://github.com/francois-rozet/lola/blob/main/experiments/cache_latents.py).
+Keep those caches beside their matching `config.yaml` and `state.pth`:
+
+```text
+datasets/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large
+├── config.yaml
+├── state.pth
+└── cache/rayleigh_benard
+    ├── train
+    ├── valid
+    └── test
+```
+
+Each split contains HDF5 files with `state` (latent trajectories) and `label` (conditioning).
+These use AutoCast's `miniwell` loader, not `cached_latents`.
+
+:::{dropdown} Generate this format with LoLA instead
+
+Follow [LoLA's setup instructions](https://github.com/francois-rozet/lola#code), then run from its `experiments` directory in that environment:
+
+```bash
+uv run python cache_latents.py \
+    dataset=rayleigh_benard \
+    run=/absolute/path/to/autocast/datasets/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large \
+    server.datasets=/absolute/path/to/autocast/datasets \
+    split=train repeat=4
+```
+
+Adapt `server.*` and `compute.*` to your cluster first: this script submits SLURM GPU jobs.
+Repeat for `split=valid` and `split=test` with `repeat=1`, and wait for all jobs to finish.
+LoLA's training recipe caches repeated random augmentations; the AutoCast preset above encodes each original trajectory once.
+:::
+
+## Train a processor
+
+Train a small ViT-backed flow-matching processor on those cached latents:
+
+```bash
+uv run autocast processor \
+    --workdir outputs/rayleigh_benard/processor \
+    datamodule=cached_latents \
+    ++datamodule.data_path="$PWD/datasets/rayleigh_benard/cached_latents" \
+    ++datamodule.in_memory=false \
+    processor@model.processor=flow_matching_vit \
+    ++trainer.max_epochs=10
+```
+
+For a LoLA cache, replace the three `datamodule` arguments with:
+
+```bash
+datamodule=miniwell \
+++datamodule.data_path="$PWD/datasets/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large/cache/rayleigh_benard"
+```
+
+To train diffusion with the same backbone, replace that processor override with:
+
+```text
+processor@model.processor=diffusion_vit
+```
+
+## Evaluate in physical space
+
+Both cache routes use the same evaluation command:
+
+```bash
+uv run autocast eval \
+    --workdir outputs/rayleigh_benard/processor \
+    ++eval.chunk_size=1 \
+    ++eval.max_test_batches=2 \
+    ++eval.max_rollout_batches=2 \
+    '++eval.batch_indices=[0]'
+```
+
+AutoCast finds the processor checkpoint and reconstructs the autoencoder from native-cache metadata or the adjacent LoLA checkpoint, then selects `encode_once` evaluation.
+The processor rolls out in latent space, while predictions are decoded and scored against the original physical fields.
+Results appear under `outputs/rayleigh_benard/processor/eval`, including aggregate CSV files, lead-time metrics, and rollout visualizations.
+The batch limits make this an initial check; remove them for full evaluation.
+
+## Scale up
+
+The commands above expose the complete workflow with a short training budget.
+For paper-scale runs, use the maintained [Rayleigh–Bénard experiment presets](https://github.com/alan-turing-institute/autocast/tree/main/local_hydra/local_experiment/the_well/rayleigh_benard) and [SLURM submitters](https://github.com/alan-turing-institute/autocast/tree/main/slurm_scripts/comparison/the_well/rayleigh_benard).
+Those presets use the LoLA HDF5 cache and a larger ViT configuration.
+They cover ambient and latent CRPS, flow matching, diffusion, and longer evaluations.

--- a/local_hydra/decoder/the_well/rayleigh_benard/lola_f32c64.yaml
+++ b/local_hydra/decoder/the_well/rayleigh_benard/lola_f32c64.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - /external/lola/ae/dcae_f32c64_large@_here_
+  - _self_
+
+_target_: autocast.external.lola.wrapped_decoder.WrappedDecoder
+
+pix_channels: 4
+mean: [0.38, 0.01, 0.00, 0.00]
+std: [0.25, 0.15, 0.21, 0.18]
+device: cpu
+runpath: ???

--- a/local_hydra/encoder/the_well/rayleigh_benard/lola_f32c64.yaml
+++ b/local_hydra/encoder/the_well/rayleigh_benard/lola_f32c64.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - /external/lola/ae/dcae_f32c64_large@_here_
+  - _self_
+
+_target_: autocast.external.lola.wrapped_encoder.WrappedEncoder
+
+pix_channels: 4
+mean: [0.38, 0.01, 0.00, 0.00]
+std: [0.25, 0.15, 0.21, 0.18]
+# The datamodule applies the matching LogScalars transform.
+log_scalars: false
+device: cpu
+runpath: ???

--- a/local_hydra/local_experiment/cache_latents/the_well/rayleigh_benard/lola_f32c64.yaml
+++ b/local_hydra/local_experiment/cache_latents/the_well/rayleigh_benard/lola_f32c64.yaml
@@ -1,0 +1,26 @@
+# @package _global_
+defaults:
+  - override /datamodule: rayleigh_benard
+  - override /encoder@model.encoder: the_well/rayleigh_benard/lola_f32c64
+  - override /decoder@model.decoder: the_well/rayleigh_benard/lola_f32c64
+  - _self_
+
+experiment_name: cache_latents_the_well_rayleigh_benard_lola_f32c64
+lola_autoencoder_path: ${hydra:runtime.cwd}/datasets/rayleigh_benard/1e3z5x2c_rayleigh_benard_dcae_f32c64_large
+
+# The supplied LoLA wrapper applies the checkpoint's normalization itself.
+datamodule:
+  well_base_path: ${hydra:runtime.cwd}/datasets
+  use_normalization: false
+  batch_size: 1
+  num_workers: 0
+  # Cache all frames, rather than the default 100-step evaluation horizon.
+  max_rollout_steps: .inf
+
+model:
+  encoder:
+    runpath: ${lola_autoencoder_path}
+    chunk_size: 1
+  decoder:
+    runpath: ${lola_autoencoder_path}
+    chunk_size: 1

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -24,4 +24,5 @@ uv run python docs/build.py
 The old notebooks remain recoverable from Git history. Their exploratory
 variants (such as direct learned-autoencoder/EPD assembly and additive or
 concatenated input noise) are not all maintained as separate runnable examples.
-Research-scale workflows belong in Markdown walkthroughs, not in notebook CI.
+Research-scale Rayleigh–Bénard instructions belong in the
+[Markdown walkthrough](../docs/walkthrough/rayleigh-benard.md), not in notebook CI.

--- a/src/autocast/data/datamodule.py
+++ b/src/autocast/data/datamodule.py
@@ -26,6 +26,7 @@ class TheWellDataModule(LightningDataModule):
         autoencoder_mode: bool = False,
         num_workers: int | None = None,  # Auto-detect if None
         normalization_path: str = "../stats.yaml",
+        full_trajectory_mode: bool = False,
         **well_kwargs,
     ):
         super().__init__()
@@ -45,6 +46,7 @@ class TheWellDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             autoencoder_mode=autoencoder_mode,
+            full_trajectory_mode=full_trajectory_mode,
             **well_kwargs,
         )
         self.val_dataset = TheWell(
@@ -56,6 +58,7 @@ class TheWellDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             autoencoder_mode=autoencoder_mode,
+            full_trajectory_mode=full_trajectory_mode,
             **well_kwargs,
         )
         self.test_dataset = TheWell(
@@ -67,6 +70,7 @@ class TheWellDataModule(LightningDataModule):
             normalization_type=normalization_type,
             normalization_path=normalization_path,
             autoencoder_mode=autoencoder_mode,
+            full_trajectory_mode=full_trajectory_mode,
             **well_kwargs,
         )
 

--- a/src/autocast/external/lola/wrapped_encoder.py
+++ b/src/autocast/external/lola/wrapped_encoder.py
@@ -92,4 +92,6 @@ class WrappedEncoder(ChannelsFirstEncoder):
                 bc if global_cond is None else torch.cat([global_cond, bc], dim=1)
             )
 
-        return global_cond
+        # The Well can store scalars in float64. Match the fields before passing
+        # conditioning to the processor's linear layers.
+        return global_cond.to(batch.input_fields) if global_cond is not None else None

--- a/src/autocast/scripts/cache_latents.py
+++ b/src/autocast/scripts/cache_latents.py
@@ -200,7 +200,9 @@ def cache_latents(
     # Save the full autoencoder config so the decoder can be reconstructed at
     # eval time (e.g. for data-space evaluation of a processor-only checkpoint).
     ae_config_path = output_dir / "autoencoder_config.yaml"
-    OmegaConf.save(cfg, ae_config_path)
+    # Freeze paths and component settings from this run, not a later eval's
+    # Hydra context (which may have a different working directory).
+    OmegaConf.save(cfg, ae_config_path, resolve=True)
     log.info("Autoencoder config saved to %s", ae_config_path)
 
     log.info("Caching complete. Output directory: %s", output_dir)

--- a/src/autocast/scripts/eval/encoder_processor_decoder.py
+++ b/src/autocast/scripts/eval/encoder_processor_decoder.py
@@ -2055,6 +2055,30 @@ def _resolve_auto_eval_mode(
     return "latent"
 
 
+def _inject_cached_autoencoder_components(
+    cfg: DictConfig, ae_cfg: DictConfig
+) -> DictConfig:
+    """Restore the native cache's autoencoder without replacing explicit overrides."""
+    with open_dict(cfg):
+        if not cfg.get("autoencoder_checkpoint") and ae_cfg.get(
+            "autoencoder_checkpoint"
+        ):
+            cfg.autoencoder_checkpoint = ae_cfg.autoencoder_checkpoint
+        if cfg.get("model") is None:
+            cfg.model = OmegaConf.create({})
+
+    # A processor checkpoint has no encoder/decoder weights. Reuse the cache's
+    # component configs (including LoLA runpath), resolving their original context.
+    ae_model = ae_cfg.get("model", {})
+    with open_dict(cfg.model):
+        for component in ("encoder", "decoder"):
+            if cfg.model.get(component) is None and ae_model.get(component) is not None:
+                cfg.model[component] = OmegaConf.to_container(
+                    ae_model[component], resolve=True
+                )
+    return cfg
+
+
 def _maybe_swap_to_ambient_datamodule(
     cfg: DictConfig,
     *,
@@ -2066,7 +2090,8 @@ def _maybe_swap_to_ambient_datamodule(
     ``ambient`` and ``encode_once`` need the encoder on raw fields, so when
     the current datamodule yields ``EncodedBatch`` we overwrite
     ``cfg.datamodule`` with the autoencoder's training datamodule read from
-    ``<cache_dir>/autoencoder_config.yaml``. No-op for ``eval.mode=latent``
+    ``<cache_dir>/autoencoder_config.yaml`` and backfill missing autoencoder
+    components and checkpoint references. No-op for ``eval.mode=latent``
     (the encoder is never invoked) and for raw-Batch datamodules. Raises if
     the swap is needed but the config is absent; pass ``datamodule=...``
     explicitly in that case.
@@ -2130,7 +2155,9 @@ def _maybe_swap_to_ambient_datamodule(
     # full_trajectory_mode=True for encoding. For eval we need windowed batches
     # matching processor training (n_steps_input / n_steps_output), otherwise
     # metric shapes become incompatible.
-    swapped_datamodule = OmegaConf.create(ae_datamodule)
+    swapped_datamodule = OmegaConf.create(
+        OmegaConf.to_container(ae_datamodule, resolve=True)
+    )
     if not isinstance(swapped_datamodule, DictConfig):
         msg = (
             f"autoencoder_config.yaml at {data_path} contains a non-mapping "
@@ -2176,7 +2203,7 @@ def _maybe_swap_to_ambient_datamodule(
     )
     with open_dict(cfg):
         cfg.datamodule = swapped_datamodule
-    return cfg
+    return _inject_cached_autoencoder_components(cfg, ae_cfg)
 
 
 def _resolve_eval_path(

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -1,6 +1,27 @@
+from types import SimpleNamespace
+
+import pytest
 import torch
 
-from autocast.data.datamodule import SpatioTemporalDataModule
+from autocast.data.datamodule import SpatioTemporalDataModule, TheWellDataModule
+
+
+@pytest.mark.parametrize("full_trajectory_mode", [False, True])
+def test_well_datamodule_separates_windowed_and_rollout_modes(
+    monkeypatch, full_trajectory_mode
+):
+    monkeypatch.setattr("autocast.data.datamodule.TheWell", SimpleNamespace)
+
+    dm = TheWellDataModule(
+        well_dataset_name="rayleigh_benard",
+        full_trajectory_mode=full_trajectory_mode,
+        num_workers=0,
+    )
+
+    for dataset in (dm.train_dataset, dm.val_dataset, dm.test_dataset):
+        assert dataset.full_trajectory_mode is full_trajectory_mode
+    assert dm.rollout_val_dataset.full_trajectory_mode is True
+    assert dm.rollout_test_dataset.full_trajectory_mode is True
 
 
 def test_file_backed_rollout_datasets_apply_channel_idxs_once(tmp_path):

--- a/tests/scripts/test_cache_latents.py
+++ b/tests/scripts/test_cache_latents.py
@@ -1,12 +1,15 @@
 """Tests for the cache_latents script."""
 
+from types import SimpleNamespace
+
 import torch
+from omegaconf import OmegaConf
 from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
 from autocast.data.encoded_dataset import CachedLatentDataset
 from autocast.encoders.base import EncoderWithCond
-from autocast.scripts.cache_latents import _encode_and_save_split
+from autocast.scripts.cache_latents import _encode_and_save_split, cache_latents
 from autocast.types.batch import Batch
 from autocast.types.types import TensorBNC
 
@@ -93,6 +96,38 @@ def _make_cond_dataloader(cond_dim=3, t_in=1, t_out=9):
 
 
 # --- Tests ---
+
+
+def test_cache_latents_saves_resolved_autoencoder_metadata(tmp_path, monkeypatch):
+    cfg = OmegaConf.create(
+        {
+            "checkpoint_root": str(tmp_path / "autoencoder"),
+            "datamodule": {},
+            "model": {"encoder": {"runpath": "${checkpoint_root}"}},
+        }
+    )
+    loader = _make_full_traj_dataloader(n_trajectories=1)
+    dm = SimpleNamespace(
+        setup=lambda **_kwargs: None,
+        train_dataloader=lambda: loader,
+        val_dataloader=lambda: loader,
+        test_dataloader=lambda: loader,
+    )
+    monkeypatch.setattr(
+        "autocast.scripts.cache_latents.setup_datamodule", lambda cfg: (dm, cfg, {})
+    )
+    monkeypatch.setattr(
+        "autocast.scripts.cache_latents.setup_autoencoder_components",
+        lambda _cfg, _stats: (_MockEncoder(), None),
+    )
+
+    cache_dir = cache_latents(cfg, tmp_path / "cache", device="cpu")
+
+    metadata = (cache_dir / "autoencoder_config.yaml").read_text()
+    assert "${" not in metadata
+    saved_cfg = OmegaConf.create(metadata)
+    assert saved_cfg.model.encoder.runpath == str(tmp_path / "autoencoder")
+    assert saved_cfg.datamodule.full_trajectory_mode is True
 
 
 def test_encode_and_save_creates_traj_files(tmp_path):

--- a/tests/scripts/test_docs_build.py
+++ b/tests/scripts/test_docs_build.py
@@ -63,11 +63,12 @@ def test_notebooks_can_span_chapters_and_nested_sections(tmp_path):
 def test_navigation_keeps_walkthrough_before_focused_examples_and_results():
     toc = yaml.safe_load((REPO / "docs" / "_toc.yml").read_text())
     chapters = [chapter["file"] for chapter in toc["chapters"]]
-    assert chapters[:5] == [
+    assert chapters[:6] == [
         "installation",
         "tutorials/quickstart",
         "walkthrough/index",
         "tutorials/index",
+        "walkthrough/rayleigh-benard",
         "tutorials/evaluation_and_results",
     ]
 

--- a/tests/scripts/test_eval_encoder_processor_decoder.py
+++ b/tests/scripts/test_eval_encoder_processor_decoder.py
@@ -1469,6 +1469,86 @@ def test_maybe_swap_to_ambient_datamodule_loads_from_cache_dir(tmp_path):
     assert cfg.datamodule.use_normalization is True
 
 
+@pytest.mark.parametrize("checkpoint", [None, "/saved/autoencoder.ckpt"])
+@pytest.mark.parametrize("override_components", [False, True])
+def test_native_cache_restores_autoencoder_and_preserves_overrides(
+    tmp_path, checkpoint, override_components
+):
+    ae_cfg = OmegaConf.create(
+        {
+            "ae_run": "/saved/lola",
+            "raw_path": "/saved/datasets",
+            "autoencoder_checkpoint": checkpoint,
+            "datamodule": {
+                "_target_": THE_WELL_DATAMODULE_TARGET,
+                "well_base_path": "${raw_path}",
+                "full_trajectory_mode": True,
+                "n_steps_input": 1,
+                "n_steps_output": 100,
+            },
+            "model": {
+                "encoder": {
+                    "_target_": LOLA_WRAPPED_ENCODER_TARGET,
+                    "runpath": "${ae_run}",
+                    "log_scalars": False,
+                    "mean": [0.5],
+                },
+                "decoder": {
+                    "_target_": LOLA_WRAPPED_DECODER_TARGET,
+                    "runpath": "${ae_run}",
+                },
+            },
+        }
+    )
+    OmegaConf.save(ae_cfg, tmp_path / "autoencoder_config.yaml")
+    cfg = OmegaConf.create(
+        {
+            "datamodule": {
+                "data_path": str(tmp_path),
+                "n_steps_input": 2,
+                "n_steps_output": 5,
+                "stride": 3,
+            },
+            "model": {"processor": {"_target_": "fake.Processor"}},
+        }
+    )
+    if override_components:
+        cfg.model["encoder"] = {"_target_": "custom.Encoder"}
+        cfg.model["decoder"] = {"_target_": "custom.Decoder"}
+        cfg.autoencoder_checkpoint = "/override/autoencoder.ckpt"
+    OmegaConf.set_struct(cfg, True)
+    encoded = EncodedBatch(
+        encoded_inputs=torch.zeros(1, 2, 2, 2, 1),
+        encoded_output_fields=torch.zeros(1, 5, 2, 2, 1),
+        global_cond=None,
+        encoded_info={},
+    )
+
+    _maybe_swap_to_ambient_datamodule(
+        cfg, eval_mode="encode_once", example_batch=encoded
+    )
+
+    assert cfg.datamodule.well_base_path == "/saved/datasets"
+    assert cfg.datamodule.full_trajectory_mode is False
+    assert cfg.datamodule.n_steps_input == 2
+    assert cfg.datamodule.n_steps_output == 5
+    assert cfg.datamodule.min_dt_stride == 3
+    assert cfg.datamodule.max_dt_stride == 3
+    assert cfg.model.processor._target_ == "fake.Processor"
+    if override_components:
+        assert cfg.model.encoder._target_ == "custom.Encoder"
+        assert cfg.model.decoder._target_ == "custom.Decoder"
+        assert cfg.autoencoder_checkpoint == "/override/autoencoder.ckpt"
+    else:
+        assert cfg.model.encoder._target_ == LOLA_WRAPPED_ENCODER_TARGET
+        assert cfg.model.encoder.runpath == "/saved/lola"
+        assert cfg.model.encoder.log_scalars is False
+        assert list(cfg.model.encoder.mean) == [0.5]
+        assert cfg.model.decoder._target_ == LOLA_WRAPPED_DECODER_TARGET
+        assert cfg.model.decoder.runpath == "/saved/lola"
+        assert cfg.get("autoencoder_checkpoint") == checkpoint
+
+
 def test_maybe_swap_to_ambient_datamodule_errors_without_ae_config(tmp_path):
     cfg = OmegaConf.create(
         {
@@ -1737,10 +1817,11 @@ def test_build_lola_autoencoder_config_nodes_propagates_chunk_size(tmp_path):
     assert decoder_cfg.chunk_size == 8
 
 
-def test_wrapped_encoder_encode_cond_can_log_scalars():
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_wrapped_encoder_encode_cond_can_log_scalars(dtype):
     encoder = WrappedEncoder.__new__(WrappedEncoder)
     object.__setattr__(encoder, "log_scalars", True)
-    scalars = torch.tensor([[1.0e7, 5.0]])
+    scalars = torch.tensor([[1.0e7, 5.0]], dtype=dtype)
     boundary_conditions = torch.tensor([[[2.0, 2.0], [0.0, 0.0]]])
     batch = Batch(
         input_fields=torch.zeros(1, 1, 2, 2, 1),
@@ -1754,7 +1835,8 @@ def test_wrapped_encoder_encode_cond_can_log_scalars():
 
     assert cond is not None
     expected = torch.cat([torch.log(scalars), boundary_conditions.flatten(1)], dim=1)
-    assert torch.allclose(cond, expected)
+    assert cond.dtype == batch.input_fields.dtype
+    assert torch.allclose(cond, expected.to(batch.input_fields))
 
 
 def test_wrapped_encoder_chunked_apply_matches_unchunked():

--- a/tests/scripts/test_rayleigh_benard_workflow.py
+++ b/tests/scripts/test_rayleigh_benard_workflow.py
@@ -1,0 +1,184 @@
+"""Exercise both RB cache routes with tiny Well files and a LoLA autoencoder."""
+
+from pathlib import Path
+
+import h5py
+import lightning as L
+import pandas as pd
+import pytest
+import torch
+from einops import rearrange
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+from the_well.utils.dummy_data import write_dummy_data
+
+from autocast.external.lola.lola_autoencoder import get_autoencoder
+from autocast.scripts.cache_latents import cache_latents
+from autocast.scripts.eval.encoder_processor_decoder import run_evaluation
+from autocast.scripts.setup import setup_datamodule, setup_processor_model
+
+
+@pytest.fixture
+def rb_cache_config(tmp_path, REPO_ROOT):
+    dataset_dir = tmp_path / "datasets" / "rayleigh_benard"
+    for split in ("train", "valid", "test"):
+        split_dir = dataset_dir / "data" / split
+        split_dir.mkdir(parents=True)
+        path = split_dir / "tiny.hdf5"
+        write_dummy_data(str(path))
+        with h5py.File(path, "r+") as data:
+            data.attrs["dataset_name"] = "rayleigh_benard"
+            scalars = data["scalars"]
+            assert isinstance(scalars, h5py.Group)
+            scalars.move("a", "Rayleigh")
+            scalars.move("b", "Prandtl")
+            scalars.attrs["field_names"] = [
+                "Rayleigh",
+                "Prandtl",
+                "time_varying_scalar",
+            ]
+
+    config_dir = REPO_ROOT / "src" / "autocast" / "configs"
+    with initialize_config_dir(version_base=None, config_dir=str(config_dir)):
+        cfg = compose(
+            config_name="encoder_processor_decoder",
+            overrides=[
+                f"hydra.searchpath=[file://{REPO_ROOT / 'local_hydra'}]",
+                "local_experiment=cache_latents/the_well/rayleigh_benard/lola_f32c64",
+                f"lola_autoencoder_path={dataset_dir / 'tiny_autoencoder'}",
+                f"datamodule.well_base_path={tmp_path / 'datasets'}",
+            ],
+        )
+    assert cfg.datamodule.max_rollout_steps == float("inf")
+    assert cfg.model.encoder.pix_channels == 4
+    # Keep the checkpoint normalization/conditioning, but shrink the network
+    # and use the dummy file's two variable channels for this CPU fixture.
+    for component in (cfg.model.encoder, cfg.model.decoder):
+        component.pix_channels = 2
+        component.mean = [0.38, 0.01]
+        component.std = [0.25, 0.15]
+        component.hid_channels = [4, 8]
+        component.hid_blocks = [1, 1]
+        component.lat_channels = 2
+    run_dir = Path(cfg.lola_autoencoder_path)
+    run_dir.mkdir()
+    ae_config = OmegaConf.to_container(cfg.model.encoder, resolve=True)
+    assert isinstance(ae_config, dict)
+    ae_kwargs = {str(key): value for key, value in ae_config.items()}
+    for key in (
+        "_target_",
+        "mean",
+        "std",
+        "log_scalars",
+        "device",
+        "runpath",
+        "chunk_size",
+    ):
+        ae_kwargs.pop(key)
+    torch.save(get_autoencoder(**ae_kwargs).state_dict(), run_dir / "state.pth")
+    OmegaConf.save(
+        OmegaConf.create(
+            {
+                "ae": ae_kwargs,
+                "dataset": {
+                    "name": "rayleigh_benard",
+                    "augment": ["log_scalars"],
+                    "stats": {"mean": [0.38, 0.01], "std": [0.25, 0.15]},
+                },
+            }
+        ),
+        run_dir / "config.yaml",
+    )
+    return cfg
+
+
+@pytest.mark.parametrize("cache_format", ["native", "lola"])
+@pytest.mark.parametrize("processor", ["flow_matching_vit", "diffusion_vit"])
+def test_rb_cache_train_and_physical_eval(
+    rb_cache_config, tmp_path, REPO_ROOT, cache_format, processor
+):
+    cfg = rb_cache_config
+    native_dir = cache_latents(cfg, tmp_path / "native", device="cpu")
+    saved = (native_dir / "autoencoder_config.yaml").read_text()
+    assert "${" not in saved
+    trajectory = torch.load(native_dir / "train" / "traj_000000.pt", weights_only=True)
+    assert trajectory["encoded_fields"].shape[0] == 10
+    assert trajectory["global_cond"].dtype == trajectory["encoded_fields"].dtype
+    assert torch.allclose(
+        trajectory["global_cond"][:2], torch.tensor([0.25, 0.75]).log()
+    )
+
+    data_path = native_dir
+    if cache_format == "lola":
+        # Match LoLA's on-disk state/label schema using the same encoded values.
+        data_path = Path(cfg.lola_autoencoder_path) / "cache" / "rayleigh_benard"
+        for split in ("train", "valid", "test"):
+            split_dir = data_path / split
+            split_dir.mkdir(parents=True)
+            trajectories = [
+                torch.load(path, weights_only=True)
+                for path in sorted((native_dir / split).glob("traj_*.pt"))
+            ]
+            with h5py.File(split_dir / "tiny.hdf5", "w") as data:
+                fields = torch.stack([item["encoded_fields"] for item in trajectories])
+                data["state"] = rearrange(fields, "b t h w c -> b t c h w").numpy()
+                data["label"] = torch.stack(
+                    [item["global_cond"] for item in trajectories]
+                ).numpy()
+
+    datamodule = "cached_latents" if cache_format == "native" else "miniwell"
+    sampling_steps = (
+        "flow_ode_steps" if processor == "flow_matching_vit" else "sampler_steps"
+    )
+    with initialize_config_dir(
+        version_base=None, config_dir=str(REPO_ROOT / "src" / "autocast" / "configs")
+    ):
+        processor_cfg = compose(
+            config_name="processor",
+            overrides=[
+                f"datamodule={datamodule}",
+                f"datamodule.data_path={data_path}",
+                "datamodule.batch_size=1",
+                "datamodule.num_workers=0",
+                f"processor@model.processor={processor}",
+                f"model.processor.{sampling_steps}=1",
+                "model.processor.backbone.hid_channels=8",
+                "model.processor.backbone.hid_blocks=1",
+                "model.processor.backbone.attention_heads=1",
+            ],
+        )
+    dm, processor_cfg, stats = setup_datamodule(processor_cfg)
+    model = setup_processor_model(processor_cfg, stats, datamodule=dm)
+    trainer = L.Trainer(
+        accelerator="cpu",
+        devices=1,
+        max_steps=1,
+        max_epochs=1,
+        limit_val_batches=0,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
+    trainer.fit(model, datamodule=dm)
+    checkpoint = tmp_path / "processor.ckpt"
+    trainer.save_checkpoint(checkpoint)
+    processor_cfg.eval = {
+        "mode": "auto",
+        "accelerator": "cpu",
+        "chunk_size": 1,
+        "checkpoint": str(checkpoint),
+        "max_test_batches": 1,
+        "max_rollout_batches": 1,
+        "max_rollout_steps": 4,
+        "metrics": ["mse"],
+        "batch_indices": [],
+    }
+    (tmp_path / "eval").mkdir()
+    run_evaluation(processor_cfg, work_dir=tmp_path / "eval")
+    assert processor_cfg.datamodule.well_dataset_name == "rayleigh_benard"
+    assert processor_cfg.datamodule.use_normalization is False
+    assert processor_cfg.model.encoder.runpath == cfg.lola_autoencoder_path
+    metrics = pd.read_csv(tmp_path / "eval" / "evaluation_metrics.csv")
+    assert not metrics.empty
+    assert torch.isfinite(torch.as_tensor(metrics["mse"].to_numpy())).all()


### PR DESCRIPTION
Stacked on #448 (`update-notebooks-and-organisation`). Related to #436.

- Add an RB walkthrough covering native caching and LoLA HDF5 caches, processor training, and decoded evaluation.
- Fix trajectory-mode handling, conditioning dtypes, and autoencoder restoration from native-cache metadata.

### Known limitations

- The CPU integration tests verify that both formats train and evaluate; they do **not** establish upstream LoLA parity. The HDF5 fixtures are converted from native latents.
- Native caching encodes each original trajectory once; the LoLA training recipe caches four randomly augmented versions.
- Chunking, device, and matmul precision are not aligned, so numerical equality is not established.
- `stride > 1` has different meanings in the two loaders: frame spacing versus window-start spacing. The guide uses `stride=1`.

Keep this draft pending an independent upstream parity check with matched data, checkpoint, augmentation, and precision, plus resolution of the windowing differences.

Validation: 289 targeted checks passed (the multiprocessing check ran separately outside the macOS sandbox). The docs build with existing/environment warnings. No full-scale GPU runs were attempted.
