### PR TITLE
Add checkpoint cleanup command

### DIFF
--- a/src/autocast/scripts/workflow/cli.py
+++ b/src/autocast/scripts/workflow/cli.py
@@ -9,6 +9,7 @@ from autocast.scripts.workflow.commands import (
     benchmark_command,
     benchmark_manifest_command,
     cache_latents_command,
+    clean_command,
     eval_command,
     infer_dataset_from_workdir,
     infer_resume_checkpoint,
@@ -160,6 +161,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_common_args(cache_parser)
 
+    # -- clean -------------------------------------------------------------
+    clean_parser = subparsers.add_parser(
+        "clean",
+        description="Remove AutoCast checkpoint files below a path.",
+    )
+    clean_parser.add_argument("path", type=Path)
+    clean_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show how many checkpoint files would be removed without deleting them.",
+    )
+
     # -- time-epochs -------------------------------------------------------
     time_parser = subparsers.add_parser(
         "time-epochs",
@@ -253,7 +266,7 @@ def _resolve_resume_from(
     return str(inferred_resume) if inferred_resume is not None else None
 
 
-def main() -> None:
+def main() -> None:  # noqa: PLR0911, PLR0912
     """Parse command-line args and execute the selected workflow command."""
     parser = build_parser()
     args, unknown = parser.parse_known_args()
@@ -261,6 +274,12 @@ def main() -> None:
     unknown_flags = [token for token in unknown if token.startswith("-")]
     if unknown_flags:
         parser.error(f"unrecognized arguments: {' '.join(unknown_flags)}")
+
+    if args.command == "clean":
+        if unknown:
+            parser.error(f"unrecognized arguments: {' '.join(unknown)}")
+        clean_command(args.path, dry_run=args.dry_run)
+        return
 
     # Merge passthrough Hydra globals and positional/unknown overrides.
     combined_overrides = []

--- a/src/autocast/scripts/workflow/commands.py
+++ b/src/autocast/scripts/workflow/commands.py
@@ -556,6 +556,28 @@ def build_eval_overrides(
 # ---------------------------------------------------------------------------
 
 
+def clean_command(path: str | Path, *, dry_run: bool = False) -> tuple[int, int]:
+    """Remove checkpoint files below *path* and return count and bytes removed."""
+    root = Path(path).expanduser()
+    if not root.exists():
+        msg = f"Path does not exist: {root}"
+        raise FileNotFoundError(msg)
+
+    if root.is_file():
+        checkpoints = [root] if root.suffix == ".ckpt" else []
+    else:
+        checkpoints = sorted(p for p in root.rglob("*.ckpt") if p.is_file())
+
+    total_bytes = sum(checkpoint.stat().st_size for checkpoint in checkpoints)
+    if not dry_run:
+        for checkpoint in checkpoints:
+            checkpoint.unlink()
+
+    action = "Would remove" if dry_run else "Removed"
+    print(f"{action} {len(checkpoints)} checkpoint file(s) ({total_bytes} bytes).")
+    return len(checkpoints), total_bytes
+
+
 def train_command(
     *,
     kind: str,

--- a/tests/scripts/test_workflow.py
+++ b/tests/scripts/test_workflow.py
@@ -17,6 +17,7 @@ from autocast.scripts.workflow.commands import (
     benchmark_manifest_command,
     build_effective_eval_overrides,
     build_train_overrides,
+    clean_command,
     eval_command,
     infer_dataset_from_workdir,
     infer_eval_checkpoint,
@@ -1268,6 +1269,42 @@ def test_build_parser_benchmark_basic(parser: argparse.ArgumentParser):
     args = parser.parse_args(["benchmark", "--workdir", "/tmp/w"])
     assert args.command == "benchmark"
     assert args.workdir == "/tmp/w"
+
+
+def test_build_parser_clean_basic(parser: argparse.ArgumentParser):
+    args = parser.parse_args(["clean", "/tmp/run", "--dry-run"])
+    assert args.command == "clean"
+    assert args.path == Path("/tmp/run")
+    assert args.dry_run is True
+
+
+def test_clean_command_removes_only_checkpoints(tmp_path: Path):
+    nested = tmp_path / "checkpoints"
+    nested.mkdir()
+    first = tmp_path / "model.ckpt"
+    second = nested / "last.ckpt"
+    keep = nested / "metrics.csv"
+    first.write_bytes(b"123")
+    second.write_bytes(b"4567")
+    keep.write_text("keep")
+
+    assert clean_command(tmp_path) == (2, 7)
+    assert not first.exists()
+    assert not second.exists()
+    assert keep.exists()
+
+
+def test_clean_command_dry_run_keeps_checkpoints(tmp_path: Path):
+    checkpoint = tmp_path / "model.ckpt"
+    checkpoint.write_bytes(b"123")
+
+    assert clean_command(tmp_path, dry_run=True) == (1, 3)
+    assert checkpoint.exists()
+
+
+def test_clean_command_rejects_missing_path(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="Path does not exist"):
+        clean_command(tmp_path / "missing")
 
 
 def test_build_parser_train_eval_with_eval_overrides(


### PR DESCRIPTION
## Summary
- add `autocast clean <PATH>` for removing `*.ckpt` files
- preserve all non-checkpoint outputs
- support `--dry-run` and report file count and bytes
- add parser and cleanup regression tests

Fixes #440

## Testing
- 124 workflow tests passed
- Ruff passed
- Pyright passed
