### PR TITLE
Add spatial AdaLN noise conditioning

### DIFF
--- a/docs/reference/processors/vit.rst
+++ b/docs/reference/processors/vit.rst
@@ -5,3 +5,47 @@ autocast.processors.vit
    :members:
    :undoc-members:
    :show-inheritance:
+
+Azula ViT: global and spatial AdaLN noise
+---------------------------------------
+
+``AzulaViTProcessor`` supports two noise layouts, selected by ``noise_mode``:
+
+* ``global`` (default): one Gaussian vector per example/ensemble member,
+  shared across all patch tokens.
+* ``spatial``: independent Gaussian vectors per patch token. Each block's
+  existing AdaLN weights are shared across tokens, but its scale, shift and
+  gate can vary spatially. The noise draw is reused across blocks and redrawn
+  on every ``map()`` call, including each autoregressive forecast step.
+
+For example, override an Azula processor with:
+
+.. code-block:: yaml
+
+   noise_mode: spatial
+   n_noise_input_channels: 16
+   n_noise_channels: 256
+   patch_size: 1
+
+At 32x32 this samples 16 independent values at each of 1024 tokens, rather
+than 16 values for the whole field. The input projection maps each local
+16-vector to 256 features using shared weights. With the same channel
+dimensions, global and spatial modes have identical trainable parameter
+counts and compatible state dictionaries, although spatial modulation costs
+more computation and activating it changes the model's stochastic behaviour.
+
+Unlike input noise concatenation, spatial AdaLN does not append input channels:
+it modulates hidden features in every transformer block. A token corresponds
+to one processor input cell only when ``patch_size: 1``; larger patches draw
+one vector per patch, not per cell.
+
+``map(x)`` samples noise automatically. For controlled draws, pass
+``forward(x, x_noise)`` a tensor of shape ``(B, D)`` for global mode or
+``(B, N, D)`` for spatial mode, where ``D = n_noise_input_channels``
+(defaulting to ``n_noise_channels``), and
+``N = (H / patch_height) * (W / patch_width)``. Tokens are flattened with
+width varying fastest. Spatial dimensions must be divisible by the patch
+dimensions. Optional global conditioning is broadcast to all tokens.
+
+Spatial mode is opt-in and requires positive noise dimensions. Global noise
+remains the default.

--- a/src/autocast/configs/processor/vit_azula_large.yaml
+++ b/src/autocast/configs/processor/vit_azula_large.yaml
@@ -9,4 +9,6 @@ n_layers: 10
 patch_size: 4
 temporal_method: none
 n_noise_channels: 256
+n_noise_input_channels: null
+noise_mode: global
 include_global_cond: false

--- a/src/autocast/configs/processor/vit_azula_small.yaml
+++ b/src/autocast/configs/processor/vit_azula_small.yaml
@@ -9,4 +9,6 @@ n_layers: 10
 patch_size: 4
 temporal_method: none
 n_noise_channels: 256
+n_noise_input_channels: null
+noise_mode: global
 include_global_cond: false

--- a/src/autocast/nn/base.py
+++ b/src/autocast/nn/base.py
@@ -39,6 +39,7 @@ class TemporalBackboneBase(nn.Module, ABC):
         tcn_kernel_size: int = 3,
         tcn_num_layers: int = 2,
         use_precomputed_modulation: bool = False,
+        spatial_modulation: bool = False,
     ):
         """Initialize Temporal Backbone Base.
 
@@ -60,6 +61,7 @@ class TemporalBackboneBase(nn.Module, ABC):
             tcn_kernel_size: Kernel size for TCN
             tcn_num_layers: Number of TCN layers
             use_precomputed_modulation: Whether to use precomputed modulation tensors.
+            spatial_modulation: Whether precomputed modulation is per token (B, N, D).
         """
         super().__init__()
 
@@ -71,6 +73,10 @@ class TemporalBackboneBase(nn.Module, ABC):
         self.n_steps_input = n_steps_input
         self.mod_features = mod_features
         self.use_precomputed_modulation = use_precomputed_modulation
+        self.spatial_modulation = spatial_modulation
+        if spatial_modulation and not use_precomputed_modulation:
+            msg = "Spatial modulation requires use_precomputed_modulation=True."
+            raise ValueError(msg)
 
         # Validate global conditioning configuration
         if include_global_cond and (
@@ -218,6 +224,7 @@ class TemporalBackboneBase(nn.Module, ABC):
             t: Diffusion modulation input. Either:
                 - scalar timesteps with shape (B,), which are embedded via SineEncoding
                 - precomputed modulation vectors with shape (B, D), where D=mod_features
+                - per-token vectors (B, N, D) when spatial_modulation=True
             cond: Conditioning input (B, T_cond, W, H, C)
             global_cond: Optional global conditioning/modulation vector (B, D)
 
@@ -225,7 +232,12 @@ class TemporalBackboneBase(nn.Module, ABC):
             Denoised output (B, T, W, H, C)
         """
         # Accept either scalar timesteps (B,) or precomputed modulation vectors (B, D).
-        if t.ndim == 2 and t.shape[-1] == self.mod_features:
+        if self.spatial_modulation:
+            if t.ndim != 3 or t.shape[-1] != self.mod_features:
+                msg = "Expected spatial modulation with shape (B, N, mod_features)."
+                raise ValueError(msg)
+            t_emb = t
+        elif t.ndim == 2 and t.shape[-1] == self.mod_features:
             t_emb = t
         else:
             if self.time_embedding is None:
@@ -241,7 +253,10 @@ class TemporalBackboneBase(nn.Module, ABC):
             if global_cond is None:
                 msg = "Model init with global_cond_channels but no global_cond provided"
                 raise ValueError(msg)
-            t_emb = t_emb + self.global_cond_embedding(global_cond)
+            cond_emb = self.global_cond_embedding(global_cond)
+            if self.spatial_modulation:
+                cond_emb = rearrange(cond_emb, "b d -> b 1 d")
+            t_emb = t_emb + cond_emb
 
         # Apply temporal processing
         x_t_temporal, cond_temporal = self.apply_temporal_processing(x_t, cond)

--- a/src/autocast/nn/vit.py
+++ b/src/autocast/nn/vit.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 
 from azula.nn.vit import ViT
+from einops.layers.torch import Rearrange
 from torch import nn
 
 from autocast.nn.base import TemporalBackboneBase
@@ -48,6 +49,7 @@ class TemporalViTBackbone(TemporalBackboneBase):
         rope: bool = False,
         rpb: bool = True,
         window_size: int | Sequence[int] | None = None,
+        spatial_modulation: bool = False,
     ):
         """Initialize Temporal ViT Backbone.
 
@@ -83,6 +85,7 @@ class TemporalViTBackbone(TemporalBackboneBase):
                 the installed Azula ViT used here.
             checkpointing: Whether to use gradient checkpointing in ViT
             use_precomputed_modulation: Whether to use precomputed modulation tensors.
+            spatial_modulation: Whether AdaLN receives one vector per patch token.
         """
         if window_size is not None:
             msg = (
@@ -107,6 +110,7 @@ class TemporalViTBackbone(TemporalBackboneBase):
             tcn_kernel_size=tcn_kernel_size,
             tcn_num_layers=tcn_num_layers,
             use_precomputed_modulation=use_precomputed_modulation,
+            spatial_modulation=spatial_modulation,
         )
 
         self.patch_size = patch_size
@@ -126,6 +130,18 @@ class TemporalViTBackbone(TemporalBackboneBase):
             rpb=rpb,
             checkpointing=checkpointing,
         )
+        if spatial_modulation:
+            for block in self.vit.get_submodule("blocks").children():
+                # Azula 0.7 inserts a singleton token axis for global AdaLN.
+                # Replace only that parameter-free reshape: local vectors keep
+                # their token axis, with identical weights and checkpoint keys.
+                ada_zero = block.get_submodule("ada_zero")
+                if not isinstance(ada_zero, nn.Sequential) or not isinstance(
+                    ada_zero[-1], Rearrange
+                ):
+                    msg = "Installed Azula has an unsupported AdaLN module layout."
+                    raise RuntimeError(msg)
+                ada_zero[-1] = Rearrange("b tokens (n c) -> n b tokens c", n=3)
 
     @property
     def backbone(self) -> nn.Module:

--- a/src/autocast/processors/azula_vit.py
+++ b/src/autocast/processors/azula_vit.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from enum import Enum
 
 import torch
 from einops import rearrange
@@ -8,6 +9,13 @@ from torch import Tensor, nn
 from autocast.nn.vit import TemporalViTBackbone
 from autocast.processors.base import Processor
 from autocast.types import EncodedBatch
+
+
+class AdaLNNoiseMode(str, Enum):
+    """Whether AdaLN noise is shared globally or independent per patch token."""
+
+    GLOBAL = "global"
+    SPATIAL = "spatial"
 
 
 class AzulaViTProcessor(Processor[EncodedBatch]):
@@ -43,12 +51,30 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         qk_norm: bool = True,
         rope: bool = False,
         rpb: bool = True,
+        noise_mode: AdaLNNoiseMode | str = AdaLNNoiseMode.GLOBAL,
     ):
         super().__init__()
         self.n_spatial_dims = len(spatial_resolution)
         if self.n_spatial_dims != 2:
             msg = "Diffusion wrapper expects 2D spatial resolution inputs (H, W)"
             raise ValueError(msg)
+
+        self.noise_mode = AdaLNNoiseMode(noise_mode)
+        self.patch_size = (
+            (patch_size, patch_size)
+            if isinstance(patch_size, int)
+            else tuple(patch_size)
+        )
+        if self.noise_mode == AdaLNNoiseMode.SPATIAL:
+            if n_noise_channels is None or n_noise_channels <= 0:
+                msg = "Spatial AdaLN requires positive n_noise_channels."
+                raise ValueError(msg)
+            if n_noise_input_channels is not None and n_noise_input_channels <= 0:
+                msg = "Spatial AdaLN requires positive n_noise_input_channels."
+                raise ValueError(msg)
+            if len(self.patch_size) != 2 or any(p <= 0 for p in self.patch_size):
+                msg = "Spatial AdaLN requires two positive patch_size dimensions."
+                raise ValueError(msg)
 
         self.n_noise_channels = n_noise_channels
         self.n_noise_input_channels = n_noise_input_channels or n_noise_channels
@@ -105,7 +131,26 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
             rpb=rpb,
             checkpointing=checkpointing,
             use_precomputed_modulation=True,
+            spatial_modulation=self.noise_mode == AdaLNNoiseMode.SPATIAL,
         )
+
+    def _noise_shape(self, x: Tensor) -> tuple[int, ...]:
+        """Return the noise shape on the processor's actual input patch grid."""
+        channels = self.n_noise_input_channels or self.model.mod_features
+        if self.noise_mode == AdaLNNoiseMode.GLOBAL:
+            return (x.shape[0], channels)
+        if x.ndim not in (4, 5):
+            msg = "Spatial AdaLN expects 4D or 5D input fields."
+            raise ValueError(msg)
+        height, width = x.shape[-2:] if x.ndim == 4 else x.shape[2:4]
+        ph, pw = self.patch_size
+        if height % ph or width % pw:
+            msg = (
+                f"Input grid {(height, width)} must be divisible by patch_size "
+                f"{self.patch_size}."
+            )
+            raise ValueError(msg)
+        return (x.shape[0], (height // ph) * (width // pw), channels)
 
     def forward(
         self,
@@ -124,7 +169,10 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         Args:
             x: Input tensor with shape (B, C, H, W) or
                 (B, T=n_steps_input, H, W, C).
-            x_noise: Optional noise/modulation tensor.
+            x_noise: Noise of shape (B, D) in global mode, or (B, N, D) in
+                spatial mode. D is n_noise_input_channels (defaulting to
+                n_noise_channels); N is the number of input patch tokens,
+                ordered with width varying fastest. Use map() to draw noise.
             global_cond: Optional global conditioning tensor with shape
                 (B, C_global). Used only when include_global_cond=True.
 
@@ -132,30 +180,13 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
             Output tensor with the same rank as ``x``: (B, C, H, W) if ``x`` was
             4D, (B, T=n_steps_output, H, W, C) otherwise.
         """
-        if x_noise is not None and self.modulation_proj is not None:
+        expected_shape = self._noise_shape(x)
+        if x_noise is None or tuple(x_noise.shape) != expected_shape:
+            received = None if x_noise is None else tuple(x_noise.shape)
+            msg = f"Expected x_noise with shape {expected_shape}, got {received}."
+            raise ValueError(msg)
+        if self.modulation_proj is not None:
             x_noise = self.modulation_proj(x_noise)
-
-        if (
-            self.n_noise_channels
-            and x_noise is not None
-            and x_noise.shape[-1] != self.n_noise_channels
-        ):
-            msg = (
-                f"Expected x_noise with last dim {self.n_noise_channels}, "
-                f"got {x_noise.shape[-1]}."
-            )
-            raise ValueError(msg)
-
-        if (
-            not self.n_noise_channels
-            and x_noise is not None
-            and x_noise.shape[-1] != self.model.mod_features
-        ):
-            msg = (
-                f"Expected x_noise with last dim {self.model.mod_features}, "
-                f"got {x_noise.shape[-1]}."
-            )
-            raise ValueError(msg)
 
         model_global_cond = None
         if self.include_global_cond:
@@ -192,18 +223,12 @@ class AzulaViTProcessor(Processor[EncodedBatch]):
         ).contiguous()
 
     def map(self, x: Tensor, global_cond: Tensor | None = None) -> Tensor:
-        noise_channels = self.n_noise_input_channels or self.n_noise_channels
-        if noise_channels is None:
-            noise_channels = self.model.mod_features
-
+        # One draw per member/forecast step, reused across all transformer blocks.
+        noise_shape = self._noise_shape(x)
         if self.n_noise_channels:
-            noise = torch.randn(
-                x.shape[0], noise_channels, dtype=x.dtype, device=x.device
-            )
+            noise = torch.randn(noise_shape, dtype=x.dtype, device=x.device)
         else:
-            noise = torch.zeros(
-                x.shape[0], noise_channels, dtype=x.dtype, device=x.device
-            )
+            noise = torch.zeros(noise_shape, dtype=x.dtype, device=x.device)
         return self(x, noise, global_cond=global_cond)
 
     def loss(self, batch: EncodedBatch) -> Tensor:

--- a/tests/processors/test_azula_vit_spatial_noise.py
+++ b/tests/processors/test_azula_vit_spatial_noise.py
@@ -1,0 +1,226 @@
+"""Spatial AdaLN uses shared weights but independent noise at each patch token."""
+
+from pathlib import Path
+
+import pytest
+import torch
+from einops import repeat
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+
+from autocast.decoders.channels_last import ChannelsLast
+from autocast.encoders.permute_concat import PermuteConcat
+from autocast.losses.ensemble import CRPSLoss
+from autocast.models.encoder_decoder import EncoderDecoder
+from autocast.models.encoder_processor_decoder_ensemble import (
+    EncoderProcessorDecoderEnsemble,
+)
+from autocast.processors.azula_vit import AzulaViTProcessor
+from autocast.types import Batch
+
+
+def make_processor(**kwargs):
+    config = {
+        "in_channels": 3,
+        "out_channels": 3,
+        "spatial_resolution": (8, 8),
+        "hidden_dim": 16,
+        "num_heads": 2,
+        "n_layers": 2,
+        "patch_size": 2,
+        "temporal_method": "none",
+        "n_noise_input_channels": 4,
+        "n_noise_channels": 8,
+    }
+    return AzulaViTProcessor(**(config | kwargs))
+
+
+@pytest.mark.parametrize("include_global_cond", [False, True])
+def test_broadcast_noise_matches_global_and_checkpoint(include_global_cond):
+    kwargs = {"include_global_cond": include_global_cond, "global_cond_channels": 2}
+    global_model = make_processor(**kwargs).eval()
+    spatial_model = make_processor(noise_mode="spatial", **kwargs).eval()
+    spatial_model.load_state_dict(global_model.state_dict(), strict=True)
+    assert spatial_model.state_dict().keys() == global_model.state_dict().keys()
+    assert sum(p.numel() for p in spatial_model.parameters()) == sum(
+        p.numel() for p in global_model.parameters()
+    )
+    x = torch.randn(2, 3, 8, 8)
+    z = torch.randn(2, 4)
+    local_z = repeat(z, "b d -> b n d", n=16)
+    cond = torch.randn(2, 2) if include_global_cond else None
+    torch.testing.assert_close(
+        spatial_model(x, local_z, cond), global_model(x, z, cond)
+    )
+
+
+@pytest.mark.parametrize(("patch_size", "n_tokens"), [(1, 64), (2, 16), ((2, 4), 8)])
+@pytest.mark.parametrize("with_time", [False, True])
+def test_map_samples_independent_token_noise(patch_size, n_tokens, with_time):
+    processor = make_processor(noise_mode="spatial", patch_size=patch_size)
+    x = torch.randn(2, 1, 8, 8, 3) if with_time else torch.randn(2, 3, 8, 8)
+    captured = []
+    assert processor.modulation_proj is not None
+    handle = processor.modulation_proj.register_forward_pre_hook(
+        lambda _module, args: captured.append(args[0].detach().clone())
+    )
+    try:
+        torch.manual_seed(123)
+        first = processor.map(x)
+        torch.manual_seed(123)
+        repeated = processor.map(x)
+        second = processor.map(x)
+    finally:
+        handle.remove()
+    assert first.shape == x.shape
+    assert captured[0].shape == (2, n_tokens, 4)
+    assert not torch.equal(captured[0][:, 0], captured[0][:, 1])
+    assert not torch.equal(captured[0][0], captured[0][1])
+    assert not torch.equal(captured[0], captured[2])
+    torch.testing.assert_close(first, repeated)
+    assert not torch.equal(first, second)
+
+
+def test_local_modulation_is_pointwise_before_attention():
+    processor = make_processor(noise_mode="spatial")
+    noise = torch.zeros(2, 16, 4)
+    changed = noise.clone()
+    changed[:, 0] = 1
+    modulator = processor.model.get_submodule("vit.blocks.0.ada_zero")
+    assert processor.modulation_proj is not None
+    original_mod = modulator(processor.modulation_proj(noise))
+    changed_mod = modulator(processor.modulation_proj(changed))
+    assert original_mod.shape == (3, 2, 16, 16)
+    torch.testing.assert_close(original_mod[:, :, 1:], changed_mod[:, :, 1:])
+    assert not torch.equal(original_mod[:, :, 0], changed_mod[:, :, 0])
+
+
+@pytest.mark.parametrize("checkpointing", [False, True])
+def test_multistep_backward_uses_all_parameters(checkpointing):
+    processor = make_processor(
+        noise_mode="spatial",
+        n_steps_input=2,
+        n_steps_output=3,
+        checkpointing=checkpointing,
+    )
+    output = processor.map(torch.randn(2, 2, 8, 8, 3))
+    assert output.shape == (2, 3, 8, 8, 3)
+    output.square().mean().backward()
+    for name, parameter in processor.named_parameters():
+        assert parameter.grad is not None, name
+        assert torch.isfinite(parameter.grad).all(), name
+
+
+@pytest.mark.parametrize("shape", [(2, 4), (2, 15, 4), (1, 16, 4), (2, 16, 5)])
+def test_wrong_spatial_noise_shape_is_rejected(shape):
+    processor = make_processor(noise_mode="spatial")
+    with pytest.raises(ValueError, match="Expected x_noise with shape"):
+        processor(torch.randn(2, 3, 8, 8), torch.randn(shape))
+
+
+def test_spatial_requires_noise_and_divisible_grid():
+    with pytest.raises(ValueError, match="positive n_noise_channels"):
+        make_processor(noise_mode="spatial", n_noise_channels=0)
+    with pytest.raises(ValueError, match="positive n_noise_input_channels"):
+        make_processor(noise_mode="spatial", n_noise_input_channels=0)
+    with pytest.raises(ValueError, match="not a valid"):
+        make_processor(noise_mode="unknown")
+    processor = make_processor(noise_mode="spatial")
+    with pytest.raises(ValueError, match="divisible by patch_size"):
+        processor.map(torch.randn(2, 3, 7, 8))
+    with pytest.raises(ValueError, match="4D or 5D"):
+        processor.map(torch.randn(2, 3, 8))
+
+
+def test_default_global_and_disabled_noise_are_unchanged():
+    default = make_processor()
+    explicit = make_processor(noise_mode="global")
+    explicit.load_state_dict(default.state_dict())
+    x = torch.randn(2, 3, 8, 8)
+    torch.manual_seed(123)
+    expected = default.map(x)
+    torch.manual_seed(123)
+    torch.testing.assert_close(explicit.map(x), expected)
+    disabled = make_processor(n_noise_channels=None, n_noise_input_channels=None)
+    torch.testing.assert_close(disabled.map(x), disabled.map(x))
+
+
+def test_ensemble_crps_backward():
+    fields = torch.randn(2, 1, 8, 8, 3)
+    batch = Batch(fields, torch.randn_like(fields), None, None)
+    encoder_decoder = EncoderDecoder(
+        encoder=PermuteConcat(in_channels=3, n_steps_input=1, with_constants=False),
+        decoder=ChannelsLast(output_channels=3, time_steps=1),
+    )
+    model = EncoderProcessorDecoderEnsemble(
+        encoder_decoder=encoder_decoder,
+        processor=make_processor(noise_mode="spatial"),
+        n_members=4,
+        loss_func=CRPSLoss(),
+        train_in_latent_space=False,
+    )
+    prediction = model(batch)
+    assert prediction.shape == (2, 1, 8, 8, 3, 4)
+    assert not torch.equal(prediction[..., 0], prediction[..., 1])
+    loss, _ = model.loss(batch)
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+    loss.backward()
+    for name, parameter in model.processor.named_parameters():
+        assert parameter.grad is not None, name
+        assert torch.isfinite(parameter.grad).all(), name
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_explicit_noise_chunks_receive_gradients(dtype):
+    processor = make_processor(noise_mode="spatial").to(dtype=dtype)
+    x = torch.randn(2, 3, 8, 8, dtype=dtype)
+    noise = torch.randn(2, 16, 4, dtype=dtype, requires_grad=True)
+    output = processor(x, noise)
+    assert output.dtype == dtype
+    output.square().mean().backward()
+    assert noise.grad is not None
+    assert torch.isfinite(noise.grad).all()
+    assert (noise.grad.abs().sum(dim=-1) > 0).all()
+
+
+def test_spatial_without_input_projection():
+    processor = make_processor(noise_mode="spatial", n_noise_input_channels=None)
+    assert processor.modulation_proj is None
+    x = torch.randn(2, 3, 8, 12)
+    assert processor.map(x).shape == x.shape
+    assert processor(x, torch.randn(2, 24, 8)).shape == x.shape
+
+
+@pytest.mark.parametrize("patch_size", [0, -1, (2,), (2, 0), (2, 2, 2)])
+def test_invalid_spatial_patch_size_is_rejected(patch_size):
+    with pytest.raises(ValueError, match="two positive patch_size dimensions"):
+        make_processor(noise_mode="spatial", patch_size=patch_size)
+
+
+def test_explicit_spatial_forward_requires_noise_chunks():
+    processor = make_processor(noise_mode="spatial")
+    with pytest.raises(ValueError, match="Expected x_noise with shape"):
+        processor(torch.randn(2, 3, 8, 8))
+
+
+@pytest.mark.parametrize("preset", ["vit_azula_small", "vit_azula_large"])
+def test_hydra_spatial_mode_override(preset):
+    config_dir = Path(__file__).resolve().parents[2] / "src/autocast/configs"
+    with initialize_config_dir(version_base=None, config_dir=str(config_dir)):
+        cfg = compose(
+            config_name="encoder_processor_decoder",
+            overrides=[
+                f"processor@model.processor={preset}",
+                "model.processor.noise_mode=spatial",
+                "model.processor.n_noise_input_channels=16",
+                "model.processor.in_channels=3",
+                "model.processor.out_channels=3",
+                "model.processor.spatial_resolution=[8,8]",
+                "model.processor.hidden_dim=16",
+                "model.processor.num_heads=2",
+                "model.processor.n_layers=1",
+            ],
+        )
+    processor = instantiate(cfg.model.processor)
+    assert processor.map(torch.randn(2, 3, 8, 8)).shape == (2, 3, 8, 8)


### PR DESCRIPTION
This PR:
- Adds opt-in per-patch noise conditioning to `AzulaViTProcessor`, including explicit `(B, N, D)` inputs.
- Preserves global defaults, checkpoint compatibility and parameter counts.
- Documents noise layouts and test sampling, gradients, shape validation and ensemble integration.